### PR TITLE
Add ability to filter by Tech Pair to reports page (Take 2)

### DIFF
--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -12,7 +12,6 @@ import {
     generateTechPairs,
     generateApgExamples,
     calculateTotalObjectPercentage,
-    findAndCalculatePercentage
 } from './utils';
 
 class ReportsPage extends Component {

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -21,7 +21,7 @@ class ReportsPage extends Component {
         this.state = {
             techMatrix: [[null]], // This is a matrix of ATs and Browsers
             techPairs: [],
-            apgExamples: [],
+            apgExamples: []
         };
 
         this.setTechPairsState = this.setTechPairsState.bind(this);
@@ -47,9 +47,15 @@ class ReportsPage extends Component {
     }
 
     selectTechPair(i) {
-      this.setState({
-        techPairs: [...this.state.techPairs.slice(0, i), Object.assign(this.state.techPairs[i], {active: !this.state.techPairs[i]['active']}), ...this.state.techPairs.slice(i + 1)]
-      });
+        this.setState({
+            techPairs: [
+                ...this.state.techPairs.slice(0, i),
+                Object.assign(this.state.techPairs[i], {
+                    active: !this.state.techPairs[i]['active']
+                }),
+                ...this.state.techPairs.slice(i + 1)
+            ]
+        });
     }
 
     setTechPairsState() {
@@ -82,7 +88,9 @@ class ReportsPage extends Component {
                 if (techMatrix[i][j] !== null) {
                     let at = techMatrix[0][j];
                     let browser = techMatrix[i][0];
-                    let techPair = this.state.techPairs.find(pair => pair.browser === browser && pair.at === at);
+                    let techPair = this.state.techPairs.find(
+                        pair => pair.browser === browser && pair.at === at
+                    );
                     techPairHeaders.push(
                         <th
                             key={`${at} with ${browser}`}
@@ -121,49 +129,51 @@ class ReportsPage extends Component {
         const { techMatrix, apgExamples, techPairs } = this.state;
 
         apgExamples.forEach(apgExample => {
-          let row = [];
-          row.push(
-            <td key={`example-${apgExample}`}
-            >
-              <span>
-                <FontAwesomeIcon icon={faFolder} />
-              </span>
-            {apgExample}
-          </td>
-        );
-          techPairs.filter(pair => pair.active).forEach(pair => {
-            let techMatrixExample = techMatrix[pair.techMatrixRow][pair.techMatrixColumn][apgExample];
-            if (techMatrixExample) {
-              let percentage = Math.trunc((techMatrixExample.pass / techMatrixExample.total) * 100);
-              row.push(
-                <td
-                  key={`data-${apgExample}-${pair.at}-${pair.browser}`}
-                >
-                  <ProgressBar
-                    now={percentage}
-                    variant="info"
-                    label={`${percentage}%`}
-                  />
+            let row = [];
+            row.push(
+                <td key={`example-${apgExample}`}>
+                    <span>
+                        <FontAwesomeIcon icon={faFolder} />
+                    </span>
+                    {apgExample}
                 </td>
-              );
-            } else {
-              row.push(
-                <td
-                  key={`data-${apgExample}-${pair.at}-${pair.browser}`}
-                  aria-label={`No results data for ${apgExample} on ${pair.at} with ${pair.browser}`}
-                >
-                  -
-                </td>
-              );
-            }
-          });
-          apgExampleRows.push(
-            <tr key={apgExample}>
-              {row}
-            </tr>
-          );
-        }
-        );
+            );
+            techPairs
+                .filter(pair => pair.active)
+                .forEach(pair => {
+                    let techMatrixExample =
+                        techMatrix[pair.techMatrixRow][pair.techMatrixColumn][
+                            apgExample
+                        ];
+                    if (techMatrixExample) {
+                        let percentage = Math.trunc(
+                            (techMatrixExample.pass / techMatrixExample.total) *
+                                100
+                        );
+                        row.push(
+                            <td
+                                key={`data-${apgExample}-${pair.at}-${pair.browser}`}
+                            >
+                                <ProgressBar
+                                    now={percentage}
+                                    variant="info"
+                                    label={`${percentage}%`}
+                                />
+                            </td>
+                        );
+                    } else {
+                        row.push(
+                            <td
+                                key={`data-${apgExample}-${pair.at}-${pair.browser}`}
+                                aria-label={`No results data for ${apgExample} on ${pair.at} with ${pair.browser}`}
+                            >
+                                -
+                            </td>
+                        );
+                    }
+                });
+            apgExampleRows.push(<tr key={apgExample}>{row}</tr>);
+        });
     }
 
     render() {
@@ -187,26 +197,28 @@ class ReportsPage extends Component {
             this.generateApgExampleRows(apgExampleRows, techPairHeaders);
 
             this.state.techPairs.forEach((techPair, index) => {
-              techPairSelectors.push(
-                <div className="form-check form-check-inline" key={`${techPair['at']}-with-${techPair['browser']}`}>
-                  <input
-                    type="checkbox"
-                    id={`${techPair['at']}-with-${techPair['browser']}-checkbox`}
-                    name={`${techPair['at']}-with-${techPair['browser']}`}
-                    checked={techPair['active']}
-                    onChange={() => this.selectTechPair(index)}
-                    className="form-check-input"
-                  ></input>
-                  <label
-                    htmlFor={`${techPair['at']}-with-${techPair['browser']}-checkbox`}
-                    className="form-check-label"
-                  >
-                    {`${techPair['at']} with ${techPair['browser']}`}
-                  </label>
-                </div>
-              );
-            }
-            );
+                techPairSelectors.push(
+                    <div
+                        className="form-check form-check-inline"
+                        key={`${techPair['at']}-with-${techPair['browser']}`}
+                    >
+                        <input
+                            type="checkbox"
+                            id={`${techPair['at']}-with-${techPair['browser']}-checkbox`}
+                            name={`${techPair['at']}-with-${techPair['browser']}`}
+                            checked={techPair['active']}
+                            onChange={() => this.selectTechPair(index)}
+                            className="form-check-input"
+                        ></input>
+                        <label
+                            htmlFor={`${techPair['at']}-with-${techPair['browser']}-checkbox`}
+                            className="form-check-label"
+                        >
+                            {`${techPair['at']} with ${techPair['browser']}`}
+                        </label>
+                    </div>
+                );
+            });
         }
 
         return (
@@ -220,7 +232,9 @@ class ReportsPage extends Component {
                 <Table bordered hover>
                     <thead>
                         <tr>
-                            <th><h2>Design Pattern Examples</h2></th>
+                            <th>
+                                <h2>Design Pattern Examples</h2>
+                            </th>
                             {techPairHeaders}
                         </tr>
                     </thead>

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -117,115 +117,6 @@ class ReportsPage extends Component {
         return { techPairHeaders, topLevelRowData };
     }
 
-    generateApgExampleRowsOrignal(apgExampleRows, techPairHeaders) {
-        const { techMatrix } = this.state;
-        const { publishedRunsById } = this.props;
-        // Determine which columns should have percentages
-        // for the published result
-        publishedRunsById &&
-            Object.values(publishedRunsById).forEach(run => {
-                const tableRows = [];
-
-                // Get the APG example row index
-                const apgRowIndex = apgExampleRows.findIndex(row =>
-                    row.key.includes(run.apg_example_name)
-                );
-
-                // Get the browser column index
-                const headerColumnIndex = techPairHeaders.findIndex(
-                    header =>
-                        header.key.includes(run.at_name) &&
-                        header.key.includes(run.browser_name)
-                );
-
-                const percentage = findAndCalculatePercentage(
-                    techMatrix,
-                    run.at_name,
-                    run.browser_name,
-                    run.apg_example_name
-                );
-
-                const techPair = this.state.techPairs.find(pair => pair.browser === run.browser_name && pair.at === run.at_name);
-                console.log(this.state.techPairs);
-
-                // Add new row
-                if (apgRowIndex < 0) {
-                    tableRows[0] = (
-                      <td key={`example-${run.id}-${run.apg_example_name}`}
-                      >
-                            <span>
-                                <FontAwesomeIcon icon={faFolder} />
-                            </span>
-                            {run.apg_example_name}
-                        </td>
-                    );
-                    for (let i = 0; i < techPairHeaders.length; i++) {
-                        if (i === headerColumnIndex) {
-                            tableRows.push(
-                                <td
-                                    key={`data-${run.id}-${run.apg_example_name}-${techPairHeaders[headerColumnIndex].key}`}
-                                    className={techPair.active ? '' : 'd-none'}
-                                >
-                                    <ProgressBar
-                                        now={percentage}
-                                        variant="info"
-                                        label={`${percentage}%`}
-                                    />
-                                </td>
-                            );
-                        } else {
-                            // Not the techPair we just found it is some other
-                          // tech pair
-                            tableRows.push(
-                                <td
-                                    key={`data-${run.id}-${run.apg_example_name}-${techPairHeaders[i].key}`}
-                                    aria-label={`No results data for ${run.apg_example_name} on ${techPairHeaders[i].key}`}
-                                    className={techPair.active ? '' : 'd-none'}
-                                >
-                                    -
-                                </td>
-                            );
-                        }
-                    }
-                    apgExampleRows.push(
-                        <tr key={`${run.id}-${run.apg_example_name}`}>
-                            {tableRows}
-                        </tr>
-                    );
-                } else {
-                    // If the row already exists, update the column with percent
-                    let apgExampleRow = apgExampleRows[apgRowIndex];
-                    let dataEntries = [];
-                    for (let dataEntry of apgExampleRow.props.children) {
-                        if (
-                            dataEntry.key.includes(run.at_name) &&
-                            dataEntry.key.includes(run.browser_name)
-                        ) {
-                            // What if this was a dash
-                            dataEntries.push(
-                              <td key={dataEntry.key}
-                                className={techPair.active ? '' : 'd-none'}
-                              >
-                                    <ProgressBar
-                                        now={percentage}
-                                        variant="info"
-                                        label={`${percentage}%`}
-                                    />
-                                </td>
-                            );
-                        } else {
-                            dataEntries.push(dataEntry);
-                        }
-                    }
-                    apgExampleRows[apgRowIndex] = (
-                        <tr key={`${run.id}-${run.apg_example_name}`}>
-                            {dataEntries}
-                        </tr>
-                    );
-                }
-            });
-    }
-
     generateApgExampleRows(apgExampleRows) {
         const { techMatrix, apgExamples, techPairs } = this.state;
 
@@ -241,7 +132,30 @@ class ReportsPage extends Component {
           </td>
         );
           techPairs.filter(pair => pair.active).forEach(pair => {
-            row.push(<td>Placeholder</td>);
+            let techMatrixExample = techMatrix[pair.techMatrixRow][pair.techMatrixColumn][apgExample];
+            if (techMatrixExample) {
+              let percentage = Math.trunc((techMatrixExample.pass / techMatrixExample.total) * 100);
+              row.push(
+                <td
+                  key={`data-${apgExample}-${pair.at}-${pair.browser}`}
+                >
+                  <ProgressBar
+                    now={percentage}
+                    variant="info"
+                    label={`${percentage}%`}
+                  />
+                </td>
+              );
+            } else {
+              row.push(
+                <td
+                  key={`data-${apgExample}-${pair.at}-${pair.browser}`}
+                  aria-label={`No results data for ${apgExample} on ${pair.at} with ${pair.browser}`}
+                >
+                  -
+                </td>
+              );
+            }
           });
           apgExampleRows.push(
             <tr key={apgExample}>

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -9,6 +9,7 @@ import { faFolderOpen, faFolder } from '@fortawesome/free-solid-svg-icons';
 import { ProgressBar } from 'react-bootstrap';
 import {
     generateStateMatrix,
+    generateTechPairs,
     calculateTotalObjectPercentage,
     findAndCalculatePercentage
 } from './utils';
@@ -17,12 +18,14 @@ class ReportsPage extends Component {
     constructor() {
         super();
         this.state = {
-            techMatrix: [[null]] // This is a matrix of ATs and Browsers
+            techMatrix: [[null]], // This is a matrix of ATs and Browsers
+            techPairs: []
         };
 
         this.setTechPairsState = this.setTechPairsState.bind(this);
         this.generateTopLevelData = this.generateTopLevelData.bind(this);
         this.generateApgExampleRows = this.generateApgExampleRows.bind(this);
+        this.selectTechPair = this.selectTechPair.bind(this);
     }
 
     componentDidMount() {
@@ -41,10 +44,17 @@ class ReportsPage extends Component {
         }
     }
 
+    selectTechPair(i) {
+      this.setState({
+        techPairs: [...this.state.techPairs.slice(0, i), Object.assign(this.state.techPairs[i], {active: !this.state.techPairs[i]['active']}), ...this.state.techPairs.slice(i + 1)]
+      });
+    }
+
     setTechPairsState() {
         const { publishedRunsById } = this.props;
         let techMatrix = generateStateMatrix(publishedRunsById);
-        this.setState({ techMatrix });
+        let techPairs = generateTechPairs(techMatrix);
+        this.setState({ techMatrix, techPairs });
     }
 
     generateTopLevelData() {
@@ -202,6 +212,7 @@ class ReportsPage extends Component {
         let techPairHeaders = [];
         let topLevelRowData = [];
         let apgExampleRows = [];
+        let techPairSelectors = [];
 
         // Generate the data table only if there is data
         if (techMatrix.length > 1) {
@@ -215,6 +226,28 @@ class ReportsPage extends Component {
             );
 
             this.generateApgExampleRows(apgExampleRows, techPairHeaders);
+
+            this.state.techPairs.forEach((techPair, index) => {
+              techPairSelectors.push(
+                <div className="form-check form-check-inline" key={`${techPair['at']}-with-${techPair['browser']}`}>
+                  <input
+                    type="checkbox"
+                    id={`${techPair['at']}-with-${techPair['browser']}-checkbox`}
+                    name={`${techPair['at']}-with-${techPair['browser']}`}
+                    checked={techPair['active']}
+                    onChange={() => this.selectTechPair(index)}
+                    className="form-check-input"
+                  ></input>
+                  <label
+                    htmlFor={`${techPair['at']}-with-${techPair['browser']}-checkbox`}
+                    className="form-check-label"
+                  >
+                    {`${techPair['at']} with ${techPair['browser']}`}
+                  </label>
+                </div>
+              );
+            }
+            );
         }
 
         return (
@@ -223,10 +256,12 @@ class ReportsPage extends Component {
                     <title>{`ARIA-AT Reports`}</title>
                 </Helmet>
                 <h1>Reports Page</h1>
+                <h2>Available AT and Browser Combinations</h2>
+                <form className="mb-3">{techPairSelectors}</form>
                 <Table bordered hover>
                     <thead>
                         <tr>
-                            <th>Design Pattern Examples</th>
+                            <th><h2>Design Pattern Examples</h2></th>
                             {techPairHeaders}
                         </tr>
                     </thead>

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -133,7 +133,7 @@ export function generateTechPairs(techMatrix) {
         for (let j = 1; j < techMatrix[0].length; j++) {
             if (techMatrix[i][j] !== null) {
                 techPairs.push(
-                    {browser: techMatrix[i][0], at: techMatrix[0][j], active: true}
+                    {browser: techMatrix[i][0], at: techMatrix[0][j], techMatrixColumn: j, techMatrixRow: i, active: true}
                 );
             }
         }

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -3,13 +3,13 @@
  * from the Redux store and maps it into a matrix
  * whereby the columns are AT names and the rows
  * are browser names.
- * 
+ *
  * At the intersection of a row and column is an object
  * that contains as the key, a test plan name, and the value
- * as an object containing the total number of tests 
+ * as an object containing the total number of tests
  * that have results and the number of tests with results
  * that pass.
- * 
+ *
  * An input like this:
  * {
     1: {
@@ -118,6 +118,21 @@ export function generateStateMatrix(publishedRunsById) {
     );
 
     return techMatrix;
+}
+
+export function generateTechPairs(techMatrix) {
+    let techPairs = [];
+    for (let i = 1; i < techMatrix.length; i++) {
+        for (let j = 1; j < techMatrix[0].length; j++) {
+            if (techMatrix[i][j] !== null) {
+                techPairs.push(
+                    {browser: techMatrix[i][0], at: techMatrix[0][j], active: true}
+                );
+            }
+        }
+    }
+    console.log(techPairs);
+    return techPairs;
 }
 
 /**

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -123,7 +123,6 @@ export function generateStateMatrix(publishedRunsById) {
 export function generateApgExamples(publishedRunsById) {
     const runs = Object.values(publishedRunsById);
     const apgExamples = [...new Set(runs.map(r => r.apg_example_name))];
-    console.log(apgExamples);
     return apgExamples;
 }
 
@@ -132,13 +131,16 @@ export function generateTechPairs(techMatrix) {
     for (let i = 1; i < techMatrix.length; i++) {
         for (let j = 1; j < techMatrix[0].length; j++) {
             if (techMatrix[i][j] !== null) {
-                techPairs.push(
-                    {browser: techMatrix[i][0], at: techMatrix[0][j], techMatrixColumn: j, techMatrixRow: i, active: true}
-                );
+                techPairs.push({
+                    browser: techMatrix[i][0],
+                    at: techMatrix[0][j],
+                    techMatrixColumn: j,
+                    techMatrixRow: i,
+                    active: true
+                });
             }
         }
     }
-    console.log(techPairs);
     return techPairs;
 }
 

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -167,26 +167,3 @@ export function calculateTotalObjectPercentage(object) {
 
     return Math.trunc((topLevelData.pass / topLevelData.total) * 100);
 }
-
-export function findAndCalculatePercentage(
-    techMatrix,
-    runAtName,
-    runBrowserName,
-    apgExampleName
-) {
-    // Get the data at that browser
-    const techMatrixCol = techMatrix[0].findIndex(
-        at_name => at_name === runAtName
-    );
-    const techMatrixRow = techMatrix.findIndex(
-        browserRow => browserRow[0] === runBrowserName
-    );
-
-    // The math for the rows works by taking all the passing tests
-    // and dividing by total number of tests with results
-    return Math.trunc(
-        (techMatrix[techMatrixRow][techMatrixCol][apgExampleName].pass /
-            techMatrix[techMatrixRow][techMatrixCol][apgExampleName].total) *
-            100
-    );
-}

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -120,6 +120,13 @@ export function generateStateMatrix(publishedRunsById) {
     return techMatrix;
 }
 
+export function generateApgExamples(publishedRunsById) {
+    const runs = Object.values(publishedRunsById);
+    const apgExamples = [...new Set(runs.map(r => r.apg_example_name))];
+    console.log(apgExamples);
+    return apgExamples;
+}
+
 export function generateTechPairs(techMatrix) {
     let techPairs = [];
     for (let i = 1; i < techMatrix.length; i++) {

--- a/client/tests/ReportsPage.test.jsx
+++ b/client/tests/ReportsPage.test.jsx
@@ -6,7 +6,6 @@ import { storeFactory } from './util';
 import {
     generateStateMatrix,
     calculateTotalObjectPercentage,
-    findAndCalculatePercentage
 } from '../components/ReportsPage/utils';
 import ReportsPage from '../components/ReportsPage';
 
@@ -61,13 +60,13 @@ describe('utils', () => {
     test('generateStateMatrix', () => {
         /**
          *  Expecting a matrix like this:
-         * 
-         * 
+         *
+         *
             [
                 [null, "JAWS", "NVDA"],
                 ["Firefox", { "Editor Menubar Example" : { total: 1, pass: 1 } }, { "Checkbox Example (Two State)" : { total: 1, pass: 1 } }]
             ]
-         * 
+         *
          */
         const matrix = generateStateMatrix(publishedRunsById);
 
@@ -96,17 +95,6 @@ describe('utils', () => {
 
         const totalPercent = calculateTotalObjectPercentage(objectToTotal);
         expect(totalPercent).toBe(100);
-    });
-
-    test('findAndCalculatePercentage', () => {
-        const matrix = generateStateMatrix(publishedRunsById);
-        const percentage = findAndCalculatePercentage(
-            matrix,
-            publishedRunsById[1].at_name,
-            publishedRunsById[1].browser_name,
-            publishedRunsById[1].apg_example_name
-        );
-        expect(percentage).toBe(100);
     });
 });
 

--- a/client/tests/ReportsPage.test.jsx
+++ b/client/tests/ReportsPage.test.jsx
@@ -5,6 +5,8 @@ Enzyme.configure({ adapter: new EnzymeAdapter() });
 import { storeFactory } from './util';
 import {
     generateStateMatrix,
+    generateTechPairs,
+    generateApgExamples,
     calculateTotalObjectPercentage,
 } from '../components/ReportsPage/utils';
 import ReportsPage from '../components/ReportsPage';
@@ -101,12 +103,16 @@ describe('utils', () => {
 describe('render', () => {
     test('generateTopLevelData()', () => {
         const techMatrix = generateStateMatrix(publishedRunsById);
+        let techPairs = generateTechPairs(techMatrix);
+        let apgExamples = generateApgExamples(publishedRunsById);
         const store = storeFactory({});
         const wrapper = shallow(<ReportsPage store={store} />)
             .dive()
             .dive();
         wrapper.setState({
-            techMatrix
+            techMatrix,
+            techPairs,
+            apgExamples
         });
         const {
             techPairHeaders,
@@ -130,12 +136,16 @@ describe('render', () => {
 
     test('generateApgExampleRows()', () => {
         const techMatrix = generateStateMatrix(publishedRunsById);
+        let techPairs = generateTechPairs(techMatrix);
+        let apgExamples = generateApgExamples(publishedRunsById);
         const store = storeFactory({ runs: { publishedRunsById } });
         const wrapper = shallow(<ReportsPage store={store} />)
             .dive()
             .dive();
         wrapper.setState({
-            techMatrix
+            techMatrix,
+            techPairs,
+            apgExamples
         });
 
         let apgExampleRows = [];


### PR DESCRIPTION
This work was orignally implemented in: https://github.com/w3c/aria-at-app/pull/219. But two bugs were found one where the page crashed. This was caused by col and rows being switched which was easy to fix. The other bug was more serious and rows with `-` (without data) never were hidden. This was a fundamental design flaw. 

In this PR instead of iterating over the `techMatrix` add two new objects `techPairs` and `apgExamples` which a much similar data objects and use those to generate the table. This allows the rows to generated in one iteration and for them to be hidden without classes which much similar than the orginal. 