### PR TITLE
Add AT Alert

### DIFF
--- a/client/components/ATAlert/ATAlert.css
+++ b/client/components/ATAlert/ATAlert.css
@@ -1,0 +1,8 @@
+.at-alert {
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+}

--- a/client/components/ATAlert/index.jsx
+++ b/client/components/ATAlert/index.jsx
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import './ATAlert.css';
+
+class ATAlert extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        const { message } = this.props;
+        return (
+            <div className="at-alert" role="status" aria-live="polite">
+                {message}
+            </div>
+        );
+    }
+}
+
+ATAlert.propTypes = {
+    message: PropTypes.string
+};
+
+export default ATAlert;

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -471,18 +471,21 @@ class TestQueueRun extends Component {
                     </div>
                 </td>
                 <td className="actions">
-                    <div className="test-cta-wrapper">
-                        <Button
-                            variant="primary"
-                            href={`/run/${runId}`}
-                            disabled={!currentUserAssigned}
-                            ref={this.startTestingButton}
-                        >
-                            {this.testsCompletedOrInProgressByThisUser
-                                ? 'Continue testing'
-                                : 'Start testing'}
-                        </Button>
-                    </div>
+                  {currentUserAssigned && (
+                        <div className="test-cta-wrapper">
+
+                            <Button
+                                variant="primary"
+                                href={`/run/${runId}`}
+                                disabled={!currentUserAssigned}
+                                ref={this.startTestingButton}
+                            >
+                                {this.testsCompletedOrInProgressByThisUser
+                                    ? 'Continue testing'
+                                    : 'Start testing'}
+                            </Button>
+                        </div>
+                    )}
                     <div className="secondary-actions">
                         {admin && this.renderOpenAsDropdown()}
                         {admin && this.renderDeleteMenu()}

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -10,6 +10,7 @@ import nextId from 'react-id-generator';
 import { Button, Dropdown} from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import ATAlert from '@components/ATAlert';
 import checkForConflict from '../../utils/checkForConflict';
 import {
     deleteTestResults,
@@ -19,7 +20,7 @@ import {
 } from '../../actions/runs';
 import './TestQueueRun.css';
 
-class TestQueueRow extends Component {
+class TestQueueRun extends Component {
     constructor(props) {
         super(props);
 
@@ -71,6 +72,9 @@ class TestQueueRow extends Component {
     handleAssignSelfClick() {
         const { dispatch, userId, runId } = this.props;
         dispatch(saveUsersToRuns([userId], [runId]));
+        this.setState({
+            alertMessage: 'You have been assigned to this test run.'
+        });
     }
 
     toggleTesterAssign(uid) {
@@ -454,7 +458,6 @@ class TestQueueRow extends Component {
                     <div className="status-wrapper">{status}</div>
                     <div className="secondary-actions">
                         {admin && newStatus && (
-                        
                             <Button
                                 variant="secondary"
                                 onClick={() =>
@@ -463,7 +466,6 @@ class TestQueueRow extends Component {
                             >
                                 Mark as {newStatus}
                             </Button>
-                        
                         )}
                         {results}
                     </div>
@@ -497,6 +499,7 @@ class TestQueueRow extends Component {
                             </Button>
                         )) ||
                             ''}
+                    <ATAlert message={this.state.alertMessage} />
                     </div>
                 </td>
             </tr>
@@ -504,7 +507,7 @@ class TestQueueRow extends Component {
     }
 }
 
-TestQueueRow.propTypes = {
+TestQueueRun.propTypes = {
     admin: PropTypes.bool,
     runId: PropTypes.number,
     runStatus: PropTypes.string,
@@ -541,4 +544,4 @@ const mapStateToProps = (state, ownProps) => {
     };
 };
 
-export default connect(mapStateToProps)(TestQueueRow);
+export default connect(mapStateToProps)(TestQueueRun);


### PR DESCRIPTION
This PR does three things:
1. Adds an "ATAlert" component, which you can use to add a invisible alert for an AT. I tested in NVDA and firefox. In this case, you will here "You have been assigned to this test run" after you click "Assign yourself". Not sure if this is the best announcement? @isaacdurazo ?
2. Hides the "start testing" button instead of disabling it
3. Renames the "TestQueueRun" component within the file (it was named "TestQueueRow" which did not match the folder)
