### PR TITLE
Complete Published Runs API Endpoint

### DIFF
--- a/server/tests/integration/server.int.test.js
+++ b/server/tests/integration/server.int.test.js
@@ -166,17 +166,17 @@ describe(atEndpoint, () => {
             expect(response.body).toEqual([
                 {
                     id: 1,
-                    name: "JAWS"
+                    name: 'JAWS'
                 },
                 {
                     id: 2,
-                    name: "NVDA",
+                    name: 'NVDA'
                 },
                 {
                     id: 3,
-                    name: "VoiceOver for macOS"
+                    name: 'VoiceOver for macOS'
                 },
-                {   
+                {
                     id: atName.id,
                     name: 'at'
                 }

--- a/server/tests/unit/services.test.js
+++ b/server/tests/unit/services.test.js
@@ -247,7 +247,7 @@ describe('ATService', () => {
                     { name: 'NVDA' },
                     { name: 'VoiceOver for macOS' },
                     ...expected
-                ]
+                ];
                 const returnedAts = (await ATService.getATs()).map(at => ({
                     name: at.dataValues.name
                 }));


### PR DESCRIPTION
- The controller/routing already existed
- The published Runs return the same `Run` object as the active runs endpoint so abstract out a function to convert runs from the DB to the run objects returned to the FE.