### PR TITLE
Add link to test details

### DIFF
--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -5,7 +5,11 @@ import { connect } from 'react-redux';
 import { getPublishedRuns } from '../../actions/runs';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFolderOpen, faFileAlt, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import {
+    faFolderOpen,
+    faFileAlt,
+    faExternalLinkAlt
+} from '@fortawesome/free-solid-svg-icons';
 import { ProgressBar } from 'react-bootstrap';
 import {
     generateTechPairs,
@@ -231,8 +235,7 @@ class ReportsPage extends Component {
                             <td
                                 key={`stat-header-link-${exampleName}-${at}-${browser}`}
                                 aria-label="Link to detailed test report"
-                            >
-                            </td>
+                            ></td>
                         );
                     });
 
@@ -304,7 +307,15 @@ class ReportsPage extends Component {
                                         <td
                                             key={`${exampleName}-${testName}-${i}-${at}-${browser}-link`}
                                         >
-                                          <a href={`/results/run/${runId}#test-${executionOrder}`} target="blank" aria-label={`Detailed Test Report for ${testName} ${at} ${browser}`}><FontAwesomeIcon icon={faExternalLinkAlt} /></a>
+                                            <a
+                                                href={`/results/run/${runId}#test-${executionOrder}`}
+                                                target="blank"
+                                                aria-label={`Detailed Test Report for ${testName} ${at} ${browser}`}
+                                            >
+                                                <FontAwesomeIcon
+                                                    icon={faExternalLinkAlt}
+                                                />
+                                            </a>
                                         </td>
                                     );
                                 } else {
@@ -369,8 +380,7 @@ class ReportsPage extends Component {
                         supportRow.push(
                             <td
                                 key={`${exampleName}-${browser}-${at}-support-link`}
-                            >
-                            </td>
+                            ></td>
                         );
                     }
                 });

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { getPublishedRuns } from '../../actions/runs';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFolderOpen, faFileAlt } from '@fortawesome/free-solid-svg-icons';
+import { faFolderOpen, faFileAlt, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { ProgressBar } from 'react-bootstrap';
 import {
     generateTechPairs,
@@ -103,7 +103,7 @@ class ReportsPage extends Component {
             .filter(({ active }) => active)
             .map(({ browser, at }) => {
                 return (
-                    <th key={`${at} with ${browser}`} colSpan={3}>
+                    <th key={`${at} with ${browser}`} colSpan={4}>
                         <h3 className="text-center">
                             {at} with {browser}
                         </h3>
@@ -134,7 +134,7 @@ class ReportsPage extends Component {
                 );
 
                 topLevelRowData.push(
-                    <td key={`Percentage of ${at} with ${browser}`} colSpan={3}>
+                    <td key={`Percentage of ${at} with ${browser}`} colSpan={4}>
                         <ProgressBar
                             now={percentage}
                             variant="info"
@@ -177,7 +177,7 @@ class ReportsPage extends Component {
                             exampleRow.push(
                                 <td
                                     key={`data-${exampleName}-${at}-${browser}`}
-                                    colSpan={3}
+                                    colSpan={4}
                                 >
                                     <ProgressBar
                                         now={percentage}
@@ -191,7 +191,7 @@ class ReportsPage extends Component {
                                 <td
                                     key={`data-${exampleName}-${at}-${browser}`}
                                     aria-label={`No results data for ${exampleName} on ${at} with ${browser}`}
-                                    colSpan={3}
+                                    colSpan={4}
                                 >
                                     -
                                 </td>
@@ -225,6 +225,13 @@ class ReportsPage extends Component {
                                 key={`stat-header-unexpected-${exampleName}-${at}-${browser}`}
                             >
                                 Unexpected Behavior
+                            </td>
+                        );
+                        testStatHeaderRow.push(
+                            <td
+                                key={`stat-header-link-${exampleName}-${at}-${browser}`}
+                                aria-label="Link to detailed test report"
+                            >
                             </td>
                         );
                     });
@@ -262,7 +269,9 @@ class ReportsPage extends Component {
                                         passingRequiredAssertions,
                                         optionalAssertions,
                                         passingOptionalAssertions,
-                                        unexpectedBehaviors
+                                        unexpectedBehaviors,
+                                        runId,
+                                        executionOrder
                                     } = testWithResults;
                                     testRow.push(
                                         <td
@@ -291,11 +300,18 @@ class ReportsPage extends Component {
                                             {formatInteger(unexpectedBehaviors)}
                                         </td>
                                     );
+                                    testRow.push(
+                                        <td
+                                            key={`${exampleName}-${testName}-${i}-${at}-${browser}-link`}
+                                        >
+                                          <a href={`/results/run/${runId}#test-${executionOrder}`} target="blank" aria-label={`Detailed Test Report for ${testName} ${at} ${browser}`}><FontAwesomeIcon icon={faExternalLinkAlt} /></href>
+                                        </td>
+                                    );
                                 } else {
                                     testRow.push(
                                         <td
                                             key={`${exampleName}-${testName}-${i}-${at}-${browser}`}
-                                            colSpan={3}
+                                            colSpan={4}
                                         >
                                             skipped
                                         </td>
@@ -348,6 +364,12 @@ class ReportsPage extends Component {
                                 key={`${exampleName}-${browser}-${at}-support-unexpected`}
                             >
                                 {formatInteger(unexpectedBehaviors)}
+                            </td>
+                        );
+                        supportRow.push(
+                            <td
+                                key={`${exampleName}-${browser}-${at}-support-link`}
+                            >
                             </td>
                         );
                     }

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -304,7 +304,7 @@ class ReportsPage extends Component {
                                         <td
                                             key={`${exampleName}-${testName}-${i}-${at}-${browser}-link`}
                                         >
-                                          <a href={`/results/run/${runId}#test-${executionOrder}`} target="blank" aria-label={`Detailed Test Report for ${testName} ${at} ${browser}`}><FontAwesomeIcon icon={faExternalLinkAlt} /></href>
+                                          <a href={`/results/run/${runId}#test-${executionOrder}`} target="blank" aria-label={`Detailed Test Report for ${testName} ${at} ${browser}`}><FontAwesomeIcon icon={faExternalLinkAlt} /></a>
                                         </td>
                                     );
                                 } else {

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -48,7 +48,9 @@ function generateTestsWithMetaData(runs, techPairs) {
                         optionalAssertions,
                         passingOptionalAssertions:
                             optionalAssertionsSummary.pass,
-                        unexpectedBehaviors
+                        unexpectedBehaviors,
+                        executionOrder: test.execution_order,
+                        runId: runForTechPair.id
                     });
                 }
             });
@@ -86,6 +88,8 @@ function generateTestsWithMetaData(runs, techPairs) {
  * @type {number} optionalAssertions
  * @type {number} passingOptionalAssertions
  * @type {number} unexpectedBehaviors
+ * @type {number} executionOrder
+ * @type {number} runId
  */
 export function generateApgExamples(publishedRunsById, techPairs) {
     const runs = Object.values(publishedRunsById);

--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -19,7 +19,7 @@ class RunResultsPage extends Component {
 
         this.handleRaiseIssueClick = this.handleRaiseIssueClick.bind(this);
 
-      this.$refs = {};
+        this.$refs = {};
     }
 
     async componentDidMount() {
@@ -33,15 +33,15 @@ class RunResultsPage extends Component {
     }
 
     async componentDidUpdate() {
-      if (this.$refs && location.href.includes('#test-')) {
-        const anchor = location.href.split('#')[1];
-        if (anchor !== undefined) {
-          const ref = this.$refs[anchor];
-          if (ref !== undefined) {
-            ref.scrollIntoView();
-          }
+        if (this.$refs && location.href.includes('#test-')) {
+            const anchor = location.href.split('#')[1];
+            if (anchor !== undefined) {
+                const ref = this.$refs[anchor];
+                if (ref !== undefined) {
+                    ref.scrollIntoView();
+                }
+            }
         }
-      }
     }
 
     handleRaiseIssueClick(i) {
@@ -52,7 +52,7 @@ class RunResultsPage extends Component {
         });
     }
 
-    renderResultRow(test, i) {
+    renderResultRow(test) {
         const details = test.result.result.details;
         let required =
             details.summary[1].pass + details.summary[1].fail > 0
@@ -203,8 +203,8 @@ class RunResultsPage extends Component {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {tests.map((test, i) =>
-                                        this.renderResultRow(test, i)
+                                    {tests.map(test =>
+                                        this.renderResultRow(test)
                                     )}
                                     <tr>
                                         <td>Support</td>
@@ -262,7 +262,11 @@ class RunResultsPage extends Component {
                                     <Fragment key={nextId()}>
                                         <div>
                                             <h2
-                                              ref={ref=>{this.$refs[`test-${t.execution_order}`] = ref}}
+                                                ref={ref => {
+                                                    this.$refs[
+                                                        `test-${t.execution_order}`
+                                                    ] = ref;
+                                                }}
                                                 id={`test-${t.execution_order}`}
                                                 className="float-left"
                                             >

--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -18,6 +18,8 @@ class RunResultsPage extends Component {
         };
 
         this.handleRaiseIssueClick = this.handleRaiseIssueClick.bind(this);
+
+      this.$refs = {};
     }
 
     async componentDidMount() {
@@ -28,6 +30,18 @@ class RunResultsPage extends Component {
         if (!testVersion) {
             dispatch(getTestVersions());
         }
+    }
+
+    async componentDidUpdate() {
+      if (this.$refs && location.href.includes('#test-')) {
+        const anchor = location.href.split('#')[1];
+        if (anchor !== undefined) {
+          const ref = this.$refs[anchor];
+          if (ref !== undefined) {
+            ref.scrollIntoView();
+          }
+        }
+      }
     }
 
     handleRaiseIssueClick(i) {
@@ -248,6 +262,7 @@ class RunResultsPage extends Component {
                                     <Fragment key={nextId()}>
                                         <div>
                                             <h2
+                                              ref={ref=>{this.$refs[`test-${t.execution_order}`] = ref}}
                                                 id={`test-${t.execution_order}`}
                                                 className="float-left"
                                             >

--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -55,7 +55,7 @@ class RunResultsPage extends Component {
         return (
             <tr key={nextId()}>
                 <td>
-                    <a href={`#test-${i.toString()}`}>{details.name}</a>
+                    <a href={`#test-${test.execution_order}`}>{details.name}</a>
                 </td>
                 <td>{required}</td>
                 <td>{optional}</td>
@@ -248,7 +248,7 @@ class RunResultsPage extends Component {
                                     <Fragment key={nextId()}>
                                         <div>
                                             <h2
-                                                id={`test-${i.toString()}`}
+                                                id={`test-${t.execution_order}`}
                                                 className="float-left"
                                             >
                                                 Details for test: {t.name}


### PR DESCRIPTION
- Link to the existing details tables on the pages of the existing report
- Modify the existing anchors to use `execution_order` instead of `index` so they will definitely work across pages when if the order the test `tests` being iterated over is different
- Manually scroll to the anchor with the `componentDIdUpdate` use a solution heavily inspired by https://github.com/filippoitaliano/react-snorty-tips/blob/master/react/anchor-link.md

See it working here: https://www.loom.com/share/6972e49a8fea4956b54862f00cb1c6fc