### PR TITLE
Change configure AT/Browser rows to not have form controls.

### DIFF
--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -40,7 +40,8 @@ function getDefaultsTechCombinations(testVersion, activeRunConfiguration) {
                 at_id,
                 at_version: combo.at_version,
                 browser_id: combo.browser_id,
-                browser_version: combo.browser_version
+                browser_version: combo.browser_version,
+                editable: false
             });
         }
     }
@@ -227,7 +228,7 @@ class ConfigureActiveRuns extends Component {
 
     addTechnologyRow() {
         let newRunTechnologies = [...this.state.runTechnologyRows];
-        newRunTechnologies.push({});
+        newRunTechnologies.push({editable: true});
         this.setState({
             runTechnologyRows: newRunTechnologies
         });
@@ -368,7 +369,7 @@ class ConfigureActiveRuns extends Component {
                                     <th>AT Version</th>
                                     <th>Browser</th>
                                     <th>Browser Version</th>
-                                    <th>Delete</th>
+                                    <th>Action</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -392,6 +393,9 @@ class ConfigureActiveRuns extends Component {
                                                     }
                                                     deleteTechnologyRow={
                                                         this.deleteTechnologyRow
+                                                    }
+                                                    editable={
+                                                        runTech.editable
                                                     }
                                                 />
                                             );

--- a/client/components/ConfigureTechnologyRow/index.jsx
+++ b/client/components/ConfigureTechnologyRow/index.jsx
@@ -83,76 +83,111 @@ class ConfigureTechnologyRow extends Component {
             availableBrowsers,
             availableAts,
             runTechnologies,
-            index
+            index,
+            editable
         } = this.props;
 
         return (
-            <tr>
-                <td>
-                    <Form.Control
-                        aria-label={`AT ${index + 1}`}
-                        value={
-                            runTechnologies.at_id ? runTechnologies.at_id : -1
+            !editable ? (
+                <tr>
+                    <td>
+                        {
+                            availableAts.find(
+                                at => at.at_id === runTechnologies.at_id
+                            ).at_name
                         }
-                        onChange={this.handleAtChange}
-                        as="select"
-                    >
-                        <option key={-1} value={-1}></option>;
-                        {availableAts.map((at, index) => {
-                            return (
-                                <option key={index} value={at.at_id}>
-                                    {at.at_name}
-                                </option>
-                            );
-                        })}
-                    </Form.Control>
-                </td>
-                <td>
-                    <Form.Control
-                        aria-label={`AT ${index + 1} Version`}
-                        value={runTechnologies.at_version || ''}
-                        onChange={this.handleAtVersionChange}
-                    />
-                </td>
-                <td>
-                    <Form.Control
-                        aria-label={`Browser ${index + 1}`}
-                        value={
-                            runTechnologies.browser_id
-                                ? runTechnologies.browser_id
-                                : -1
+                    </td>
+                    <td>{runTechnologies.at_version}</td>
+                    <td>
+                        {
+                            availableBrowsers.find(
+                                browser =>
+                                    browser.id === runTechnologies.browser_id
+                            ).name
                         }
-                        onChange={this.handleBrowserChange}
-                        as="select"
-                    >
-                        <option key={-1} value={-1}></option>;
-                        {availableBrowsers.map((browser, index) => {
-                            return (
-                                <option key={index} value={browser.id}>
-                                    {browser.name}
-                                </option>
-                            );
-                        })}
-                    </Form.Control>
-                </td>
-                <td>
-                    <Form.Control
-                        aria-label={`Browser ${index + 1} version`}
-                        value={runTechnologies.browser_version || ''}
-                        onChange={this.handleBrowserVersionChange}
-                    />
-                </td>
-                <td>
-                    <Button
-                        variant="danger"
-                        aria-label={`Delete at/browser combination ${index +
-                            1}`}
-                        onClick={this.deleteRun}
-                    >
-                        Delete
-                    </Button>
-                </td>
-            </tr>
+                    </td>
+                    <td>{runTechnologies.browser_version}</td>
+                    <td>
+                        <Button
+                            variant="danger"
+                            aria-label={`Delete at/browser combination ${index +
+                                1}`}
+                            onClick={this.deleteRun}
+                        >
+                            Remove
+                        </Button>
+                    </td>
+                </tr>
+            ) : (
+                <tr>
+                    <td>
+                        <Form.Control
+                            aria-label={`AT ${index + 1}`}
+                            value={
+                                runTechnologies.at_id
+                                    ? runTechnologies.at_id
+                                    : -1
+                            }
+                            onChange={this.handleAtChange}
+                            as="select"
+                        >
+                            <option key={-1} value={-1}></option>;
+                            {availableAts.map((at, index) => {
+                                return (
+                                    <option key={index} value={at.at_id}>
+                                        {at.at_name}
+                                    </option>
+                                );
+                            })}
+                        </Form.Control>
+                    </td>
+                    <td>
+                        <Form.Control
+                            aria-label={`AT ${index + 1} Version`}
+                            value={runTechnologies.at_version || ''}
+                            onChange={this.handleAtVersionChange}
+                        />
+                    </td>
+                    <td>
+                        <Form.Control
+                            aria-label={`Browser ${index + 1}`}
+                            value={
+                                runTechnologies.browser_id
+                                    ? runTechnologies.browser_id
+                                    : -1
+                            }
+                            onChange={this.handleBrowserChange}
+                            as="select"
+                        >
+                            <option key={-1} value={-1}></option>;
+                            {availableBrowsers.map((browser, index) => {
+                                return (
+                                    <option key={index} value={browser.id}>
+                                        {browser.name}
+                                    </option>
+                                );
+                            })}
+                        </Form.Control>
+                    </td>
+                    <td>
+                        <Form.Control
+                            aria-label={`Browser ${index + 1} version`}
+                            value={runTechnologies.browser_version || ''}
+                            onChange={this.handleBrowserVersionChange}
+                        />
+                    </td>
+                    <td>
+                        <Button
+                            variant="danger"
+                            aria-label={`Delete at/browser combination ${index +
+                                1}`}
+                            onClick={this.deleteRun}
+                        >
+                            Remove
+                        </Button>
+                    </td>
+                </tr>
+            )
         );
     }
 }
@@ -163,7 +198,8 @@ ConfigureTechnologyRow.propTypes = {
     availableAts: PropTypes.array,
     availableBrowsers: PropTypes.array,
     handleTechnologyRowChange: PropTypes.func,
-    deleteTechnologyRow: PropTypes.func
+    deleteTechnologyRow: PropTypes.func,
+    editable: PropTypes.bool
 };
 
 export default ConfigureTechnologyRow;

--- a/client/tests/ConfigureTechnologyRow.test.jsx
+++ b/client/tests/ConfigureTechnologyRow.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import EnzymeAdapter from 'enzyme-adapter-react-16';
+Enzyme.configure({ adapter: new EnzymeAdapter() });
+import ConfigureTechnologyRow from '../components/ConfigureTechnologyRow';
+
+describe('render', () => {
+    describe('runTechnologies props', () => {
+        test('when runTechnologies present, table rows should not have form elements', () => {
+            const runTechnologies = {
+                at_id: 1,
+                at_version: 1,
+                browser_id: 1,
+                browser_version: 1
+            };
+            const availableAts = [
+                {
+                    at_id: 1,
+                    at_name: 'foo'
+                }
+            ];
+            const availableBrowsers = [
+                {
+                    id: 1,
+                    name: 'bar'
+                }
+            ];
+
+            const component = shallow(
+                <ConfigureTechnologyRow
+                    runTechnologies={runTechnologies}
+                    availableAts={availableAts}
+                    availableBrowsers={availableBrowsers}
+                />
+            );
+            expect(component.find('td')).toHaveLength(5);
+            expect(component.find('td').every('.form-control')).toBe(false);
+        });
+    });
+});

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -97,9 +97,9 @@ async function saveTestResults(testResult) {
 
         // There will always be a serialized form for a complete or partially complete test.
         // Partially complete tests are tests that are skipped.
-        const stringifiedSerializedForm = serialized_form ? `'${JSON.stringify(
-            serialized_form
-        ).replace(/'/g, "''")}'` : 'NULL';
+        const stringifiedSerializedForm = serialized_form
+            ? `'${JSON.stringify(serialized_form).replace(/'/g, "''")}'`
+            : 'NULL';
 
         // If a result has been sent, insert or update result row
         if (result) {


### PR DESCRIPTION
Asana issue: https://app.asana.com/0/1193055321453706/1198879584985510

This change:
- Sets a row with a configured AT/Browser pair to have no inputs
- Changes the "Delete" button to "Remove"
- Changes the "Delete" column to "Action"

Test:
- Go to the Configure Active Runs page
- Verify that the configured AT/Browser pairs are rows without inputs
- Configure a new AT/Browser pair and save
- Verify that the new pair is a row without inputs