### PR TITLE
Save partial results other buttons

### DIFF
--- a/client/components/DisplayTest/index.jsx
+++ b/client/components/DisplayTest/index.jsx
@@ -77,25 +77,34 @@ class DisplayTest extends Component {
                 break;
             }
             case 'closeTest': {
+                // Save the serialized form of iframe
+                if (this.iframe.current) {
+                    await this.iframe.current.processResults(null);
+                }
                 history.push(`/test-queue`);
                 break;
             }
             case 'goToNextTest': {
                 // Save the serialized form of iframe
-                await this.iframe.current.processResults(null);
+                if (this.iframe.current) {
+                    await this.iframe.current.processResults(null);
+                }
                 displayNextTest();
                 break;
             }
             case 'goToPreviousTest': {
+                // Save the serialized form of iframe
+                if (this.iframe.current) {
+                    await this.iframe.current.processResults(null);
+                }
                 displayPreviousTest();
                 break;
             }
             case 'redoTest': {
-                if (!this.testHasResult) {
+                if (this.iframe.current) {
                     this.iframe.current.reloadAndClear();
-                } else {
-                    await deleteResultFromTest();
                 }
+                await deleteResultFromTest();
                 break;
             }
             case 'editTest': {
@@ -134,11 +143,7 @@ class DisplayTest extends Component {
     }
 
     handleCloseRunClick() {
-        if (this.testHasResult) {
-            this.performButtonAction('closeTest');
-        } else {
-            this.confirm('closeTest');
-        }
+        this.performButtonAction('closeTest');
     }
 
     handleEditClick() {
@@ -182,12 +187,7 @@ class DisplayTest extends Component {
         } = this.props;
 
         let modalTitle, action;
-        let cannotSave = `Test ${testIndex} has not been completed in full and your progress on this test won’t be saved.`;
 
-        if (this.buttonAction === 'closeTest') {
-            modalTitle = 'Close';
-            action = `You are about to leave this test run. ${cannotSave}`;
-        }
         if (this.buttonAction === 'redoTest') {
             modalTitle = 'Start Over';
             action = `Are you sure you want to start over test ${testIndex}. Your progress (if any) will be lost.`;

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -79,7 +79,7 @@ class TestRun extends Component {
                 test_id: test.id,
                 run_id: run.id,
                 user_id: openAsUser || userId,
-                skip: true
+                serializedForm: null
             })
         );
         return true;

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -83,9 +83,9 @@ async function saveTestResults(testResult) {
 
         // There will always be a serialized form for a complete or partially complete test.
         // Partially complete tests are tests that are skipped.
-        const stringifiedSerializedForm = `'${JSON.stringify(
+        const stringifiedSerializedForm = serialized_form ? `'${JSON.stringify(
             serialized_form
-        ).replace(/'/g, "''")}'`;
+        ).replace(/'/g, "''")}'` : 'NULL';
 
         // If a result has been sent, insert or update result row
         if (result) {


### PR DESCRIPTION
Partial results should now be saved when the following buttons are clicked:

- Skip
- Previous
- Close
- Next


