### PR TITLE
Add new `GET /api/run/config` and `GET /api/test-versions` endpoints 

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,7 @@ const cycleRoutes = require('./routes/cycle');
 const atRoutes = require('./routes/at');
 const runRoutes = require('./routes/run');
 const testRoutes = require('./routes/tests');
+const testVersionRoutes = require('./routes/test-version');
 const path = require('path');
 
 const app = express();
@@ -22,6 +23,7 @@ app.use('/cycle', cycleRoutes);
 app.use('/at', atRoutes);
 app.use('/run', runRoutes);
 app.use('/test', testRoutes);
+app.use('/test-versions', testVersionRoutes);
 
 const listener = express();
 listener.use('/api', app);

--- a/server/controllers/RunController.js
+++ b/server/controllers/RunController.js
@@ -1,9 +1,8 @@
 const RunService = require('../services/RunService');
 
 async function configureRuns(req, res) {
-    const cycle = req.body.data;
     try {
-        const savedRun = await RunService.configureRuns(cycle);
+        const savedRun = await RunService.configureRuns(req.body.data);
         res.status(201).json(savedRun);
     } catch (error) {
         res.status(400);
@@ -14,8 +13,8 @@ async function configureRuns(req, res) {
 
 async function getActiveRuns(req, res) {
     try {
-        const cycles = await RunService.getActiveRuns();
-        res.status(201).json(cycles);
+        const runs = await RunService.getActiveRuns();
+        res.status(201).json(runs);
     } catch (error) {
         res.status(400);
         res.end();
@@ -25,8 +24,19 @@ async function getActiveRuns(req, res) {
 
 async function getPublishedRuns(req, res) {
     try {
-        const cycles = await RunService.getPublishedRuns();
-        res.status(201).json(cycles);
+        const runs = await RunService.getPublishedRuns();
+        res.status(201).json(runs);
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in RunController: ${error}`);
+    }
+}
+
+async function getActiveRunsConfiguration(req, res) {
+    try {
+        const config = await RunService.getActiveRunsConfiguration();
+        res.status(201).json(config);
     } catch (error) {
         res.status(400);
         res.end();
@@ -37,5 +47,6 @@ async function getPublishedRuns(req, res) {
 module.exports = {
     configureRuns,
     getActiveRuns,
-    getPublishedRuns
+    getPublishedRuns,
+    getActiveRunsConfiguration
 };

--- a/server/controllers/TestVersionController.js
+++ b/server/controllers/TestVersionController.js
@@ -1,0 +1,16 @@
+const RunService = require('../services/RunService');
+
+async function getNewTestVersions(req, res) {
+    try {
+        const testVersions = await RunService.getNewTestVersions();
+        res.status(201).json(testVersions);
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in TestVersionController: ${error}`);
+    }
+}
+
+module.exports = {
+    getNewTestVersions
+};

--- a/server/models/TestVersions.js
+++ b/server/models/TestVersions.js
@@ -1,5 +1,5 @@
 module.exports = function(sequelize, DataTypes) {
-    return sequelize.define(
+    let TestVersion = sequelize.define(
         'TestVersion',
         {
             id: {
@@ -39,4 +39,17 @@ module.exports = function(sequelize, DataTypes) {
             tableName: 'test_version'
         }
     );
+
+    TestVersion.associate = function(models) {
+        models.TestVersion.hasMany(models.ApgExample, {
+            foreignKey: 'test_version_id',
+            sourceKey: 'id'
+        });
+        models.TestVersion.hasMany(models.At, {
+            foreignKey: 'test_version_id',
+            sourceKey: 'id'
+        });
+    };
+
+    return TestVersion;
 };

--- a/server/routes/run.js
+++ b/server/routes/run.js
@@ -6,5 +6,6 @@ const router = Router();
 router.post('/', RunController.configureRuns);
 router.get('/active', RunController.getActiveRuns);
 router.get('/published', RunController.getPublishedRuns);
+router.get('/config', RunController.getActiveRunsConfiguration);
 
 module.exports = router;

--- a/server/routes/test-version.js
+++ b/server/routes/test-version.js
@@ -1,0 +1,8 @@
+const { Router } = require('express');
+const TestVersionController = require('../controllers/TestVersionController');
+
+const router = Router();
+
+router.get('/', TestVersionController.getNewTestVersions);
+
+module.exports = router;

--- a/server/services/RunService.js
+++ b/server/services/RunService.js
@@ -2,9 +2,10 @@ const db = require('../models/index');
 /**
  * @typedef AtBrowserPairing
  * @type {object}
- * @property at_version
- * @property browser_id
- * @property browser_version
+ * @property {number} at_name_id
+ * @property {string} at_version
+ * @property {number} browser_id
+ * @property {string} browser_version
  *
  * @typedef Run
  * @type {object}
@@ -23,6 +24,43 @@ const db = require('../models/index');
  * @property {string} run_status
  * @property {number} test_version_id
  * @property {Array.<number>} testers - user_id of assigned testers
+ *
+ * @typedef TestSuiteVersion
+ * @type {object}
+ * @property {number} id
+ * @property {string} git_repo
+ * @property {string} git_tag
+ * @property {string} git_hash
+ * @property {string} git_commit_msg
+ * @property {Object.Date} date
+ * @property {Array.<At>}          supported_ats
+ * @property {Array.<ApgExamples>} apg_examples
+ *
+ * @typedef At
+ * @type {object}
+ * @property {number} at_name_id
+ * @property {string} at_name
+ * @property {string} at_key
+ * @property {number} at_id
+ *
+ * @typedef Browser
+ * @type {object}
+ * @property {number} id
+ * @property {string} name
+ *
+ * @typedef ApgExample
+ * @type {object}
+ * @property {number} id
+ * @property {string} directory
+ * @property {string} name
+ *
+ * @typedef RunConfigration
+ * @type {object}
+ * @property {TestSuiteVersion}         active_test_version
+ * @property {Array.<AtBrowserPairing>} active_at_browser_pairs
+ * @property {Array.<number>}           active_apg_examples
+ * @property {Array.<Browser>}          browsers
+ *
  */
 
 /**
@@ -408,6 +446,41 @@ async function getPublishedRuns() {
         throw error;
     }
 }
+
+/**
+ * Gets the currently active test version, apg examples and browser version to AT version pairs
+ *
+ * @return {Object.<RunConfiguration>}
+ *
+ */
+
+/* eslint-disable no-unused-vars */
+async function getRunConfiguration() {
+    try {
+        return {};
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
+    }
+}
+
+/**
+ * Gets all more recent versions of the ARIA-AT test repository in order of there release.
+ *
+ * @return {Array.<TestSuiteVersion>}
+ *
+ */
+
+/* eslint-disable no-unused-vars */
+async function getNewTestVersions() {
+    try {
+        return [];
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
+    }
+}
+
 module.exports = {
     configureRuns,
     getActiveRuns,

--- a/server/tests/unit/services/RunService.test.js
+++ b/server/tests/unit/services/RunService.test.js
@@ -664,7 +664,7 @@ describe('RunService', () => {
                         git_tag: testVersion.git_tag,
                         git_hash: testVersion.git_hash,
                         git_commit_msg: testVersion.git_commit_msg,
-                        date: testVersion.date,
+                        date: testVersion.datetime,
                         supported_ats: [
                             {
                                 at_id: expect.any(Number),
@@ -719,6 +719,201 @@ describe('RunService', () => {
                         { id: expect.any(Number), name: db.Browser.SAFARI }
                     ]
                 });
+            });
+        });
+    });
+
+    describe('RunService.getNewTestVersions', () => {
+        it('should return all test versions if there are no active versions', async () => {
+            await dbCleaner(async () => {
+                const testVersion1 = await db.TestVersion.findOne({
+                    where: {
+                        git_hash: process.env.IMPORT_ARIA_AT_TESTS_COMMIT_1
+                    },
+                    include: [db.ApgExample]
+                });
+                const testVersion2 = await db.TestVersion.findOne({
+                    where: {
+                        git_hash: process.env.IMPORT_ARIA_AT_TESTS_COMMIT_2
+                    },
+                    include: [db.ApgExample]
+                });
+
+                const testVersions = await RunService.getNewTestVersions();
+                expect(testVersions).toEqual([
+                    {
+                        id: testVersion1.id,
+                        git_repo: testVersion1.git_repo,
+                        git_tag: testVersion1.git_tag,
+                        git_hash: testVersion1.git_hash,
+                        git_commit_msg: testVersion1.git_commit_msg,
+                        date: testVersion1.datetime,
+                        supported_ats: [
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'jaws',
+                                at_name: 'JAWS',
+                                at_name_id: expect.any(Number)
+                            },
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'nvda',
+                                at_name: 'NVDA',
+                                at_name_id: expect.any(Number)
+                            },
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'voiceover_macos',
+                                at_name: 'VoiceOver for macOS',
+                                at_name_id: expect.any(Number)
+                            }
+                        ],
+                        apg_examples: [
+                            {
+                                id: expect.any(Number),
+                                directory: 'menubar-editor',
+                                name: 'Editor Menubar Example'
+                            },
+                            {
+                                id: expect.any(Number),
+                                directory: 'combobox-autocomplete-both',
+                                name:
+                                    '(NOT READY! DO NOT TEST!) Editable Combobox With Both List and Inline Autocomplete Example'
+                            },
+                            {
+                                id: expect.any(Number),
+                                directory: 'checkbox',
+                                name: 'Checkbox Example (Two State)'
+                            }
+                        ]
+                    },
+                    {
+                        id: testVersion2.id,
+                        git_repo: testVersion2.git_repo,
+                        git_tag: testVersion2.git_tag,
+                        git_hash: testVersion2.git_hash,
+                        git_commit_msg: testVersion2.git_commit_msg,
+                        date: testVersion2.datetime,
+                        supported_ats: [
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'jaws',
+                                at_name: 'JAWS',
+                                at_name_id: expect.any(Number)
+                            },
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'nvda',
+                                at_name: 'NVDA',
+                                at_name_id: expect.any(Number)
+                            },
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'voiceover_macos',
+                                at_name: 'VoiceOver for macOS',
+                                at_name_id: expect.any(Number)
+                            }
+                        ],
+                        apg_examples: [
+                            {
+                                id: expect.any(Number),
+                                directory: 'menubar-editor',
+                                name: 'Editor Menubar Example'
+                            },
+                            {
+                                id: expect.any(Number),
+                                directory: 'combobox-autocomplete-both',
+                                name:
+                                    '(NOT READY! DO NOT TEST!) Editable Combobox With Both List and Inline Autocomplete Example'
+                            },
+                            {
+                                id: expect.any(Number),
+                                directory: 'checkbox',
+                                name: 'Checkbox Example (Two State)'
+                            }
+                        ]
+                    }
+                ]);
+            });
+        });
+
+        it('should return only the newest test versions if there are old versions', async () => {
+            await dbCleaner(async () => {
+                const testVersion2 = await db.TestVersion.findOne({
+                    where: {
+                        git_hash: process.env.IMPORT_ARIA_AT_TESTS_COMMIT_2
+                    },
+                    include: [db.ApgExample]
+                });
+                await testVersion2.update({ active: true });
+
+                const testVersion3 = await db.TestVersion.create({
+                    git_repo: 'git@git.com',
+                    git_tag: '1.1.1',
+                    git_hash: 'asda123ads2',
+                    git_commit_msg: 'Add new test',
+                    datetime: Date.now()
+                });
+
+                const testVersions = await RunService.getNewTestVersions();
+                expect(testVersions).toEqual([
+                    {
+                        id: testVersion2.id,
+                        git_repo: testVersion2.git_repo,
+                        git_tag: testVersion2.git_tag,
+                        git_hash: testVersion2.git_hash,
+                        git_commit_msg: testVersion2.git_commit_msg,
+                        date: testVersion2.datetime,
+                        supported_ats: [
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'jaws',
+                                at_name: 'JAWS',
+                                at_name_id: expect.any(Number)
+                            },
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'nvda',
+                                at_name: 'NVDA',
+                                at_name_id: expect.any(Number)
+                            },
+                            {
+                                at_id: expect.any(Number),
+                                at_key: 'voiceover_macos',
+                                at_name: 'VoiceOver for macOS',
+                                at_name_id: expect.any(Number)
+                            }
+                        ],
+                        apg_examples: [
+                            {
+                                id: expect.any(Number),
+                                directory: 'menubar-editor',
+                                name: 'Editor Menubar Example'
+                            },
+                            {
+                                id: expect.any(Number),
+                                directory: 'combobox-autocomplete-both',
+                                name:
+                                    '(NOT READY! DO NOT TEST!) Editable Combobox With Both List and Inline Autocomplete Example'
+                            },
+                            {
+                                id: expect.any(Number),
+                                directory: 'checkbox',
+                                name: 'Checkbox Example (Two State)'
+                            }
+                        ]
+                    },
+                    {
+                        id: testVersion3.id,
+                        git_repo: testVersion3.git_repo,
+                        git_tag: testVersion3.git_tag,
+                        git_hash: testVersion3.git_hash,
+                        git_commit_msg: testVersion3.git_commit_msg,
+                        date: testVersion3.datetime,
+                        supported_ats: [],
+                        apg_examples: []
+                    }
+                ]);
             });
         });
     });

--- a/server/tests/unit/services/RunService.test.js
+++ b/server/tests/unit/services/RunService.test.js
@@ -592,6 +592,22 @@ describe('RunService', () => {
     });
 
     describe('RunService.getActiveRunsConfiguration', () => {
+        it('should return the active config without anything active', async () => {
+            await dbCleaner(async () => {
+                const config = await RunService.getActiveRunsConfiguration();
+                expect(config).toEqual({
+                    active_test_version: {},
+                    active_at_browser_pairs: [],
+                    active_apg_examples: [],
+                    browsers: [
+                        { id: expect.any(Number), name: db.Browser.FIREFOX },
+                        { id: expect.any(Number), name: db.Browser.CHROME },
+                        { id: expect.any(Number), name: db.Browser.SAFARI }
+                    ]
+                });
+            });
+        });
+
         it('should return the active config', async () => {
             await dbCleaner(async () => {
                 const testVersion = await db.TestVersion.findOne({


### PR DESCRIPTION
- Added to new API endpoints following the jdoc specs laid out by @spectranaut 
- `GET /api/run/config` is used to populate the current settings on the edit active run configuration page
- `GET /api/test-versions` is used to populate the possible test versions on the edit active run configuration page
- Both endpoints use services in the `RunService`. Even though `getNewTestVersions` doesn't clearly do anything with runs I left it in the run service because it shares a lot of code with the the `getActiveRunsConfiguration` method that definately belongs in `RunService` because they both return `TestSuiteVersion` objects
- I added through unit testing of the `RunService`, but didn't test the controllers/routes because they are just boilerplate