### PR TITLE
Remove access for unlogged in user

### DIFF
--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -33,7 +33,13 @@ export default [
             {
                 path: '/account/settings',
                 exact: true,
-                component: UserSettings
+                component: () => {
+                    return (
+                        <ConfirmAuth requiredPermission="tester">
+                            <Route component={UserSettings} />
+                        </ConfirmAuth>
+                    );
+                }
             },
             {
                 path: '/cycles',
@@ -48,12 +54,24 @@ export default [
             },
             {
                 path: '/test-queue/:cycleId(\\d+)',
-                component: TestQueue
+                component: () => {
+                    return (
+                        <ConfirmAuth requiredPermission="tester">
+                            <Route component={TestQueue} />
+                        </ConfirmAuth>
+                    );
+                }
             },
             {
                 path: '/test-queue',
                 exact: true,
-                component: TesterHome
+                component: () => {
+                    return (
+                        <ConfirmAuth requiredPermission="tester">
+                            <Route component={TesterHome} />
+                        </ConfirmAuth>
+                    );
+                }
             },
             {
                 path: '/results',


### PR DESCRIPTION
[asana issue](https://app.asana.com/0/1193055321453706/1172041722322605)

This makes the following changes:

The following pages are not only reachable if logged in by either tester or admin (otherwise page not found)
- `/account/settings`
- `/test-queue/:cycleId(\\d+)`
- `/test-queue`

The following pages are left exposed because as I recall, Matt might want to share them by link:
- `/results`
- `/cycles/:cycleId(\\d+)/run/:runId(\\d+)`

 On the execute test page, you cannot save results or submit an issue, the buttons silently do not work -- but it we want to leave a public facing version of the page, we should do something about that. We might want to make a part of Isaac's redesign of the tester workflow and we will need to find out the priority of this from Matt.