### PR TITLE
Usability fixes

### DIFF
--- a/client/components/ConfigureTechnologyRow/index.jsx
+++ b/client/components/ConfigureTechnologyRow/index.jsx
@@ -16,6 +16,30 @@ class ConfigureTechnologyRow extends Component {
         this.handleAtChange = this.handleAtChange.bind(this);
         this.deleteRun = this.deleteRun.bind(this);
         this.undoDelete = this.undoDelete.bind(this);
+
+        this.newRowRef = React.createRef();
+        this.deleteRef = React.createRef();
+        this.undoRef = React.createRef();
+    }
+
+    componentDidMount() {
+        const { editable } = this.props;
+        if (editable) {
+            this.newRowRef.current.focus();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if (
+            !this.props.editable
+        ) {
+            if (this.props.deleted && !prevProps.deleted) {
+                this.undoRef.current.focus();
+            }
+            else if (!this.props.deleted && prevProps.deleted) {
+                this.deleteRef.current.focus();
+            }
+        }
     }
 
     handleBrowserVersionChange(event) {
@@ -121,6 +145,7 @@ class ConfigureTechnologyRow extends Component {
                             1}`}
                         onClick={this.deleteRun}
                         disabled={deleted === true}
+                        ref={this.deleteRef}
                     >
                         Remove
                     </Button>
@@ -128,6 +153,7 @@ class ConfigureTechnologyRow extends Component {
                         disabled={deleted === false}
                         onClick={this.undoDelete}
                         aria-label="Undo delete"
+                        ref={this.undoRef}
                     >
                         <FontAwesomeIcon icon={faUndo}></FontAwesomeIcon>
                     </Button>
@@ -143,6 +169,7 @@ class ConfigureTechnologyRow extends Component {
                         }
                         onChange={this.handleAtChange}
                         as="select"
+                        ref={this.newRowRef}
                     >
                         <option key={-1} value={-1}></option>;
                         {availableAts.map((at, index) => {

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -24,7 +24,7 @@ class TestQueue extends Component {
     }
 
     renderAtBrowserList(runIds) {
-        const { userId, usersById, admin, activeRunsById } = this.props;
+        const { admin, activeRunsById } = this.props;
         const {
             at_name: atName,
             at_version: atVersion,
@@ -35,7 +35,7 @@ class TestQueue extends Component {
         let tableId = nextId('table_name_');
 
         return (
-            <div key={`${nextId('at_browser_pair')}`}>
+            <div key={`${atName}${atVersion}${browserName}${browserVersion}`}>
                 <h3
                     id={tableId}
                 >{`${atName} ${atVersion} with ${browserName} ${browserVersion}`}</h3>
@@ -50,28 +50,12 @@ class TestQueue extends Component {
                     </thead>
                     <tbody>
                         {runIds.map(runId => {
-                            const run = activeRunsById[runId];
-                            const {
-                                apg_example_name,
-                                testers,
-                                at_name_id,
-                                run_status,
-                                id,
-                                tests
-                            } = run;
                             return (
                                 <TestQueueRun
-                                    key={id}
-                                    runId={id}
-                                    runStatus={run_status}
-                                    apgExampleName={apg_example_name}
-                                    testers={testers}
-                                    usersById={usersById}
-                                    userId={userId}
+                                    key={runId}
+                                    runId={runId}
                                     atName={atName}
-                                    atNameId={at_name_id}
                                     browserName={browserName}
-                                    testsForRun={tests}
                                     admin={admin}
                                 />
                             );


### PR DESCRIPTION
Confirm the following for the test queue page:
- the first column in the test queue tables is a `th`
- there is no `tabindex="-1"` on the assignee list
- the button to start testing says "start testing" when you are first assigned and switches to "continue testing" as soon as you save partial results or complete results
- the focus moves to the "Start testing" button after you click "assign yourself"

Confirm the following for the configure run page:
- When you add a new row, the focus goes to the AT dropdown for that row
- When you click "delete" for a row, the focus goes to the "undo" button, and when you click "undo", the focus goes to the "delete" button