### PR TITLE
Fix null constraint bug on created_at and updated_at columns in latest migration

### DIFF
--- a/server/migrations/20200915203422-AddColumnsToTestRun.js
+++ b/server/migrations/20200915203422-AddColumnsToTestRun.js
@@ -26,19 +26,21 @@ module.exports = {
                 ),
                 queryInterface.addColumn(
                     'run',
-                    'createdAt',
+                    'created_at',
                     {
                         type: Sequelize.DATE,
-                        allowNull: false
+                        allowNull: false,
+                        defaultValue: Number.NEGATIVE_INFINITY
                     },
                     { transaction: t }
                 ),
                 queryInterface.addColumn(
                     'run',
-                    'updatedAt',
+                    'updated_at',
                     {
                         type: Sequelize.DATE,
-                        allowNull: false
+                        allowNull: false,
+                        defaultValue: Number.NEGATIVE_INFINITY
                     },
                     { transaction: t }
                 )
@@ -58,10 +60,10 @@ module.exports = {
                 queryInterface.removeColumn('run', 'test_version_id', {
                     transaction: t
                 }),
-                queryInterface.removeColumn('run', 'createdAt', {
+                queryInterface.removeColumn('run', 'created_at', {
                     transaction: t
                 }),
-                queryInterface.removeColumn('run', 'updatedAt', {
+                queryInterface.removeColumn('run', 'updated_at', {
                     transaction: t
                 })
             ]);

--- a/server/migrations/20200915203422-AddColumnsToTestRun.js
+++ b/server/migrations/20200915203422-AddColumnsToTestRun.js
@@ -29,8 +29,7 @@ module.exports = {
                     'created_at',
                     {
                         type: Sequelize.DATE,
-                        allowNull: false,
-                        defaultValue: Number.NEGATIVE_INFINITY
+                        defaultValue: Sequelize.NOW
                     },
                     { transaction: t }
                 ),
@@ -39,8 +38,7 @@ module.exports = {
                     'updated_at',
                     {
                         type: Sequelize.DATE,
-                        allowNull: false,
-                        defaultValue: Number.NEGATIVE_INFINITY
+                        defaultValue: Sequelize.NOW
                     },
                     { transaction: t }
                 )

--- a/server/models/Run.js
+++ b/server/models/Run.js
@@ -74,10 +74,21 @@ module.exports = function(sequelize, DataTypes) {
                 type: DataTypes.BOOLEAN,
                 allowNull: false,
                 defaultValue: false
+            },
+            createdAt: {
+                type: DataTypes.DATE,
+                allowNull: false,
+                defaultValue: Number.NEGATIVE_INFINITY
+            },
+            updatedAt: {
+                type: DataTypes.DATE,
+                allowNull: false,
+                defaultValue: Number.NEGATIVE_INFINITY
             }
         },
         {
-            tableName: 'run'
+            tableName: 'run',
+            underscored: true
         }
     );
 

--- a/server/models/Run.js
+++ b/server/models/Run.js
@@ -77,13 +77,13 @@ module.exports = function(sequelize, DataTypes) {
             },
             createdAt: {
                 type: DataTypes.DATE,
-                allowNull: false,
-                defaultValue: Number.NEGATIVE_INFINITY
+                allowNull: true,
+                defaultValue: sequelize.NOW
             },
             updatedAt: {
                 type: DataTypes.DATE,
-                allowNull: false,
-                defaultValue: Number.NEGATIVE_INFINITY
+                allowNull: true,
+                defaultValue: sequelize.NOW
             }
         },
         {


### PR DESCRIPTION
I was able to reproduce this bug by populating my database with the staging database data:
```
# On staging server
ssh root@aria-at-staging.w3.org
pg_dump -U atr -h localhost aria_at_report > dump.sql

# On local machine
scp root@aria-at-staging.w3.org:dump.sql .
psql -d aria_at_report < dump.sql
```

## Changes in this PR:

- Changed `createdAt` and `updatedAt` to `created_at` and `updated_at` in `run` table
- Set a default value in the migration, which causes Sequelize to auto-populate the rows with null in those columns
- Updated Run model to include the `createdAt` and `updatedAt` attributes.

## Updating database
```
# Rollback to the migration before the latest one
yarn sequelize db:migrate:undo

# Run the migrations
yarn sequelize db:migrate

## This is outdated. There will be nulls.
# Verify that the rows were auto-populated with -infinity
psql -d aria_at_report -c "select id, created_at, updated_at from run;"
```