### PR TITLE
Make focus state consistent and finish visual polish for Test Queue

### DIFF
--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -223,7 +223,7 @@ table tbody tr.assign-testers {
 /* Button Secondary */
 .btn-secondary,
 .btn-danger {
-    background: #f4f4f4;
+    background: white;
     color: black;
     border: 1px solid #d7d7d7;
 }
@@ -242,8 +242,7 @@ table tbody tr.assign-testers {
 .show > .btn-secondary.dropdown-toggle {
     background: #f4f4f4;
     color: black;
-    border-color: #abaaaa;
-    box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.3);
+    box-shadow: 0 0 0 0.2rem rgba(103, 171, 197, 0.5);
 }
 
 .btn-primary.disabled,
@@ -272,8 +271,6 @@ table tbody tr.assign-testers {
 .btn-primary:not(:disabled):not(.disabled):active {
     background: white;
     color: #0b60ab;
-    border-color: #abaaaa;
-    box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.3);
 }
 
 /* Button Danger */
@@ -293,6 +290,13 @@ table tbody tr.assign-testers {
     white-space: nowrap;
 }
 
+.status-label.conflicts {
+    /* background: #f7e990;
+    color: #706a3f; */
+    background: #f9aeae;
+    color: #640303;
+}
+
 .status-label.in-progress {
     background: #d9f6de;
     color: #2c6c37;
@@ -307,6 +311,11 @@ table tbody tr.assign-testers {
     background: #bcddfa;
     color: #10548f;
 }
+
+.dropdown-toggle {
+    position: relative;
+}
+
 .dropdown-toggle::after {
     position: absolute;
     right: 0.5em;

--- a/client/components/ConfigureActiveRuns/ConfigureActiveRuns.css
+++ b/client/components/ConfigureActiveRuns/ConfigureActiveRuns.css
@@ -111,10 +111,16 @@ button {
     width: max-content;
 }
 
-.actions {
+.test-plans button {
+    width: 100%;
+}
+
+.test-plans.table .actions,
+.configure-at-browser .actions{
     width: 220px;
 }
 
-.test-plans button {
-    width: 100%;
+.configure-at-browser.table .browser-version,
+.test-plans.table .status {
+    width: 150px;
 }

--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -535,20 +535,14 @@ class ConfigureActiveRuns extends Component {
         // Find if any complete results
         if (testsWithResults.length > 0) {
             return (
-                <span>
-                    In Queue:{' '}
-                    <span className="status-label in-progress">
-                        In Progress
-                    </span>
+                <span className="status-label in-progress">
+                    In Progress
                 </span>
             );
         } else if (testsWithResults.length === 0) {
             return (
-                <span>
-                    In Queue:{' '}
-                    <span className="status-label not-started">
-                        Not Started
-                    </span>
+                <span className="status-label not-started">
+                    Not Started
                 </span>
             );
         }
@@ -704,7 +698,7 @@ class ConfigureActiveRuns extends Component {
                                 <th>Assistive Technology</th>
                                 <th>AT Version</th>
                                 <th>Browser</th>
-                                <th>Browser Version</th>
+                                <th className="browser-version">Browser Version</th>
                                 <th className="actions">Actions</th>
                             </tr>
                         </thead>
@@ -731,7 +725,7 @@ class ConfigureActiveRuns extends Component {
                     <thead>
                         <tr>
                             <th>Test Plan</th>
-                            <th>Status</th>
+                            <th className="status">Status</th>
                             <th className="actions">Actions</th>
                         </tr>
                     </thead>

--- a/client/components/TestQueue/TestQueue.css
+++ b/client/components/TestQueue/TestQueue.css
@@ -4,19 +4,55 @@ main.container-fluid table .col-md-3 {
     padding: 0;
 }
 
-.table-bordered td.actions {
-    border-right: 0px solid;
-    border-bottom: 0px solid;
-    border-left: 0px solid;
-    display: flex;
-    align-items: center;
+.test-queue.table td {
+    padding: 0;
+    /* background: #f4f4f4; */
 }
 
-.actions .primary-buttons .btn {
-    width: 100%;
+.test-queue.table .testers-wrapper,
+.test-queue.table .status-wrapper,
+.test-queue.table .test-cta-wrapper {
+    padding: .75em;
+    /* background: #ffffff; */
+}
+
+.test-queue.table .secondary-actions {
+    border-top: 1px solid #d2d5d9;
+    padding: .75em;
+}
+
+.test-queue.table .test-cta-wrapper .btn-primary {
+    margin-bottom: 1px;
+}
+
+.test-queue.table .secondary-actions .btn-danger {
+    margin-top: .75em;
+}
+
+.test-queue.table th.testers {
+    width: 225px;
+}
+
+.test-queue.table th.report-status, 
+.test-queue.table th.actions {
+    width: 175px;
 }
 
 .actions .primary-buttons .open-run-as .btn {
     padding-right: 2em;
     position: relative;
+}
+
+table .btn {
+    width: 100%;
+}
+
+table button {
+    margin: 0;
+}
+
+.status-label {
+    width: 100%;
+    text-align: center;
+    margin: .45em 0;
 }

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -39,14 +39,13 @@ class TestQueue extends Component {
                 <h2
                     id={tableId}
                 >{`${atName} ${atVersion} with ${browserName} ${browserVersion}`}</h2>
-                <Table aria-labelledby={tableId} striped bordered hover>
+                <Table className="test-queue" aria-labelledby={tableId} striped bordered hover>
                     <thead>
                         <tr>
                             <th className="test-plan">Test Plan</th>
-                            <th>Testers</th>
-                            <th>Report Status</th>
-                            <th>Actions</th>
-                            <th></th>
+                            <th className="testers">Testers</th>
+                            <th className="report-status">Report Status</th>
+                            <th className="actions">Actions</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/client/components/TestQueueRun/TestQueueRun.css
+++ b/client/components/TestQueueRun/TestQueueRun.css
@@ -1,14 +1,31 @@
-.assign-self {
-    padding: 0;
-    border: 0;
-    margin: 0;
+.testers-wrapper {
+    display: flex;
+    flex-direction: row
+}
+
+.testers-wrapper div {
+    flex-basis: auto;
+}
+
+.testers-wrapper .dropdown {
+    padding-right: .75em;
+}
+
+.testers-wrapper .assign-actions {
+    width: 100%;
+}
+
+.assignees {
+    margin-top: .3em;
+    font-size: 0.9rem;
+    text-align: center;
 }
 
 .assign-tester {
     border-radius: 25px;
-    width: 3em;
-    height: 3em;
+    height: 2.5em;
     border-style: dashed;
+    padding: .4em .6em;
 }
 
 .assign-tester .fa-user-plus {
@@ -29,6 +46,10 @@ li {
 
 .col-md-9 li {
     padding-right: 0.5em;
+}
+
+.no-assignees {
+    text-align: center;
 }
 
 .not-assigned {
@@ -74,4 +95,11 @@ button.more-actions:active {
 
 .primary-buttons {
     width: inherit;
+}
+
+.reports-link {
+    display: block;
+    text-align: center;
+    margin: .45em 0 0;
+    font-size: .9rem;
 }

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -7,7 +7,7 @@ import {
     faUserPlus
 } from '@fortawesome/free-solid-svg-icons';
 import nextId from 'react-id-generator';
-import { Button, Dropdown, Col, Row } from 'react-bootstrap';
+import { Button, Dropdown} from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import checkForConflict from '../../utils/checkForConflict';
@@ -451,7 +451,7 @@ class TestQueueRow extends Component {
                     </div>
                 </td>
                 <td>
-                    <div class="status-wrapper">{status}</div>
+                    <div className="status-wrapper">{status}</div>
                     <div className="secondary-actions">
                         {admin && newStatus && (
                         

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -131,6 +131,7 @@ class TestQueueRow extends Component {
                 >
                     {usersById[uid].username}
                 </a>
+                <br/>
                 {` (${testsCompleted} of ${totalTests} tests complete)`}
             </li>
         );
@@ -190,9 +191,10 @@ class TestQueueRow extends Component {
         let results = null;
 
         if (this.state.totalConflicts > 0) {
-            status = `${this.state.totalConflicts} Conflict${
+            let pluralizedStatus = `${this.state.totalConflicts} Conflict${
                 this.state.totalConflicts === 1 ? '' : 's'
             }`;
+            status = <span className="status-label conflicts">{pluralizedStatus}</span>
         } else if (
             this.state.testsWithResults > 0 &&
             this.state.testsWithResults !== testsForRun.length
@@ -205,10 +207,10 @@ class TestQueueRow extends Component {
         }
 
         if (runStatus === 'draft') {
-            results = <Link to={`/results/run/${runId}`}>DRAFT RESULTS</Link>;
+            results = <Link className="reports-link"  to={`/results/run/${runId}`}>View Draft Reports</Link>;
         } else if (runStatus === 'final') {
             results = (
-                <Link to={`/results/run/${runId}`}>PUBLISHED RESULTS</Link>
+                <Link className="reports-link" to={`/results/run/${runId}`}>View Published Results</Link>
             );
         }
 
@@ -262,47 +264,45 @@ class TestQueueRow extends Component {
 
         return (
             <Fragment>
-                <Col md={3}>
-                    <Dropdown aria-label="Assign testers menu">
-                        <Dropdown.Toggle
-                            aria-label="Assign testers"
-                            className="assign-tester"
-                            variant="secondary"
-                        >
-                            <FontAwesomeIcon icon={faUserPlus} />
-                        </Dropdown.Toggle>
-                        <Dropdown.Menu>
-                            {canAssignTesters.map(t => {
-                                let classname = t.assigned
-                                    ? 'assigned'
-                                    : 'not-assigned';
-                                return (
-                                    <Dropdown.Item
-                                        variant="secondary"
-                                        as="button"
-                                        key={nextId()}
-                                        onClick={() =>
-                                            this.toggleTesterAssign(t.id)
-                                        }
-                                        disabled={!admin && t.id !== userId}
-                                        aria-checked={t.assigned}
-                                        role="menuitemcheckbox"
-                                    >
-                                        {t.assigned && (
-                                            <FontAwesomeIcon icon={faCheck} />
-                                        )}
-                                        <span className={classname}>
-                                            {`${t.username} `}
-                                            <span className="fullname">
-                                                {t.fullname}
-                                            </span>
+                <Dropdown aria-label="Assign testers menu">
+                    <Dropdown.Toggle
+                        aria-label="Assign testers"
+                        className="assign-tester"
+                        variant="secondary"
+                    >
+                        <FontAwesomeIcon icon={faUserPlus} />
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                        {canAssignTesters.map(t => {
+                            let classname = t.assigned
+                                ? 'assigned'
+                                : 'not-assigned';
+                            return (
+                                <Dropdown.Item
+                                    variant="secondary"
+                                    as="button"
+                                    key={nextId()}
+                                    onClick={() =>
+                                        this.toggleTesterAssign(t.id)
+                                    }
+                                    disabled={!admin && t.id !== userId}
+                                    aria-checked={t.assigned}
+                                    role="menuitemcheckbox"
+                                >
+                                    {t.assigned && (
+                                        <FontAwesomeIcon icon={faCheck} />
+                                    )}
+                                    <span className={classname}>
+                                        {`${t.username} `}
+                                        <span className="fullname">
+                                            {t.fullname}
                                         </span>
-                                    </Dropdown.Item>
-                                );
-                            })}
-                        </Dropdown.Menu>
-                    </Dropdown>
-                </Col>
+                                    </span>
+                                </Dropdown.Item>
+                            );
+                        })}
+                    </Dropdown.Menu>
+                </Dropdown>
             </Fragment>
         );
     }
@@ -333,6 +333,7 @@ class TestQueueRow extends Component {
                     <Dropdown aria-label="Delete results menu">
                         <Dropdown.Toggle variant="danger">
                             <FontAwesomeIcon icon={faTrashAlt} />
+                            Delete for...
                         </Dropdown.Toggle>
                         <Dropdown.Menu>
                             {testersWithResults.map(t => {
@@ -414,21 +415,14 @@ class TestQueueRow extends Component {
             <tr key={runId}>
                 <th>{designPatternLinkOrName}</th>
                 <td>
-                    <Row>
+                    <div className="testers-wrapper">
                         {admin && this.renderAssignMenu()}
-                        <Col md={9}>
-                            <ul>
-                                {testerList.length !== 0 ? (
-                                    testerList
-                                ) : (
-                                    <li>No testers assigned</li>
-                                )}
-                            </ul>
+                        <div className="assign-actions">
                             {!currentUserAssigned && (
                                 <Button
+                                    variant="secondary"
                                     onClick={this.handleAssignSelfClick}
                                     aria-label={`Assign yourself to the test run ${this.testRun()}`}
-                                    variant="link"
                                     className="assign-self"
                                 >
                                     Assign Yourself
@@ -436,39 +430,46 @@ class TestQueueRow extends Component {
                             )}
                             {currentUserAssigned && (
                                 <Button
+                                    variant="secondary"
                                     onClick={this.handleUnassignSelfClick}
                                     aria-label={`Unassign yourself from the test run ${this.testRun()}`}
-                                    variant="link"
                                     className="assign-self"
                                 >
                                     Unassign Yourself
                                 </Button>
                             )}
-                        </Col>
-                    </Row>
+                        </div>
+                    </div>
+                    <div className="secondary-actions">
+                        <ul className="assignees">
+                            {testerList.length !== 0 ? (
+                                testerList
+                            ) : (
+                                <li className="no-assignees">No testers assigned</li>
+                            )}
+                        </ul>
+                    </div>
                 </td>
                 <td>
-                    <ul>
-                        <li>
-                            <div tabIndex="0">{status}</div>
-                        </li>
-                        <li>{results}</li>
+                    <div class="status-wrapper">{status}</div>
+                    <div className="secondary-actions">
                         {admin && newStatus && (
-                            <li>
-                                <Button
-                                    variant="secondary"
-                                    onClick={() =>
-                                        this.updateRunStatus(newStatus)
-                                    }
-                                >
-                                    Mark status as {newStatus}
-                                </Button>
-                            </li>
+                        
+                            <Button
+                                variant="secondary"
+                                onClick={() =>
+                                    this.updateRunStatus(newStatus)
+                                }
+                            >
+                                Mark as {newStatus}
+                            </Button>
+                        
                         )}
-                    </ul>
+                        {results}
+                    </div>
                 </td>
                 <td className="actions">
-                    <div className="primary-buttons">
+                    <div className="test-cta-wrapper">
                         <Button
                             variant="primary"
                             href={`/run/${runId}`}
@@ -479,23 +480,24 @@ class TestQueueRow extends Component {
                                 ? 'Continue testing'
                                 : 'Start testing'}
                         </Button>
-                        {admin && this.renderOpenAsDropdown()}
                     </div>
-                </td>
-                <td>
-                    {admin && this.renderDeleteMenu()}
-                    {(!admin && this.testsCompletedByUser[userId] && (
-                        <Button
-                            variant="danger"
-                            onClick={() =>
-                                this.handleDeleteResultsForUser(userId)
-                            }
-                            aria-label="Delete my results"
-                        >
-                            <FontAwesomeIcon icon={faTrashAlt} />
-                        </Button>
-                    )) ||
-                        ''}
+                    <div className="secondary-actions">
+                        {admin && this.renderOpenAsDropdown()}
+                        {admin && this.renderDeleteMenu()}
+                        {(!admin && this.testsCompletedByUser[userId] && (
+                            <Button
+                                variant="danger"
+                                onClick={() =>
+                                    this.handleDeleteResultsForUser(userId)
+                                }
+                                aria-label="Delete my results"
+                            >
+                                <FontAwesomeIcon icon={faTrashAlt} />
+                                Delete Results
+                            </Button>
+                        )) ||
+                            ''}
+                    </div>
                 </td>
             </tr>
         );


### PR DESCRIPTION
The major aspect of this PR are the improvements to the UI for all the possible actions we have available in the Test Queue tables:

![Screen Shot 2020-12-10 at 4 18 19 PM](https://user-images.githubusercontent.com/1379244/101841547-57dd6580-3b03-11eb-9154-dfc6c48d1cc1.png)
