### PR TITLE
Add tests and their results as return values from run API calls

### DIFF
--- a/server/models/ApgExample.js
+++ b/server/models/ApgExample.js
@@ -1,5 +1,5 @@
 module.exports = function(sequelize, DataTypes) {
-    return sequelize.define(
+    const ApgExample = sequelize.define(
         'ApgExample',
         {
             id: {
@@ -35,4 +35,13 @@ module.exports = function(sequelize, DataTypes) {
             tableName: 'apg_example'
         }
     );
+
+    ApgExample.associate = function(models) {
+        models.ApgExample.hasMany(models.Test, {
+            foreignKey: 'apg_example_id',
+            sourceKey: 'id'
+        });
+    };
+
+    return ApgExample;
 };

--- a/server/models/Run.js
+++ b/server/models/Run.js
@@ -115,6 +115,10 @@ module.exports = function(sequelize, DataTypes) {
                 name: 'user_id'
             }
         });
+        models.Run.belongsToMany(models.Test, {
+            through: 'apg_example',
+            scope: { method: 'byRun' }
+        });
     };
 
     return Run;

--- a/server/models/Test.js
+++ b/server/models/Test.js
@@ -1,5 +1,5 @@
 module.exports = function(sequelize, DataTypes) {
-    return sequelize.define(
+    const Test = sequelize.define(
         'Test',
         {
             id: {
@@ -42,4 +42,13 @@ module.exports = function(sequelize, DataTypes) {
             tableName: 'test'
         }
     );
+
+    Test.associate = function(models) {
+        models.Test.hasMany(models.TestResult, {
+            foreignKey: 'test_id',
+            sourceKey: 'id'
+        });
+    };
+
+    return Test;
 };

--- a/server/models/Test.js
+++ b/server/models/Test.js
@@ -48,6 +48,10 @@ module.exports = function(sequelize, DataTypes) {
             foreignKey: 'test_id',
             sourceKey: 'id'
         });
+        models.Test.hasMany(models.TestToAt, {
+            foreignKey: 'test_id',
+            sourceKey: 'id'
+        });
     };
 
     return Test;

--- a/server/models/TestResult.js
+++ b/server/models/TestResult.js
@@ -1,5 +1,5 @@
 module.exports = function(sequelize, DataTypes) {
-    return sequelize.define(
+    const TestResult = sequelize.define(
         'TestResult',
         {
             id: {
@@ -50,4 +50,13 @@ module.exports = function(sequelize, DataTypes) {
             tableName: 'test_result'
         }
     );
+
+    TestResult.associate = function(models) {
+        models.TestResult.belongsTo(models.TestStatus, {
+            foreignKey: 'status_id',
+            sourceKey: 'id'
+        });
+    };
+
+    return TestResult;
 };

--- a/server/models/TestStatus.js
+++ b/server/models/TestStatus.js
@@ -1,5 +1,5 @@
 module.exports = function(sequelize, DataTypes) {
-    return sequelize.define(
+    const model = sequelize.define(
         'TestStatus',
         {
             id: {
@@ -18,4 +18,10 @@ module.exports = function(sequelize, DataTypes) {
             tableName: 'test_status'
         }
     );
+
+    model.SKIPPED = 'skipped';
+    model.INCOMPLETE = 'incomplete';
+    model.COMPLETE = 'complete';
+
+    return model;
 };

--- a/server/services/RunService.js
+++ b/server/services/RunService.js
@@ -486,7 +486,16 @@ async function getPublishedRuns() {
             where: {},
             include: [
                 { model: db.RunStatus, where: { name: db.RunStatus.FINAL } },
-                db.ApgExample,
+                {
+                    model: db.ApgExample,
+                    include: {
+                        model: db.Test,
+                        include: {
+                            model: db.TestResult,
+                            include: db.TestStatus
+                        }
+                    }
+                },
                 {
                     model: db.BrowserVersionToAtVersion,
                     include: [

--- a/server/services/RunService.js
+++ b/server/services/RunService.js
@@ -411,7 +411,11 @@ async function sequelizeRunsToJsonRuns(sequelizeRuns) {
             run_status: run.RunStatus.name,
             test_version_id: run.test_version_id,
             testers: run.Users.map(u => u.id),
-            tests: run.ApgExample.Tests.reduce((acc, test) => {
+            tests: run.ApgExample.Tests.filter(test =>
+                (test.TestToAts || []).some(
+                    testToAt => testToAt.at_id == run.at_id
+                )
+            ).reduce((acc, test) => {
                 acc.push({
                     id: test.id,
                     file: test.file,
@@ -451,10 +455,13 @@ async function getActiveRuns() {
                     model: db.ApgExample,
                     include: {
                         model: db.Test,
-                        include: {
-                            model: db.TestResult,
-                            include: db.TestStatus
-                        }
+                        include: [
+                            db.TestToAt,
+                            {
+                                model: db.TestResult,
+                                include: db.TestStatus
+                            }
+                        ]
                     }
                 },
                 {
@@ -490,10 +497,13 @@ async function getPublishedRuns() {
                     model: db.ApgExample,
                     include: {
                         model: db.Test,
-                        include: {
-                            model: db.TestResult,
-                            include: db.TestStatus
-                        }
+                        include: [
+                            db.TestToAt,
+                            {
+                                model: db.TestResult,
+                                include: db.TestStatus
+                            }
+                        ]
                     }
                 },
                 {

--- a/server/tests/unit/services/RunService.test.js
+++ b/server/tests/unit/services/RunService.test.js
@@ -1,4 +1,5 @@
 const { dbCleaner } = require('../../util/db-cleaner');
+const ArrayContainingExactly = require('../../util/array-containing-exactly');
 const db = require('../../../models/index');
 const RunService = require('../../../services/RunService');
 
@@ -1586,7 +1587,7 @@ describe('RunService', () => {
                         git_hash: testVersion.git_hash,
                         git_commit_msg: testVersion.git_commit_msg,
                         date: testVersion.datetime,
-                        supported_ats: expect.arrayContaining([
+                        supported_ats: new ArrayContainingExactly([
                             {
                                 at_id: expect.any(Number),
                                 at_key: 'voiceover_macos',
@@ -1606,7 +1607,7 @@ describe('RunService', () => {
                                 at_name_id: expect.any(Number)
                             }
                         ]),
-                        apg_examples: expect.arrayContaining([
+                        apg_examples: new ArrayContainingExactly([
                             {
                                 id: expect.any(Number),
                                 directory: 'combobox-autocomplete-both',

--- a/server/tests/unit/services/RunService.test.js
+++ b/server/tests/unit/services/RunService.test.js
@@ -339,7 +339,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
                 await runWithOlderAt.reload();
                 expect(runWithOlderAt.active).toBe(true);
@@ -362,7 +363,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
             });
         });
@@ -474,7 +476,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
                 await runWithOlderBrowser.reload();
                 expect(runWithOlderBrowser.active).toBe(true);
@@ -497,7 +500,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
             });
         });
@@ -584,7 +588,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
 
                 // Check that previously activated pair is now inactive
@@ -782,7 +787,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
 
                 // Verify that pre-existing run is now active
@@ -910,7 +916,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
             });
         });
@@ -1027,7 +1034,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion2.id,
-                    testers: []
+                    testers: [],
+                    tests: []
                 });
             });
         });

--- a/server/tests/unit/services/RunService.test.js
+++ b/server/tests/unit/services/RunService.test.js
@@ -1049,14 +1049,6 @@ describe('RunService', () => {
                     name: apgExampleName
                 });
 
-                const test = await db.Test.create({
-                    name: 'Operate a checkbox',
-                    file: 'tests/checkbox/test-01-operate',
-                    execution_order: 1,
-                    apg_example_id: apgExample.id,
-                    test_version_id: testVersion.id
-                });
-
                 const user = await db.Users.create();
                 const testCycle = await db.TestCycle.create({
                     test_version_id: testVersion.id,
@@ -1128,13 +1120,6 @@ describe('RunService', () => {
                     directory: apgExampleDirectory,
                     name: apgExampleName
                 });
-                const test = await db.Test.create({
-                    name: 'Operate a checkbox',
-                    file: 'tests/checkbox/test-01-operate',
-                    execution_order: 1,
-                    apg_example_id: apgExample.id,
-                    test_version_id: testVersion.id
-                });
                 const user = await db.Users.create();
                 const testCycle = await db.TestCycle.create({
                     test_version_id: testVersion.id,
@@ -1203,6 +1188,29 @@ describe('RunService', () => {
                     run_id: run.id,
                     user_id: user.id
                 });
+
+                const test = await db.Test.create({
+                    name: 'Operate a checkbox',
+                    file: 'tests/checkbox/test-01-operate',
+                    execution_order: 1,
+                    apg_example_id: apgExample.id,
+                    test_version_id: testVersion.id
+                });
+
+                await db.TestToAt.create({
+                    test_id: test.id,
+                    at_id: at.id
+                });
+
+                // Test for another At only shouldn't be included
+                await db.Test.create({
+                    name: 'Operate a checkbox',
+                    file: 'tests/checkbox/test-01-operate',
+                    execution_order: 1,
+                    apg_example_id: apgExample.id,
+                    test_version_id: testVersion.id
+                });
+
                 const testStatus = await db.TestStatus.findOne({
                     where: { name: db.TestStatus.COMPLETE }
                 });
@@ -1450,6 +1458,29 @@ describe('RunService', () => {
                     run_id: run.id,
                     user_id: user.id
                 });
+
+                const test = await db.Test.create({
+                    name: 'Operate a checkbox',
+                    file: 'tests/checkbox/test-01-operate',
+                    execution_order: 1,
+                    apg_example_id: apgExample.id,
+                    test_version_id: testVersion.id
+                });
+
+                await db.TestToAt.create({
+                    test_id: test.id,
+                    at_id: at.id
+                });
+
+                // Test for another At only shouldn't be included
+                await db.Test.create({
+                    name: 'Operate a checkbox',
+                    file: 'tests/checkbox/test-01-operate',
+                    execution_order: 1,
+                    apg_example_id: apgExample.id,
+                    test_version_id: testVersion.id
+                });
+
                 const testStatus = await db.TestStatus.findOne({
                     where: { name: db.TestStatus.COMPLETE }
                 });

--- a/server/tests/unit/services/RunService.test.js
+++ b/server/tests/unit/services/RunService.test.js
@@ -65,7 +65,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
 
                 await testVersion.reload();
@@ -207,7 +208,8 @@ describe('RunService', () => {
                     run_status_id: runStatus.id,
                     run_status: db.RunStatus.RAW,
                     test_version_id: testVersion2.id,
-                    testers: []
+                    testers: [],
+                    tests: expect.any(Array)
                 });
                 await testVersion.reload();
                 expect(testVersion.active).toBe(false);
@@ -1534,7 +1536,10 @@ describe('RunService', () => {
                 });
                 await testVersion.update({ active: true });
 
-                const apgExample1 = testVersion.ApgExamples[0];
+                const apgExampleDir = 'checkbox';
+                const apgExample1 = testVersion.ApgExamples.find(
+                    apgExample => apgExample.directory == apgExampleDir
+                );
                 await apgExample1.update({ active: true });
 
                 const atNameString = 'NVDA';
@@ -1581,7 +1586,7 @@ describe('RunService', () => {
                         git_hash: testVersion.git_hash,
                         git_commit_msg: testVersion.git_commit_msg,
                         date: testVersion.datetime,
-                        supported_ats: [
+                        supported_ats: expect.arrayContaining([
                             {
                                 at_id: expect.any(Number),
                                 at_key: 'voiceover_macos',
@@ -1600,8 +1605,8 @@ describe('RunService', () => {
                                 at_name: 'JAWS',
                                 at_name_id: expect.any(Number)
                             }
-                        ],
-                        apg_examples: [
+                        ]),
+                        apg_examples: expect.arrayContaining([
                             {
                                 id: expect.any(Number),
                                 directory: 'combobox-autocomplete-both',
@@ -1615,10 +1620,10 @@ describe('RunService', () => {
                             },
                             {
                                 id: apgExample1.id,
-                                directory: apgExample1.directory,
+                                directory: apgExampleDir,
                                 name: apgExample1.name
                             }
-                        ]
+                        ])
                     },
                     active_at_browser_pairs: [
                         {

--- a/server/tests/util/array-containing-exactly.js
+++ b/server/tests/util/array-containing-exactly.js
@@ -21,9 +21,9 @@ class ArrayContainingExactly {
         const result =
             this.sample.length === other.length &&
             Array.isArray(other) &&
-                this.sample.every(item =>
-                    other.some(another => equals(item, another))
-                );
+            this.sample.every(item =>
+                other.some(another => equals(item, another))
+            );
 
         return result;
     }

--- a/server/tests/util/array-containing-exactly.js
+++ b/server/tests/util/array-containing-exactly.js
@@ -1,0 +1,40 @@
+// Custom matcher that is a modified version of ArrayContaining
+// but requires at every element in the array is present
+// https://github.com/facebook/jest/blob/master/packages/expect/src/asymmetricMatchers.ts#L117
+
+const { equals } = require('expect/build/jasmineUtils');
+
+class ArrayContainingExactly {
+    constructor(sample) {
+        this.sample = sample;
+    }
+
+    asymmetricMatch(other) {
+        if (!Array.isArray(this.sample)) {
+            throw new Error(
+                `You must provide an array to ${this.toString()}, not '` +
+                    typeof this.sample +
+                    "'."
+            );
+        }
+
+        const result =
+            this.sample.length === other.length &&
+            Array.isArray(other) &&
+                this.sample.every(item =>
+                    other.some(another => equals(item, another))
+                );
+
+        return result;
+    }
+
+    toString() {
+        return `Array Containing`;
+    }
+
+    getExpectedType() {
+        return 'array';
+    }
+}
+
+module.exports = ArrayContainingExactly;


### PR DESCRIPTION
See jsdoc for more information on the spec followed. It was largely cribbed from the existing `getTestsForRunsForCycle` cycle service