### PR TITLE
Add Test Navigator and Pagination to the Test Runner Page

### DIFF
--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -122,6 +122,10 @@ h5 {
     font-weight: 600;
 }
 
+h2, h3, h4, h5 {
+    margin: 0 0 0.5em;
+}
+
 button {
     margin: 0.25em 0;
 }

--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -122,7 +122,10 @@ h5 {
     font-weight: 600;
 }
 
-h2, h3, h4, h5 {
+h2,
+h3,
+h4,
+h5 {
     margin: 0 0 0.5em;
 }
 

--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -16,7 +16,7 @@ main {
 
 main,
 nav.navbar {
-    max-width: 1200px;
+    max-width: 1400px;
     margin: auto;
 }
 

--- a/client/components/DisplayTest/DisplayTest.css
+++ b/client/components/DisplayTest/DisplayTest.css
@@ -1,6 +1,11 @@
+.test-iframe-contaner {
+    padding: 0;
+}
+
 #test-iframe {
     width: 80vw;
     height: 65vh;
+    border: 1px solid #c7c7c7;
 }
 
 .testrun__button-toolbar {

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -384,9 +384,7 @@ class DisplayTest extends Component {
 
         return (
             <Fragment>
-                <h4 data-test="test-run-h4">
-                    Testing task: {test.name}
-                </h4>
+                <h4 data-test="test-run-h4">Testing task: {test.name}</h4>
                 <StatusBar key={nextId()} {...statusProps} />
                 <Row>
                     <Col md={9} className="test-iframe-contaner">

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -3,7 +3,14 @@ import PropTypes from 'prop-types';
 import './DisplayTest.css';
 import { withRouter } from 'react-router-dom';
 import nextId from 'react-id-generator';
-import { Button, ButtonToolbar, Col, Modal, Pagination, Row } from 'react-bootstrap';
+import {
+    Button,
+    ButtonToolbar,
+    Col,
+    Modal,
+    Pagination,
+    Row
+} from 'react-bootstrap';
 import RaiseIssueModal from '@components/RaiseIssueModal';
 import ReviewConflictsModal from '@components/ReviewConflictsModal';
 import StatusBar from '@components/StatusBar';
@@ -316,25 +323,39 @@ class DisplayTest extends Component {
         let menuUnderContent = (
             <ButtonToolbar className="testrun__button-toolbar">
                 {primaryButtonGroup}
-		<Pagination>
-		  <Pagination.First onClick={() => {this.props.displayTestByIndex(1)}}/>
-		  <Pagination.Prev onClick={handlePreviousTestClick} />
-                  {
-                    run.tests.reduce((acc, t, i, arr) => {
-                      const item = (<Pagination.Item key={i} active={i + 1 === testIndex} onClick={() => {this.props.displayTestByIndex(i+1)}}>
-                        {i+1}
-                      </Pagination.Item>);
-                      if (arr.length < 10 || i < 5 || i >= arr.length - 5) {
-                        acc.push(item);
-                      } else if (arr.length > 10 && i === 6) {
-                        acc.push(<Pagination.Ellipsis/>);
-                      }
-                      return acc;
-                    }, [])
-                  }
-		  <Pagination.Next onClick={handleNextTestClick} />
-		  <Pagination.Last onClick={() => {this.props.displayTestByIndex(run.tests.length + 1)}}/>
-		</Pagination>
+                <Pagination>
+                    <Pagination.First
+                        onClick={() => {
+                            this.props.displayTestByIndex(1);
+                        }}
+                    />
+                    <Pagination.Prev onClick={handlePreviousTestClick} />
+                    {run.tests.reduce((acc, t, i, arr) => {
+                        const item = (
+                            <Pagination.Item
+                                key={i}
+                                active={i + 1 === testIndex}
+                                onClick={() => {
+                                    this.props.displayTestByIndex(i + 1);
+                                }}
+                            >
+                                {i + 1}
+                            </Pagination.Item>
+                        );
+                        if (arr.length < 10 || i < 5 || i >= arr.length - 5) {
+                            acc.push(item);
+                        } else if (arr.length > 10 && i === 6) {
+                            acc.push(<Pagination.Ellipsis />);
+                        }
+                        return acc;
+                    }, [])}
+                    <Pagination.Next onClick={handleNextTestClick} />
+                    <Pagination.Last
+                        onClick={() => {
+                            this.props.displayTestByIndex(run.tests.length + 1);
+                        }}
+                    />
+                </Pagination>
             </ButtonToolbar>
         );
         let menuRightOContent = (

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -345,7 +345,7 @@ class DisplayTest extends Component {
                         if (arr.length < 10 || i < 5 || i >= arr.length - 5) {
                             acc.push(item);
                         } else if (arr.length > 10 && i === 6) {
-                            acc.push(<Pagination.Ellipsis />);
+                            acc.push(<Pagination.Ellipsis key={i} />);
                         }
                         return acc;
                     }, [])}

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -382,27 +382,14 @@ class DisplayTest extends Component {
 
         let modals = this.renderModal();
 
-        // Quick and lazy fix to make sure the
-        // content row lines up with everything
-        // else on the left.
-        const contentRowStyle = { marginLeft: '0px' };
         return (
             <Fragment>
+                <h4 data-test="test-run-h4">
+                    Testing task: {test.name}
+                </h4>
+                <StatusBar key={nextId()} {...statusProps} />
                 <Row>
-                    <Col>
-                        <h4 data-test="test-run-h4">
-                            Testing task: {test.name}
-                        </h4>
-                    </Col>
-                </Row>
-                <Row>
-                    <Col>
-                        <StatusBar key={nextId()} {...statusProps} />
-                    </Col>
-                </Row>
-
-                <Row style={contentRowStyle}>
-                    <Col md={9}>
+                    <Col md={9} className="test-iframe-contaner">
                         <Row>{testContent}</Row>
                         <Row>{menuUnderContent}</Row>
                     </Col>

--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import './DisplayTest.css';
 import { withRouter } from 'react-router-dom';
 import nextId from 'react-id-generator';
-import { Button, ButtonToolbar, Col, Modal, Row } from 'react-bootstrap';
+import { Button, ButtonToolbar, Col, Modal, Pagination, Row } from 'react-bootstrap';
 import RaiseIssueModal from '@components/RaiseIssueModal';
 import ReviewConflictsModal from '@components/ReviewConflictsModal';
 import StatusBar from '@components/StatusBar';
@@ -306,9 +306,6 @@ class DisplayTest extends Component {
                     <Button variant="primary" onClick={handleSaveClick}>
                         Save results
                     </Button>
-                    <Button variant="secondary" onClick={handleNextTestClick}>
-                        Skip test
-                    </Button>
                 </div>
             );
         }
@@ -319,14 +316,25 @@ class DisplayTest extends Component {
         let menuUnderContent = (
             <ButtonToolbar className="testrun__button-toolbar">
                 {primaryButtonGroup}
-                {testIndex !== 1 && (
-                    <Button
-                        variant="secondary"
-                        onClick={handlePreviousTestClick}
-                    >
-                        Previous test
-                    </Button>
-                )}
+		<Pagination>
+		  <Pagination.First onClick={() => {this.props.displayTestByIndex(1)}}/>
+		  <Pagination.Prev onClick={handlePreviousTestClick} />
+                  {
+                    run.tests.reduce((acc, t, i, arr) => {
+                      const item = (<Pagination.Item key={i} active={i + 1 === testIndex} onClick={() => {this.props.displayTestByIndex(i+1)}}>
+                        {i+1}
+                      </Pagination.Item>);
+                      if (arr.length < 10 || i < 5 || i >= arr.length - 5) {
+                        acc.push(item);
+                      } else if (arr.length > 10 && i === 6) {
+                        acc.push(<Pagination.Ellipsis/>);
+                      }
+                      return acc;
+                    }, [])
+                  }
+		  <Pagination.Next onClick={handleNextTestClick} />
+		  <Pagination.Last onClick={() => {this.props.displayTestByIndex(run.tests.length + 1)}}/>
+		</Pagination>
             </ButtonToolbar>
         );
         let menuRightOContent = (
@@ -411,6 +419,7 @@ DisplayTest.propTypes = {
     history: PropTypes.object,
     displayNextTest: PropTypes.func,
     displayPreviousTest: PropTypes.func,
+    displayTestByIndex: PropTypes.func,
     saveResultFromTest: PropTypes.func,
     deleteResultFromTest: PropTypes.func
 };

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -1,5 +1,9 @@
 /* Test Navigator */
 .test-navigator {
+    /* display: none; */
+}
+
+button.test-navigator-toggle.show {
     display: none;
 }
 

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -17,12 +17,12 @@ button.test-navigator-toggle.hide {
 }
 
 button.test-navigator-toggle.hide:before {
-    content: "<<";
+    content: '<<';
     position: absolute;
     left: 0;
-    font-size: .75em;
+    font-size: 0.75em;
     font-weight: 700;
-    top: .25em;
+    top: 0.25em;
 }
 
 button.test-navigator-toggle.show {
@@ -35,17 +35,29 @@ button.test-navigator-toggle.show {
 }
 
 button.test-navigator-toggle.show:before {
-    content: "";
+    content: '';
     position: absolute;
     width: 13px;
     height: 13px;
     left: 2px;
     top: 2px;
-    background: linear-gradient(180deg, rgba(128,128,128,1) 0%, rgba(128,128,128,1) 20%, rgba(255,255,255,1) 20%, rgba(255,255,255,1) 40%, rgba(128,128,128,1) 40%, rgba(128,128,128,1) 60%, rgba(255,255,255,1) 60%, rgba(255,255,255,1) 80%, rgba(128,128,128,1) 80%, rgba(128,128,128,1) 100%);
+    background: linear-gradient(
+        180deg,
+        rgba(128, 128, 128, 1) 0%,
+        rgba(128, 128, 128, 1) 20%,
+        rgba(255, 255, 255, 1) 20%,
+        rgba(255, 255, 255, 1) 40%,
+        rgba(128, 128, 128, 1) 40%,
+        rgba(128, 128, 128, 1) 60%,
+        rgba(255, 255, 255, 1) 60%,
+        rgba(255, 255, 255, 1) 80%,
+        rgba(128, 128, 128, 1) 80%,
+        rgba(128, 128, 128, 1) 100%
+    );
 }
 
 button.test-navigator-toggle.show:after {
-    content: "";
+    content: '';
     position: absolute;
     width: 2px;
     height: 15px;
@@ -65,11 +77,11 @@ button.test-navigator-toggle.show:after {
 
 .test-name-wrapper {
     position: relative;
-    margin: 0 0 .5em .25em;
+    margin: 0 0 0.5em 0.25em;
 }
 
 .test-name-wrapper:before {
-    content: "";
+    content: '';
     height: 100%;
     left: -2.25em;
     position: absolute;
@@ -85,7 +97,7 @@ button.test-navigator-toggle.show:after {
 .progress-indicator {
     position: absolute;
     left: -2.75em;
-    top: .25em;
+    top: 0.25em;
     width: 18px;
     height: 18px;
     border-radius: 50px;
@@ -99,7 +111,13 @@ button.test-navigator-toggle.show:after {
 
 .test-name-wrapper.in-progress .progress-indicator {
     background: #1e8f37;
-    background: linear-gradient(180deg,#1e8f37 0%,#1e8f37 50%, rgba(255,255,255,1) 50%, rgba(255,255,255,1) 100%);
+    background: linear-gradient(
+        180deg,
+        #1e8f37 0%,
+        #1e8f37 50%,
+        rgba(255, 255, 255, 1) 50%,
+        rgba(255, 255, 255, 1) 100%
+    );
     border: 1px solid #175b26;
 }
 
@@ -114,11 +132,11 @@ button.test-navigator-toggle.show:after {
 }
 
 .test-name-wrapper.conflicts .progress-indicator:after {
-    content: "!";
+    content: '!';
     position: absolute;
     left: 38%;
-    top: -.2em;
-    font-size: .9em;
+    top: -0.2em;
+    font-size: 0.9em;
     font-weight: 700;
 }
 
@@ -127,13 +145,11 @@ button.test-navigator-toggle.show:after {
     border: 1px solid #175b26;
 }
 
-.test-name-wrapper.complete 
-.progress-indicator:before,
-.test-name-wrapper.complete 
-.progress-indicator:after {
-    content: "";
+.test-name-wrapper.complete .progress-indicator:before,
+.test-name-wrapper.complete .progress-indicator:after {
+    content: '';
     position: absolute;
-    background:white;
+    background: white;
     -ms-transform: rotate(45deg); /* IE 9 */
     -webkit-transform: rotate(45deg); /* Chrome, Safari, Opera */
     transform: rotate(45deg);

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -1,13 +1,112 @@
-#test-iframe {
-    width: 80vw;
-    height: 65vh;
+/* Test Navigator */
+button.test-navigator-toggle {
+    text-decoration: none;
+    color: #0b60ab;
+    border: 0;
+    background-color: transparent;
+    padding: 0 0 0 1.25em;
+    position: relative;
 }
 
-.testrun__button--right {
+.test-navigator-toggle:before {
+    content: "<<";
     position: absolute;
-    right: 0;
+    left: 0;
+    font-size: .75em;
+    font-weight: 700;
+    top: .25em;
 }
 
-.testrun__button-toolbar--margin {
-    margin: 1em 0;
+.test-navigator-list {
+    position: relative;
+    margin-top: 1em;
+}
+
+.test-name-wrapper {
+    position: relative;
+    margin: 0 0 .5em .25em;
+}
+
+.test-name-wrapper:before {
+    content: "";
+    height: 100%;
+    left: -2.25em;
+    position: absolute;
+    top: 1em;
+    background: #c7c7c7;
+    width: 2px;
+}
+
+.test-name-wrapper:last-child:before {
+    height: 0%;
+}
+
+.progress-indicator {
+    position: absolute;
+    left: -2.75em;
+    top: .25em;
+    width: 18px;
+    height: 18px;
+    border-radius: 50px;
+}
+
+/* Test States in Test Navigator */
+.test-name-wrapper.not-started .progress-indicator {
+    background: White;
+    border: 1px solid black;
+}
+
+.test-name-wrapper.in-progress .progress-indicator {
+    background: #1e8f37;
+    background: linear-gradient(180deg,#1e8f37 0%,#1e8f37 50%, rgba(255,255,255,1) 50%, rgba(255,255,255,1) 100%);
+    border: 1px solid #175b26;
+}
+
+.test-name-wrapper.skipped .progress-indicator {
+    background: White;
+    border: 1px dashed black;
+}
+
+.test-name-wrapper.conflicts .progress-indicator {
+    background: #ffcd00;
+    border: 1px solid #cc9719;
+}
+
+.test-name-wrapper.conflicts .progress-indicator:after {
+    content: "!";
+    position: absolute;
+    left: 38%;
+    top: -.2em;
+    font-size: .9em;
+    font-weight: 700;
+}
+
+.test-name-wrapper.complete .progress-indicator {
+    background: #1e8f37;
+    border: 1px solid #175b26;
+}
+
+.test-name-wrapper.complete 
+.progress-indicator:before,
+.test-name-wrapper.complete 
+.progress-indicator:after {
+    content: "";
+    position: absolute;
+    background:white;
+    -ms-transform: rotate(45deg); /* IE 9 */
+    -webkit-transform: rotate(45deg); /* Chrome, Safari, Opera */
+    transform: rotate(45deg);
+}
+.test-name-wrapper.complete .progress-indicator:before {
+    width: 4px;
+    height: 3px;
+    top: 7px;
+    left: 3px;
+}
+
+.test-name-wrapper.complete .progress-indicator:after {
+    width: 3px;
+    height: 9px;
+    top: 4px;
+    left: 8px;
 }

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -1,5 +1,9 @@
 /* Test Navigator */
-button.test-navigator-toggle {
+.test-navigator {
+    display: none;
+}
+
+button.test-navigator-toggle.hide {
     text-decoration: none;
     color: #0b60ab;
     border: 0;
@@ -8,13 +12,46 @@ button.test-navigator-toggle {
     position: relative;
 }
 
-.test-navigator-toggle:before {
+button.test-navigator-toggle.hide:before {
     content: "<<";
     position: absolute;
     left: 0;
     font-size: .75em;
     font-weight: 700;
     top: .25em;
+}
+
+button.test-navigator-toggle.show {
+    width: 21px;
+    height: 21px;
+    border: 2px solid gray;
+    border-radius: 3px;
+    background: transparent;
+    position: relative;
+}
+
+button.test-navigator-toggle.show:before {
+    content: "";
+    position: absolute;
+    width: 13px;
+    height: 13px;
+    left: 2px;
+    top: 2px;
+    background: linear-gradient(180deg, rgba(128,128,128,1) 0%, rgba(128,128,128,1) 20%, rgba(255,255,255,1) 20%, rgba(255,255,255,1) 40%, rgba(128,128,128,1) 40%, rgba(128,128,128,1) 60%, rgba(255,255,255,1) 60%, rgba(255,255,255,1) 80%, rgba(128,128,128,1) 80%, rgba(128,128,128,1) 100%);
+}
+
+button.test-navigator-toggle.show:after {
+    content: "";
+    position: absolute;
+    width: 2px;
+    height: 15px;
+    left: 4px;
+    top: 2px;
+    background: white;
+}
+
+.show {
+    width: 2em;
 }
 
 .test-navigator-list {

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -1,12 +1,4 @@
 /* Test Navigator */
-.test-navigator {
-    /* display: none; */
-}
-
-button.test-navigator-toggle.show {
-    display: none;
-}
-
 button.test-navigator-toggle.hide {
     text-decoration: none;
     color: #0b60ab;
@@ -23,6 +15,11 @@ button.test-navigator-toggle.hide:before {
     font-size: 0.75em;
     font-weight: 700;
     top: 0.25em;
+}
+
+span.test-navigator-toggle-container {
+    position: absolute;
+    left: -20px;
 }
 
 button.test-navigator-toggle.show {

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -63,10 +63,6 @@ button.test-navigator-toggle.show:after {
     background: white;
 }
 
-.show {
-    width: 2em;
-}
-
 .test-navigator-list {
     position: relative;
     margin-top: 1em;

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -229,10 +229,7 @@ class TestRun extends Component {
                         </aside>
                         <button className="test-navigator-toggle show"></button>
                         <Col md={9}>
-                            <Row>
-                                <Col>{heading}</Col>
-                            </Row>
-
+                            {heading}
                             {testContent || (
                                 <Row>
                                     <Col>{content}</Col>

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -195,7 +195,7 @@ class TestRun extends Component {
                     <Row>
                         <aside className="col-md-3 test-navigator">
                             <h3>Test Navigator</h3>
-                            <button className="test-navigator-toggle">Hide</button>
+                            <button className="test-navigator-toggle hide">Hide</button>
                             <ol className="test-navigator-list">
                                 <li className="test-name-wrapper complete">
                                     <span className="progress-indicator"></span>
@@ -227,6 +227,7 @@ class TestRun extends Component {
                                 </li>
                             </ol>
                         </aside>
+                        <button className="test-navigator-toggle show"></button>
                         <Col md={9}>
                             <Row>
                                 <Col>{heading}</Col>

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -172,6 +172,7 @@ class TestRun extends Component {
                         at_key={at_key}
                         displayNextTest={this.displayNextTest}
                         displayPreviousTest={this.displayPreviousTest}
+                        displayTestByIndex={this.displayTestByIndex}
                         saveResultFromTest={this.saveResultFromTest}
                         deleteResultFromTest={this.deleteResultFromTest}
                         userId={userId}

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -233,11 +233,6 @@ class TestRun extends Component {
                                                     resultClassName =
                                                         'in-progress';
                                                 } else if (
-                                                    testersResult.status ==
-                                                    'skipped'
-                                                ) {
-                                                    resultClassName = 'skipped';
-                                                } else if (
                                                     checkForConflict(t.results)
                                                         .length
                                                 ) {
@@ -250,12 +245,6 @@ class TestRun extends Component {
                                                     resultClassName =
                                                         'complete';
                                                 }
-                                            } else if (
-                                                this.state.currentTestIndex -
-                                                    1 >
-                                                i
-                                            ) {
-                                                resultClassName = 'skipped';
                                             }
                                             return (
                                                 <li

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -10,6 +10,7 @@ import {
     saveResult
 } from '../../actions/runs';
 import DisplayTest from '@components/DisplayTest';
+import './TestRun.css';
 
 class TestRun extends Component {
     constructor(props) {
@@ -190,16 +191,54 @@ class TestRun extends Component {
                 <Helmet>
                     <title>{title}</title>
                 </Helmet>
-                <Container fluid>
+                <Container fluid>   
                     <Row>
-                        <Col>{heading}</Col>
-                    </Row>
+                        <aside className="col-md-3 test-navigator">
+                            <h3>Test Navigator</h3>
+                            <button className="test-navigator-toggle">Hide</button>
+                            <ol className="test-navigator-list">
+                                <li className="test-name-wrapper complete">
+                                    <span className="progress-indicator"></span>
+                                    <a href="#" className="test-name">Navigation to menubar switches mode from reading to interaction mode</a>
+                                </li>
+                                <li className="test-name-wrapper in-progress">
+                                    <span className="progress-indicator"></span>
+                                    <a href="#" className="test-name">Navigation to menubar using reading mode</a>
+                                </li>
+                                <li className="test-name-wrapper skipped">
+                                    <span className="progress-indicator"></span>
+                                    <a href="#" className="test-name">Navigate to menu item in menubar using reading mode</a>
+                                </li>
+                                <li className="test-name-wrapper conflicts">
+                                    <span className="progress-indicator"></span>
+                                    <a href="#" className="test-name">Navigate to menu item in menubar using interaction mode</a>
+                                </li>
+                                <li className="test-name-wrapper not-started">
+                                    <span className="progress-indicator"></span>
+                                    <a href="#" className="test-name">Navigate to menu item radio in submenu using reading mode</a>
+                                </li>
+                                <li className="test-name-wrapper not-started">
+                                    <span className="progress-indicator"></span>
+                                    <a href="#" className="test-name">Navigate to menu item radio in submenu using interaction mode</a>
+                                </li>
+                                <li className="test-name-wrapper not-started">
+                                    <span className="progress-indicator"></span>
+                                    <a href="#" className="test-name">Navigate to menu item checkbox in submenu using reading mode</a>
+                                </li>
+                            </ol>
+                        </aside>
+                        <Col md={9}>
+                            <Row>
+                                <Col>{heading}</Col>
+                            </Row>
 
-                    {testContent || (
-                        <Row>
-                            <Col>{content}</Col>
-                        </Row>
-                    )}
+                            {testContent || (
+                                <Row>
+                                    <Col>{content}</Col>
+                                </Row>
+                            )}
+                        </Col>
+                    </Row>
                 </Container>
             </Fragment>
         );

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -19,7 +19,8 @@ class TestRun extends Component {
 
         this.state = {
             currentTestIndex: 1,
-            runComplete: false
+            runComplete: false,
+            showTestNavigator: true
         };
 
         this.displayNextTest = this.displayNextTest.bind(this);
@@ -27,6 +28,7 @@ class TestRun extends Component {
         this.displayTestByIndex = this.displayTestByIndex.bind(this);
         this.saveResultFromTest = this.saveResultFromTest.bind(this);
         this.deleteResultFromTest = this.deleteResultFromTest.bind(this);
+        this.toggleTestNavigator = this.toggleTestNavigator.bind(this);
     }
 
     async componentDidMount() {
@@ -62,6 +64,12 @@ class TestRun extends Component {
     displayPreviousTest() {
         this.setState({
             currentTestIndex: this.state.currentTestIndex - 1
+        });
+    }
+
+    toggleTestNavigator() {
+        this.setState({
+            showTestNavigator: !this.state.showTestNavigator
         });
     }
 
@@ -202,62 +210,88 @@ class TestRun extends Component {
                 <Container fluid>
                     <Row>
                         <aside className="col-md-3 test-navigator">
-                            <h3>Test Navigator</h3>
-                            <button className="test-navigator-toggle hide">
-                                Hide
-                            </button>
-                            <ol className="test-navigator-list">
-                                {run.tests.map((t, i) => {
-                                    let resultClassName = 'not-started';
-                                    const testersResult =
-                                        t.results &&
-                                        t.results[openAsUser || userId];
-                                    if (testersResult) {
-                                        if (
-                                            testersResult.status == 'incomplete'
-                                        ) {
-                                            resultClassName = 'in-progress';
-                                        } else if (
-                                            testersResult.status == 'skipped'
-                                        ) {
-                                            resultClassName = 'skipped';
-                                        } else if (
-                                            checkForConflict(t.results).length
-                                        ) {
-                                            resultClassName = 'conflicts';
-                                        } else if (
-                                            testersResult.status === 'complete'
-                                        ) {
-                                            resultClassName = 'complete';
-                                        }
-                                    } else if (
-                                        this.state.currentTestIndex - 1 >
-                                        i
-                                    ) {
-                                        resultClassName = 'skipped';
-                                    }
-                                    return (
-                                        <li
-                                            className={`test-name-wrapper ${resultClassName}`}
-                                        >
-                                            <span className="progress-indicator"></span>
-                                            <a
-                                                href="#"
-                                                onClick={e => {
-                                                    this.displayTestByIndex(
-                                                        i + 1
-                                                    );
-                                                }}
-                                                className="test-name"
-                                            >
-                                                {t.name}
-                                            </a>
-                                        </li>
-                                    );
-                                })}
-                            </ol>
+                            {this.state.showTestNavigator ? (
+                                <>
+                                    <h3>Test Navigator</h3>
+                                    <button
+                                        onClick={this.toggleTestNavigator}
+                                        className="test-navigator-toggle hide"
+                                    >
+                                        Hide
+                                    </button>
+                                    <ol className="test-navigator-list">
+                                        {run.tests.map((t, i) => {
+                                            let resultClassName = 'not-started';
+                                            const testersResult =
+                                                t.results &&
+                                                t.results[openAsUser || userId];
+                                            if (testersResult) {
+                                                if (
+                                                    testersResult.status ==
+                                                    'incomplete'
+                                                ) {
+                                                    resultClassName =
+                                                        'in-progress';
+                                                } else if (
+                                                    testersResult.status ==
+                                                    'skipped'
+                                                ) {
+                                                    resultClassName = 'skipped';
+                                                } else if (
+                                                    checkForConflict(t.results)
+                                                        .length
+                                                ) {
+                                                    resultClassName =
+                                                        'conflicts';
+                                                } else if (
+                                                    testersResult.status ===
+                                                    'complete'
+                                                ) {
+                                                    resultClassName =
+                                                        'complete';
+                                                }
+                                            } else if (
+                                                this.state.currentTestIndex -
+                                                    1 >
+                                                i
+                                            ) {
+                                                resultClassName = 'skipped';
+                                            }
+                                            return (
+                                                <li
+                                                    className={`test-name-wrapper ${resultClassName}`}
+                                                    key={i}
+                                                >
+                                                    <span className="progress-indicator"></span>
+                                                    <a
+                                                        href="#"
+                                                        onClick={() => {
+                                                            this.displayTestByIndex(
+                                                                i + 1
+                                                            );
+                                                        }}
+                                                        className="test-name"
+                                                    >
+                                                        {t.name}
+                                                    </a>
+                                                </li>
+                                            );
+                                        })}
+                                    </ol>
+                                </>
+                            ) : (
+                                <button
+                                    onClick={this.toggleTestNavigator}
+                                    className="test-navigator-toggle"
+                                >
+                                    Show Test Navigator
+                                </button>
+                            )}
                         </aside>
-                        <button className="test-navigator-toggle show"></button>
+                        <button
+                            onClick={this.toggleTestNavigator}
+                            className="test-navigator-toggle show"
+                        ></button>
                         <Col md={9}>
                             {heading}
                             {testContent || (

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -10,6 +10,7 @@ import {
     saveResult
 } from '../../actions/runs';
 import DisplayTest from '@components/DisplayTest';
+import checkForConflict from '../../utils/checkForConflict';
 import './TestRun.css';
 
 class TestRun extends Component {
@@ -23,6 +24,7 @@ class TestRun extends Component {
 
         this.displayNextTest = this.displayNextTest.bind(this);
         this.displayPreviousTest = this.displayPreviousTest.bind(this);
+        this.displayTestByIndex = this.displayTestByIndex.bind(this);
         this.saveResultFromTest = this.saveResultFromTest.bind(this);
         this.deleteResultFromTest = this.deleteResultFromTest.bind(this);
     }
@@ -49,6 +51,12 @@ class TestRun extends Component {
                 currentTestIndex: newIndex
             });
         }
+    }
+
+    displayTestByIndex(index) {
+        this.setState({
+            currentTestIndex: index
+        });
     }
 
     displayPreviousTest() {
@@ -191,40 +199,62 @@ class TestRun extends Component {
                 <Helmet>
                     <title>{title}</title>
                 </Helmet>
-                <Container fluid>   
+                <Container fluid>
                     <Row>
                         <aside className="col-md-3 test-navigator">
                             <h3>Test Navigator</h3>
-                            <button className="test-navigator-toggle hide">Hide</button>
+                            <button className="test-navigator-toggle hide">
+                                Hide
+                            </button>
                             <ol className="test-navigator-list">
-                                <li className="test-name-wrapper complete">
-                                    <span className="progress-indicator"></span>
-                                    <a href="#" className="test-name">Navigation to menubar switches mode from reading to interaction mode</a>
-                                </li>
-                                <li className="test-name-wrapper in-progress">
-                                    <span className="progress-indicator"></span>
-                                    <a href="#" className="test-name">Navigation to menubar using reading mode</a>
-                                </li>
-                                <li className="test-name-wrapper skipped">
-                                    <span className="progress-indicator"></span>
-                                    <a href="#" className="test-name">Navigate to menu item in menubar using reading mode</a>
-                                </li>
-                                <li className="test-name-wrapper conflicts">
-                                    <span className="progress-indicator"></span>
-                                    <a href="#" className="test-name">Navigate to menu item in menubar using interaction mode</a>
-                                </li>
-                                <li className="test-name-wrapper not-started">
-                                    <span className="progress-indicator"></span>
-                                    <a href="#" className="test-name">Navigate to menu item radio in submenu using reading mode</a>
-                                </li>
-                                <li className="test-name-wrapper not-started">
-                                    <span className="progress-indicator"></span>
-                                    <a href="#" className="test-name">Navigate to menu item radio in submenu using interaction mode</a>
-                                </li>
-                                <li className="test-name-wrapper not-started">
-                                    <span className="progress-indicator"></span>
-                                    <a href="#" className="test-name">Navigate to menu item checkbox in submenu using reading mode</a>
-                                </li>
+                                {run.tests.map((t, i) => {
+                                    let resultClassName = 'not-started';
+                                    const testersResult =
+                                        t.results &&
+                                        t.results[openAsUser || userId];
+                                    if (testersResult) {
+                                        if (
+                                            testersResult.status == 'incomplete'
+                                        ) {
+                                            resultClassName = 'in-progress';
+                                        } else if (
+                                            testersResult.status == 'skipped'
+                                        ) {
+                                            resultClassName = 'skipped';
+                                        } else if (
+                                            checkForConflict(t.results).length
+                                        ) {
+                                            resultClassName = 'conflicts';
+                                        } else if (
+                                            testersResult.status === 'complete'
+                                        ) {
+                                            resultClassName = 'complete';
+                                        }
+                                    } else if (
+                                        this.state.currentTestIndex - 1 >
+                                        i
+                                    ) {
+                                        resultClassName = 'skipped';
+                                    }
+                                    return (
+                                        <li
+                                            className={`test-name-wrapper ${resultClassName}`}
+                                        >
+                                            <span className="progress-indicator"></span>
+                                            <a
+                                                href="#"
+                                                onClick={e => {
+                                                    this.displayTestByIndex(
+                                                        i + 1
+                                                    );
+                                                }}
+                                                className="test-name"
+                                            >
+                                                {t.name}
+                                            </a>
+                                        </li>
+                                    );
+                                })}
                             </ol>
                         </aside>
                         <button className="test-navigator-toggle show"></button>

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -222,6 +222,7 @@ class TestRun extends Component {
                                 <ol className="test-navigator-list">
                                     {run.tests.map((t, i) => {
                                         let resultClassName = 'not-started';
+                                        let resultStatus = 'not started:';
                                         const testersResult =
                                             t.results &&
                                             t.results[openAsUser || userId];
@@ -231,16 +232,19 @@ class TestRun extends Component {
                                                 'incomplete'
                                             ) {
                                                 resultClassName = 'in-progress';
+                                                resultStatus = 'in progress:';
                                             } else if (
                                                 checkForConflict(t.results)
                                                     .length
                                             ) {
                                                 resultClassName = 'conflicts';
+                                                resultStatus = 'has conflicts:';
                                             } else if (
                                                 testersResult.status ===
                                                 'complete'
                                             ) {
                                                 resultClassName = 'complete';
+                                                resultStatus = 'complete test:';
                                             }
                                         }
                                         return (
@@ -257,6 +261,7 @@ class TestRun extends Component {
                                                         );
                                                     }}
                                                     className="test-name"
+                                                    aria-label={`${resultStatus} ${t.name}`}
                                                 >
                                                     {t.name}
                                                 </a>

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -209,9 +209,8 @@ class TestRun extends Component {
                 </Helmet>
                 <Container fluid>
                     <Row>
-                        <aside className="col-md-3 test-navigator">
                             {this.state.showTestNavigator ? (
-                                <>
+                                <aside className="col-md-3 test-navigator">
                                     <h3>Test Navigator</h3>
                                     <button
                                         onClick={this.toggleTestNavigator}
@@ -267,21 +266,24 @@ class TestRun extends Component {
                                             );
                                         })}
                                     </ol>
-                                </>
-                            ) : (
-                                <button
-                                    onClick={this.toggleTestNavigator}
-                                    className="test-navigator-toggle"
-                                >
-                                    Show Test Navigator
-                                </button>
-                            )}
-                        </aside>
-                        <button
-                            onClick={this.toggleTestNavigator}
-                            className="test-navigator-toggle show"
-                        ></button>
-                        <Col md={9}>
+                                </aside>
+                            ) :
+                            (
+                              <>
+                              </>
+                            )
+                            }
+                        <Col md={this.state.showTestNavigator ? 9 : 12 }>
+                          {this.state.showTestNavigator ?
+                            <></> :
+                            <span class="test-navigator-toggle-container">
+                              <button
+                                onClick={this.toggleTestNavigator}
+                                className="test-navigator-toggle show"
+                              >
+                              </button>
+                            </span>
+                          }
                             {heading}
                             {testContent || (
                                 <Row>

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -210,81 +210,75 @@ class TestRun extends Component {
                 </Helmet>
                 <Container fluid>
                     <Row>
+                        {this.state.showTestNavigator ? (
+                            <aside className="col-md-3 test-navigator">
+                                <h3>Test Navigator</h3>
+                                <button
+                                    onClick={this.toggleTestNavigator}
+                                    className="test-navigator-toggle hide"
+                                >
+                                    Hide
+                                </button>
+                                <ol className="test-navigator-list">
+                                    {run.tests.map((t, i) => {
+                                        let resultClassName = 'not-started';
+                                        const testersResult =
+                                            t.results &&
+                                            t.results[openAsUser || userId];
+                                        if (testersResult) {
+                                            if (
+                                                testersResult.status ==
+                                                'incomplete'
+                                            ) {
+                                                resultClassName = 'in-progress';
+                                            } else if (
+                                                checkForConflict(t.results)
+                                                    .length
+                                            ) {
+                                                resultClassName = 'conflicts';
+                                            } else if (
+                                                testersResult.status ===
+                                                'complete'
+                                            ) {
+                                                resultClassName = 'complete';
+                                            }
+                                        }
+                                        return (
+                                            <li
+                                                className={`test-name-wrapper ${resultClassName}`}
+                                                key={i}
+                                            >
+                                                <span className="progress-indicator"></span>
+                                                <a
+                                                    href="#"
+                                                    onClick={() => {
+                                                        this.displayTestByIndex(
+                                                            i + 1
+                                                        );
+                                                    }}
+                                                    className="test-name"
+                                                >
+                                                    {t.name}
+                                                </a>
+                                            </li>
+                                        );
+                                    })}
+                                </ol>
+                            </aside>
+                        ) : (
+                            <></>
+                        )}
+                        <Col md={this.state.showTestNavigator ? 9 : 12}>
                             {this.state.showTestNavigator ? (
-                                <aside className="col-md-3 test-navigator">
-                                    <h3>Test Navigator</h3>
+                                <></>
+                            ) : (
+                                <span className="test-navigator-toggle-container">
                                     <button
                                         onClick={this.toggleTestNavigator}
-                                        className="test-navigator-toggle hide"
-                                    >
-                                        Hide
-                                    </button>
-                                    <ol className="test-navigator-list">
-                                        {run.tests.map((t, i) => {
-                                            let resultClassName = 'not-started';
-                                            const testersResult =
-                                                t.results &&
-                                                t.results[openAsUser || userId];
-                                            if (testersResult) {
-                                                if (
-                                                    testersResult.status ==
-                                                    'incomplete'
-                                                ) {
-                                                    resultClassName =
-                                                        'in-progress';
-                                                } else if (
-                                                    checkForConflict(t.results)
-                                                        .length
-                                                ) {
-                                                    resultClassName =
-                                                        'conflicts';
-                                                } else if (
-                                                    testersResult.status ===
-                                                    'complete'
-                                                ) {
-                                                    resultClassName =
-                                                        'complete';
-                                                }
-                                            }
-                                            return (
-                                                <li
-                                                    className={`test-name-wrapper ${resultClassName}`}
-                                                    key={i}
-                                                >
-                                                    <span className="progress-indicator"></span>
-                                                    <a
-                                                        href="#"
-                                                        onClick={() => {
-                                                            this.displayTestByIndex(
-                                                                i + 1
-                                                            );
-                                                        }}
-                                                        className="test-name"
-                                                    >
-                                                        {t.name}
-                                                    </a>
-                                                </li>
-                                            );
-                                        })}
-                                    </ol>
-                                </aside>
-                            ) :
-                            (
-                              <>
-                              </>
-                            )
-                            }
-                        <Col md={this.state.showTestNavigator ? 9 : 12 }>
-                          {this.state.showTestNavigator ?
-                            <></> :
-                            <span class="test-navigator-toggle-container">
-                              <button
-                                onClick={this.toggleTestNavigator}
-                                className="test-navigator-toggle show"
-                              >
-                              </button>
-                            </span>
-                          }
+                                        className="test-navigator-toggle show"
+                                    ></button>
+                                </span>
+                            )}
                             {heading}
                             {testContent || (
                                 <Row>

--- a/server/services/RunService.js
+++ b/server/services/RunService.js
@@ -440,27 +440,31 @@ async function sequelizeRunsToJsonRuns(sequelizeRuns) {
             testers: run.Users.map(u => u.id),
             tests: run.ApgExample.Tests.filter(test =>
                 (test.TestToAts || []).some(testToAt => testToAt.at_id == at.id)
-            ).reduce((acc, test) => {
-                acc.push({
-                    id: test.id,
-                    file: test.file,
-                    name: test.name,
-                    execution_order: test.execution_order,
-                    results: test.TestResults.filter(
-                        testResult => testResult.run_id == run.id
-                    ).reduce((acc, testResult) => {
-                        acc[testResult.user_id] = {
-                            id: testResult.id,
-                            user_id: testResult.user_id,
-                            status: testResult.TestStatus.name,
-                            result: testResult.result,
-                            serialized_form: testResult.serialized_form
-                        };
-                        return acc;
-                    }, {})
-                });
-                return acc;
-            }, [])
+            )
+                .sort((a, b) =>
+                    a.execution_order > b.execution_order ? -1 : 1
+                )
+                .reduce((acc, test) => {
+                    acc.push({
+                        id: test.id,
+                        file: test.file,
+                        name: test.name,
+                        execution_order: test.execution_order,
+                        results: test.TestResults.filter(
+                            testResult => testResult.run_id == run.id
+                        ).reduce((acc, testResult) => {
+                            acc[testResult.user_id] = {
+                                id: testResult.id,
+                                user_id: testResult.user_id,
+                                status: testResult.TestStatus.name,
+                                result: testResult.result,
+                                serialized_form: testResult.serialized_form
+                            };
+                            return acc;
+                        }, {})
+                    });
+                    return acc;
+                }, [])
         };
         return acc;
     }, {});

--- a/server/services/RunService.js
+++ b/server/services/RunService.js
@@ -442,7 +442,7 @@ async function sequelizeRunsToJsonRuns(sequelizeRuns) {
                 (test.TestToAts || []).some(testToAt => testToAt.at_id == at.id)
             )
                 .sort((a, b) =>
-                    a.execution_order > b.execution_order ? -1 : 1
+                    a.execution_order > b.execution_order ? 1 : -1
                 )
                 .reduce((acc, test) => {
                     acc.push({

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -83,9 +83,9 @@ async function saveTestResults(testResult) {
 
         // There will always be a serialized form for a complete or partially complete test.
         // Partially complete tests are tests that are skipped.
-        const stringifiedSerializedForm = serialized_form ? `'${JSON.stringify(
-            serialized_form
-        ).replace(/'/g, "''")}'` : 'NULL';
+        const stringifiedSerializedForm = serialized_form
+            ? `'${JSON.stringify(serialized_form).replace(/'/g, "''")}'`
+            : 'NULL';
 
         // If a result has been sent, insert or update result row
         if (result) {


### PR DESCRIPTION
- Adding Test Navigator markup and styling to Test Run page
- Add bootstrap pagination to test run page
- Track when changes are dirty to be able to distinguish "skipped" tests from "in progress" tests

:exclamation: I spent a day trying to wire up these new buttons and the buttons in the top nav to be able to save partial results. I attempted to do this in the `TestIframe` on `componentWillUnmount` and via the `react-router` but I ran into issues with both approaches. I found a bug already in `main` that provides the warning "Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method." It seems like by the time we are trying to save the state is already gone. Fixing the saving partial results will need to be done in a follow up PR.

:notebook: Improving the styling of the bottom pagination is also incomplete because @isaacdurazo is planning on rethinking this entire section in a follow up ticket. 