### PR TITLE
Save partial results

### DIFF
--- a/client/components/TestIframe/index.jsx
+++ b/client/components/TestIframe/index.jsx
@@ -34,7 +34,7 @@ class TestIframe extends Component {
         this.processResults(data);
     }
 
-    processResults(results) {
+    async processResults(results) {
         // stop listening for additional results
         window.removeEventListener('message', this.handleResultsMessage);
 
@@ -44,7 +44,8 @@ class TestIframe extends Component {
         const serializedForm = serialize(resultsEl);
 
         const { onResults } = this.props;
-        onResults({
+        // Trigger saving of partial results on the parent
+        await onResults({
             results,
             serializedForm
         });
@@ -96,6 +97,12 @@ class TestIframe extends Component {
         // which is sent when the "Review Results" button is clicked
         // inside the iframe
         window.addEventListener('message', this.handleResultsMessage);
+
+        // Load partial results
+        const { serializedForm } = this.props;
+        if (serializedForm) {
+            this.reloadAndHydrate(serializedForm);
+        }
     }
 
     componentWillUnmount() {
@@ -122,5 +129,6 @@ TestIframe.propTypes = {
     onResults: PropTypes.func,
     git_hash: PropTypes.string,
     file: PropTypes.string,
-    at_key: PropTypes.string
+    at_key: PropTypes.string,
+    serializedForm: PropTypes.array
 };

--- a/client/utils/formSerialization.js
+++ b/client/utils/formSerialization.js
@@ -6,7 +6,6 @@ const selector = 'input, button, textarea, select, fieldset, optgroup, option';
 // state
 export function serialize(root) {
     const nodes = root.querySelectorAll(selector);
-
     // serialized element state is saved in an
     // array since element traversal order will
     // always be the same

--- a/server/models/TestResult.js
+++ b/server/models/TestResult.js
@@ -43,6 +43,10 @@ module.exports = function(sequelize, DataTypes) {
             result: {
                 type: DataTypes.JSONB,
                 allowNull: true
+            },
+            serialized_form: {
+                type: DataTypes.JSONB,
+                allowNull: true
             }
         },
         {

--- a/server/services/RunService.js
+++ b/server/services/RunService.js
@@ -453,7 +453,8 @@ async function sequelizeRunsToJsonRuns(sequelizeRuns) {
                             id: testResult.id,
                             user_id: testResult.user_id,
                             status: testResult.TestStatus.name,
-                            result: testResult.result
+                            result: testResult.result,
+                            serialized_form: testResult.serialized_form
                         };
                         return acc;
                     }, {})
@@ -499,7 +500,6 @@ async function getActiveRuns() {
                 db.Users
             ]
         });
-
         return await sequelizeRunsToJsonRuns(activeRuns);
     } catch (error) {
         console.error(`Error: ${error}`);

--- a/server/tests/unit/services/RunService.test.js
+++ b/server/tests/unit/services/RunService.test.js
@@ -1440,7 +1440,8 @@ describe('RunService', () => {
                                     id: testResult.id,
                                     user_id: user.id,
                                     status: db.TestStatus.COMPLETE,
-                                    result: result
+                                    result: result,
+                                    serialized_form: null
                                 }
                             }
                         }
@@ -1675,7 +1676,8 @@ describe('RunService', () => {
                                     id: testResult.id,
                                     user_id: user.id,
                                     status: db.TestStatus.COMPLETE,
-                                    result: result
+                                    result: result,
+                                    serialized_form: null
                                 }
                             }
                         }


### PR DESCRIPTION
This change is for saving partial results from the ARIA-AT App side. The following changes have been made:

- The removal of modals on Previous and Skip that warn about saving. Since there are partial results being saved, these modals are no longer relevant
- Saving of serialized form of iframe for skipped tests
- React state in `DisplayTest` modal that waits for the skipped test results to be saved
- Unit tests for `TestService`

To Test:
~~- Import the tests in PR branch of the `aria-at`: `yarn workspace server db-import-tests:dev -c c13791257b7bcb5258a2df6ecf24953898777295`~~
- Run the dev ARIA-AT App server and run a test from the test queue
- Fill in some data on the test iframe, but do not fill it out completely.
- Hit 'Skip test'.
- Hit 'Previous'
- Verify that the partial data entered previously is there