### PR TITLE
Deduplicate runs on configuration page save

### DIFF
--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -164,12 +164,29 @@ class ConfigureActiveRuns extends Component {
                 continue;
             }
 
-            atBrowserPairs.push({
-                at_name_id: atIdToAtNameId[runTechnologyPair.at_id],
-                at_version: runTechnologyPair.at_version,
-                browser_id: runTechnologyPair.browser_id,
-                browser_version: runTechnologyPair.browser_version
+            let existingPair = atBrowserPairs.find(p => {
+                return (
+                    p.at_name_id === atIdToAtNameId[runTechnologyPair.at_id]
+                    && p.at_version === runTechnologyPair.at_version
+                    && p.browser_id === runTechnologyPair.browser_id
+                    && p.browser_version === runTechnologyPair.browser_version
+                );
             });
+            if (existingPair) {
+                let deduplicatedRows = [...this.state.runTechnologyRows];
+                deduplicatedRows.splice(index, 1);
+                this.setState({
+                    runTechnologyRows: deduplicatedRows
+                });
+            }
+            else {
+                atBrowserPairs.push({
+                    at_name_id: atIdToAtNameId[runTechnologyPair.at_id],
+                    at_version: runTechnologyPair.at_version,
+                    browser_id: runTechnologyPair.browser_id,
+                    browser_version: runTechnologyPair.browser_version
+                });
+            }
         }
 
         let apgExampleIds = [];

--- a/client/components/ConfigureTechnologyRow/index.jsx
+++ b/client/components/ConfigureTechnologyRow/index.jsx
@@ -22,7 +22,7 @@ class ConfigureTechnologyRow extends Component {
             handleTechnologyRowChange
         } = this.props;
 
-        let version = event.currentTarget.value;
+        let version = event.currentTarget.value.trim();
         let newRunTechnologies = { ...runTechnologies };
         newRunTechnologies.browser_version = version;
 
@@ -36,7 +36,7 @@ class ConfigureTechnologyRow extends Component {
             handleTechnologyRowChange
         } = this.props;
 
-        let version = event.currentTarget.value;
+        let version = event.currentTarget.value.trim();
         let newRunTechnologies = { ...runTechnologies };
         newRunTechnologies.at_version = version;
 


### PR DESCRIPTION
Try adding identical rows, such as "JAWS 1 Firefox 1" twice. When you click save, it should collapse to one, and you should not see duplication in the Test Queue page.