### PR TITLE
Copy remaining Cycle routes to other locations

### DIFF
--- a/server/controllers/RunController.js
+++ b/server/controllers/RunController.js
@@ -44,9 +44,22 @@ async function getActiveRunsConfiguration(req, res) {
     }
 }
 
+async function saveRunStatus(req, res) {
+    try {
+        const run = req.body.data;
+        const savedRun = await RunService.saveRunStatus(run);
+        res.status(201).json(savedRun);
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in RunController: ${error}`);
+    }
+}
+
 module.exports = {
     configureRuns,
     getActiveRuns,
     getPublishedRuns,
-    getActiveRunsConfiguration
+    getActiveRunsConfiguration,
+    saveRunStatus
 };

--- a/server/controllers/TestController.js
+++ b/server/controllers/TestController.js
@@ -42,8 +42,28 @@ async function getIssuesByTestId(req, res) {
     }
 }
 
+async function createIssue(req, res) {
+    const { run_id, test_id, title, body } = req.body.data;
+    const { accessToken } = req.session;
+    try {
+        const result = await TestService.createIssue({
+            accessToken,
+            run_id,
+            test_id,
+            title,
+            body
+        });
+        res.status(201).json(result);
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in TestController: ${error}`);
+    }
+}
+
 module.exports = {
     importTests,
     saveTestResults,
-    getIssuesByTestId
+    getIssuesByTestId,
+    createIssue
 };

--- a/server/controllers/TestController.js
+++ b/server/controllers/TestController.js
@@ -26,7 +26,24 @@ async function saveTestResults(req, res) {
     }
 }
 
+async function getIssuesByTestId(req, res) {
+    const test_id = parseInt(req.query.test_id);
+    const { accessToken } = req.session;
+    try {
+        const issues = await TestService.getIssuesByTestId({
+            accessToken,
+            test_id
+        });
+        res.status(200).json(issues);
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in TestController: ${error}`);
+    }
+}
+
 module.exports = {
     importTests,
-    saveTestResults
+    saveTestResults,
+    getIssuesByTestId
 };

--- a/server/controllers/TestController.js
+++ b/server/controllers/TestController.js
@@ -1,17 +1,32 @@
 const TestService = require('../services/TestService');
 
-module.exports = {
-    async importTests(req, res) {
-        const { git_hash } = req.body;
-        try {
-            await TestService.importTests(git_hash);
-            res.sendStatus(200);
-        } catch (error) {
-            // eslint-disable-next-line no-console
-            console.log(error.message);
-            // This is when the script fails because the git hash is invalid
-            // Sending semantic error.
-            res.sendStatus(422);
-        }
+async function importTests(req, res) {
+    const { git_hash } = req.body;
+    try {
+        await TestService.importTests(git_hash);
+        res.sendStatus(200);
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.log(error.message);
+        // This is when the script fails because the git hash is invalid
+        // Sending semantic error.
+        res.sendStatus(422);
     }
+}
+
+async function saveTestResults(req, res) {
+    try {
+        const testResult = req.body.data;
+        const savedTestResult = await TestService.saveTestResults(testResult);
+        res.status(201).json(savedTestResult);
+    } catch (error) {
+        res.status(400);
+        res.end();
+        console.error(`Error caught in TestController: ${error}`);
+    }
+}
+
+module.exports = {
+    importTests,
+    saveTestResults
 };

--- a/server/routes/run.js
+++ b/server/routes/run.js
@@ -8,4 +8,6 @@ router.get('/active', RunController.getActiveRuns);
 router.get('/published', RunController.getPublishedRuns);
 router.get('/config', RunController.getActiveRunsConfiguration);
 
+router.post('/status', RunController.saveRunStatus);
+
 module.exports = router;

--- a/server/routes/tests.js
+++ b/server/routes/tests.js
@@ -8,5 +8,6 @@ router.post('/import', TestController.importTests);
 router.post('/result', TestController.saveTestResults);
 
 router.get('/issues', TestController.getIssuesByTestId);
+router.post('/issue', TestController.createIssue);
 
 module.exports = router;

--- a/server/routes/tests.js
+++ b/server/routes/tests.js
@@ -5,4 +5,6 @@ const router = Router();
 
 router.post('/import', TestController.importTests);
 
+router.post('/result', TestController.saveTestResults);
+
 module.exports = router;

--- a/server/routes/tests.js
+++ b/server/routes/tests.js
@@ -7,4 +7,6 @@ router.post('/import', TestController.importTests);
 
 router.post('/result', TestController.saveTestResults);
 
+router.get('/issues', TestController.getIssuesByTestId);
+
 module.exports = router;

--- a/server/services/RunService.js
+++ b/server/services/RunService.js
@@ -581,10 +581,52 @@ async function getNewTestVersions() {
     }
 }
 
+/**
+ * Saves a test result and marks the test as "complete"
+ *
+ * @param {object} run
+ * @param {string} run.run_status
+ * @param {number} run.id
+ * @return {object} - run with saved_status_id
+ *
+ */
+async function saveRunStatus(run) {
+    try {
+        let { run_status, id } = run;
+
+        const status = await db.RunStatus.findOne({
+            attributes: ['id'],
+            where: {
+                name: run_status
+            }
+        });
+
+        if (!status) {
+            throw new Error(`Status "${run_status}" is not a valid status.`);
+        }
+
+        await db.Run.update(
+            { run_status_id: status.dataValues.id },
+            {
+                where: {
+                    id
+                }
+            }
+        );
+
+        run.run_status_id = status.dataValues.id;
+        return run;
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
+    }
+}
+
 module.exports = {
     configureRuns,
     getActiveRuns,
     getPublishedRuns,
     getActiveRunsConfiguration,
-    getNewTestVersions
+    getNewTestVersions,
+    saveRunStatus
 };

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -1,5 +1,6 @@
 const { exec } = require('child_process');
 const db = require('../models/index');
+const GithubService = require('./GithubService');
 
 async function runImportScript(git_hash) {
     return new Promise((resolve, reject) => {
@@ -172,7 +173,37 @@ async function saveTestResults(testResult) {
     }
 }
 
+async function getIssuesByTestId({ accessToken, test_id }) {
+    try {
+        const issues = await db.TestIssue.findAll({
+            where: {
+                test_id
+            }
+        });
+
+        const results = await GithubService.getIssues({
+            accessToken,
+            issues
+        });
+
+        const response = {
+            test_id,
+            issues: []
+        };
+
+        for (let result of results) {
+            response.issues.push(result);
+        }
+
+        return response;
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
+    }
+}
+
 module.exports = {
     importTests,
-    saveTestResults
+    saveTestResults,
+    getIssuesByTestId
 };

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -22,21 +22,157 @@ async function runImportScript(git_hash) {
     });
 }
 
-module.exports = {
-    /**
-     * Functions that use importTests should be wrapped
-     * in a try/catch in case the import script fails
-     */
-    async importTests(git_hash) {
-        if (git_hash) {
-            // check if version exists
-            let results = await db.TestVersion.findAll({ where: { git_hash } });
-            let versionExists = results.length === 0 ? false : true;
-            if (versionExists) {
-                return versionExists;
+/**
+ * Functions that use importTests should be wrapped
+ * in a try/catch in case the import script fails
+ */
+async function importTests(git_hash) {
+    if (git_hash) {
+        // check if version exists
+        let results = await db.TestVersion.findAll({ where: { git_hash } });
+        let versionExists = results.length === 0 ? false : true;
+        if (versionExists) {
+            return versionExists;
+        }
+    }
+    const { stdout, stderr } = await runImportScript(git_hash);
+    return stdout.includes('no errors') && stderr === '';
+}
+
+/**
+ * Saves a test result and marks the test as "complete"
+ *
+ * @param {object} params
+ * @return {object} - the saved result object (the same data, now with "id" and "status: complete")
+ *
+ * @example
+ *
+ *     result = {
+ *       test_id,
+ *       run_id,
+ *       user_id,
+ *       result
+ *     };
+ */
+async function saveTestResults(testResult) {
+    try {
+        const {
+            test_id,
+            run_id,
+            user_id,
+            result,
+            serialized_form
+        } = testResult;
+        let statusId, testResultId;
+
+        let resultRows = await db.sequelize.query(`
+             SELECT
+               id
+             FROM
+               test_result
+             WHERE
+               test_result.user_id = ${user_id}
+               AND test_result.run_id = ${run_id}
+               AND test_result.test_id = ${test_id}
+        `);
+
+        if (resultRows[0].length) {
+            testResultId = resultRows[0][0].id;
+        }
+
+        // If a result has been sent, insert or update result row
+        if (result) {
+            statusId = (
+                await db.sequelize.query(`
+                 SELECT
+                   id
+                 FROM
+                   test_status
+                 WHERE
+                   test_status.name = 'complete'
+            `)
+            )[0][0].id;
+
+            const stringifiedResult = result
+                ? `'${JSON.stringify(result).replace(/'/g, "''")}'`
+                : 'NULL';
+
+            const stringifiedSerializedForm = result
+                ? `'${JSON.stringify(serialized_form).replace(/'/g, "''")}'`
+                : 'NULL';
+
+            if (!testResultId) {
+                testResultId = (
+                    await db.sequelize.query(`
+                      INSERT INTO
+                        test_result(test_id, run_id, user_id, status_id, result, serialized_form)
+                      VALUES
+                        (${test_id}, ${run_id}, ${user_id}, ${statusId}, ${stringifiedResult}, ${stringifiedSerializedForm})
+                      RETURNING ID
+                     `)
+                )[0];
+            } else {
+                await db.sequelize.query(`
+                   UPDATE
+                     test_result
+                   SET
+                     result = ${stringifiedResult},
+                     serialized_form = ${stringifiedSerializedForm},
+                     status_id = ${statusId}
+                   WHERE
+                     id = ${testResultId}
+                `);
             }
         }
-        const { stdout, stderr } = await runImportScript(git_hash);
-        return stdout.includes('no errors') && stderr === '';
+
+        // If result is empty, add a "skipped" entry
+        else {
+            statusId = (
+                await db.sequelize.query(`
+                 SELECT
+                   id
+                 FROM
+                   test_status
+                 WHERE
+                   test_status.name = 'skipped'
+            `)
+            )[0][0].id;
+
+            if (!testResultId) {
+                testResultId = (
+                    await db.sequelize.query(`
+                      INSERT INTO
+                        test_result(test_id, run_id, user_id, status_id)
+                      VALUES
+                        (${test_id}, ${run_id}, ${user_id}, ${statusId})
+                      RETURNING ID
+                     `)
+                )[0];
+            } else {
+                await db.sequelize.query(`
+                   UPDATE
+                     test_result
+                   SET
+                     result = NULL,
+                     serialized_form = NULL,
+                     status_id = ${statusId}
+                   WHERE
+                     id = ${testResultId}
+                `);
+            }
+        }
+
+        testResult.id = testResultId;
+        testResult.status = result ? 'complete' : 'skipped';
+
+        return testResult;
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
     }
+}
+
+module.exports = {
+    importTests,
+    saveTestResults
 };

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -202,8 +202,45 @@ async function getIssuesByTestId({ accessToken, test_id }) {
     }
 }
 
+async function createIssue({ accessToken, run_id, test_id, title, body }) {
+    try {
+        const issue = await GithubService.createIssue({
+            accessToken,
+            issue: {
+                title,
+                body
+            }
+        });
+
+        if (issue) {
+            const issue_number = issue.number;
+            const record = {
+                run_id,
+                test_id,
+                title,
+                body,
+                issue_number
+            };
+
+            const created = await db.TestIssue.create(record);
+
+            if (created && created.dataValues) {
+                return {
+                    test_id,
+                    issues: [issue]
+                };
+            }
+            throw new Error(`TestIssue was not created, ${created}`);
+        }
+    } catch (error) {
+        console.error(`Error: ${error}`);
+        throw error;
+    }
+}
+
 module.exports = {
     importTests,
     saveTestResults,
-    getIssuesByTestId
+    getIssuesByTestId,
+    createIssue
 };


### PR DESCRIPTION
None of these routes were actually having anything to do with cycles so this was a simple copy paste job to the new locations.

There plenty of improvements I could have made to the code I moved but I didn't make any changes for now because we already refactoring so much.

I copied instead of moved so I don't break more things in the app. There is already a cleanup ticket in the backlog for removing the CycleServie and routes after they are truely not used anymore.

- Copy POST /cycles/issue to /tests/issue
- Copy GET /cycle/issues to /tests/issues
- Copy POST /cycle/result to /tests/resesult to /tests/result
- Copy POST /cycle/run/status to /run/status