### PR TITLE
Configure active runs should respect apg_examples selection

### DIFF
--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -172,9 +172,16 @@ class ConfigureActiveRuns extends Component {
             });
         }
 
+        let apgExampleIds = [];
+        for (let { id } of versionData.apg_examples) {
+            if (this.state.exampleSelected[id]) {
+                apgExampleIds.push(id);
+            }
+        }
+
         const config = {
             test_version_id: this.state.selectedVersion,
-            apg_example_ids: versionData.apg_examples.map(a => a.id),
+            apg_example_ids: apgExampleIds,
             at_browser_pairs: atBrowserPairs
         };
 


### PR DESCRIPTION
On the configure run page, select and unselect APG patterns then click "save" -- it should work now!