### PR TITLE
Change UX of Test Version select to show current git commit and a drop down when there are new versions

### DIFF
--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -452,7 +452,7 @@ class ConfigureActiveRuns extends Component {
                 ? testVersions
                       .filter(
                           version =>
-                              version.date >=
+                              version.date >
                               activeRunConfiguration.active_test_version.date
                       )
                       .map(version => {
@@ -463,16 +463,18 @@ class ConfigureActiveRuns extends Component {
                   });
         };
 
-        return (
+        const versions = getTestVersions();
+
+        return versions.length > 0 ? (
             <Form.Control
                 data-test="configure-run-commit-select"
                 value={this.state.selectedVersion}
                 onChange={this.handleVersionChange}
                 as="select"
             >
-                {getTestVersions()}
+                {versions}
             </Form.Control>
-        );
+        ) : null;
     }
 
     render() {
@@ -539,6 +541,8 @@ class ConfigureActiveRuns extends Component {
             enableSaveButton = false;
         }
 
+        const renderedTestVersions = this.renderTestVersionSelect();
+
         return (
             <Fragment>
                 <h1 data-test="configure-run-h2">Configure Active Runs</h1>
@@ -546,14 +550,42 @@ class ConfigureActiveRuns extends Component {
                 <Form className="init-box">
                     <Row>
                         <Col>
-                            <Form.Group controlId="testVersion">
-                                <Form.Label data-test="configure-run-commit-label">
-                                    Git Commit of Tests
-                                </Form.Label>
-                                {this.renderTestVersionSelect()}
-                            </Form.Group>
+                            {
+                                Object.keys(activeRunConfiguration.active_test_version).length > 0 ?
+                                <Form.Group controlId="testVersion">
+                                    <Form.Label data-test="configure-run-current-commit-label">
+                                        Current Git Commit
+                                    </Form.Label>
+                                    <p>
+                                        {activeRunConfiguration.active_test_version.git_hash.slice(
+                                            0,
+                                            7
+                                        ) +
+                                            ' - ' +
+                                            activeRunConfiguration.active_test_version.git_commit_msg.slice(
+                                                0,
+                                                80
+                                            ) +
+                                            '...'}
+                                    </p>
+                                </Form.Group>
+                                :
+                                null
+                            }
                         </Col>
                     </Row>
+                    {renderedTestVersions !== null ? (
+                        <Row>
+                            <Col>
+                                <Form.Group controlId="testVersion">
+                                    <Form.Label data-test="configure-run-commit-label">
+                                        Select a different commit
+                                    </Form.Label>
+                                    {renderedTestVersions}
+                                </Form.Group>
+                            </Col>
+                        </Row>
+                    ) : null}
                     <Row>
                         <Table
                             aria-label="Configure at/browser combinations for test run"

--- a/client/tests/ConfigureActiveRuns.test.jsx
+++ b/client/tests/ConfigureActiveRuns.test.jsx
@@ -53,11 +53,35 @@ describe('render', () => {
                 }
             ]
         };
+        let testVersion2 = {
+            date: '2020-05-07T04:00:00.000Z',
+            git_commit_msg:
+                'Checkbox 2: Test navigating through group with arrows',
+            git_hash: '12345',
+            git_repo: 'https://github.com/w3c/aria-at.git',
+            git_tag: null,
+            id: 1,
+            apg_examples: [
+                {
+                    directory: 'checkbox',
+                    id: 1,
+                    name: 'Checkbox Example (Two State)'
+                }
+            ],
+            supported_ats: [
+                {
+                    at_id: 1,
+                    at_key: 'vader-voice',
+                    at_name: 'Vader Voice',
+                    at_name_id: 1
+                }
+            ]
+        };
         beforeEach(() => {
             const initialState = {
                 ats: [{ id: 1, name: 'Vader Voice' }],
                 runs: {
-                    testVersions: [testVersion],
+                    testVersions: [testVersion, testVersion2],
                     activeRunConfiguration: {
                         active_test_version: testVersion,
                         active_at_browser_pairs: [],
@@ -74,7 +98,7 @@ describe('render', () => {
             wrapper = setup(initialState);
             wrapper.setState({ currentTestIndex: 1 });
         });
-        test('renders component ui sections', () => {
+        test('renders component ui sections with an existing active test version', () => {
             let component = findByTestAttr(wrapper, 'configure-run-h2');
             expect(component.length).toBe(1);
             expect(component.text()).toContain('Configure Active Runs');
@@ -83,15 +107,18 @@ describe('render', () => {
             expect(component.length).toBe(1);
             expect(component.text()).toContain('Update Versions');
 
-            component = findByTestAttr(wrapper, 'configure-run-commit-label');
+            component = findByTestAttr(wrapper, 'configure-run-current-commit-label');
             expect(component.length).toBe(1);
-            expect(component.text()).toContain('Git Commit of Tests');
+            expect(component.text()).toContain('Current Git Commit');
 
             component = findByTestAttr(wrapper, 'configure-run-commit-select');
             expect(component.length).toBe(1);
             expect(component.text()).toContain(
-                'ff1ed8a - Checkbox: Test navigating'
+                '12345 - Checkbox 2: Test navigating'
             );
+
+            component = findByTestAttr(wrapper, 'configure-run-commit-label');
+            expect(component.text()).toContain('Select a different commit');
         });
     });
 });


### PR DESCRIPTION
This PR is dependent on #202 

- When there are no new versions:
<img width="1322" alt="Screen Shot 2020-11-04 at 3 15 01 PM" src="https://user-images.githubusercontent.com/2789098/98164093-c4849500-1eb1-11eb-81df-18353a087fec.png">

- When there are new versions:
<img width="1341" alt="Screen Shot 2020-11-04 at 3 21 57 PM" src="https://user-images.githubusercontent.com/2789098/98164114-cb130c80-1eb1-11eb-8dfe-dc1982eb9050.png">
