### PR TITLE
Change setting page to be more SR friendly

### DIFF
--- a/client/components/ConfigureActiveRuns/ConfigureActiveRuns.css
+++ b/client/components/ConfigureActiveRuns/ConfigureActiveRuns.css
@@ -116,7 +116,7 @@ button {
 }
 
 .test-plans.table .actions,
-.configure-at-browser .actions{
+.configure-at-browser .actions {
     width: 220px;
 }
 

--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -535,15 +535,11 @@ class ConfigureActiveRuns extends Component {
         // Find if any complete results
         if (testsWithResults.length > 0) {
             return (
-                <span className="status-label in-progress">
-                    In Progress
-                </span>
+                <span className="status-label in-progress">In Progress</span>
             );
         } else if (testsWithResults.length === 0) {
             return (
-                <span className="status-label not-started">
-                    Not Started
-                </span>
+                <span className="status-label not-started">Not Started</span>
             );
         }
 
@@ -698,7 +694,9 @@ class ConfigureActiveRuns extends Component {
                                 <th>Assistive Technology</th>
                                 <th>AT Version</th>
                                 <th>Browser</th>
-                                <th className="browser-version">Browser Version</th>
+                                <th className="browser-version">
+                                    Browser Version
+                                </th>
                                 <th className="actions">Actions</th>
                             </tr>
                         </thead>

--- a/client/components/TestQueue/TestQueue.css
+++ b/client/components/TestQueue/TestQueue.css
@@ -12,13 +12,13 @@ main.container-fluid table .col-md-3 {
 .test-queue.table .testers-wrapper,
 .test-queue.table .status-wrapper,
 .test-queue.table .test-cta-wrapper {
-    padding: .75em;
+    padding: 0.75em;
     /* background: #ffffff; */
 }
 
 .test-queue.table .secondary-actions {
     border-top: 1px solid #d2d5d9;
-    padding: .75em;
+    padding: 0.75em;
 }
 
 .test-queue.table .test-cta-wrapper .btn-primary {
@@ -26,14 +26,14 @@ main.container-fluid table .col-md-3 {
 }
 
 .test-queue.table .secondary-actions .btn-danger {
-    margin-top: .75em;
+    margin-top: 0.75em;
 }
 
 .test-queue.table th.testers {
     width: 225px;
 }
 
-.test-queue.table th.report-status, 
+.test-queue.table th.report-status,
 .test-queue.table th.actions {
     width: 175px;
 }
@@ -54,5 +54,5 @@ table button {
 .status-label {
     width: 100%;
     text-align: center;
-    margin: .45em 0;
+    margin: 0.45em 0;
 }

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -39,7 +39,13 @@ class TestQueue extends Component {
                 <h2
                     id={tableId}
                 >{`${atName} ${atVersion} with ${browserName} ${browserVersion}`}</h2>
-                <Table className="test-queue" aria-labelledby={tableId} striped bordered hover>
+                <Table
+                    className="test-queue"
+                    aria-labelledby={tableId}
+                    striped
+                    bordered
+                    hover
+                >
                     <thead>
                         <tr>
                             <th className="test-plan">Test Plan</th>
@@ -106,14 +112,14 @@ class TestQueue extends Component {
                     <h2 data-test="test-queue-no-ats-h2">{noAts}</h2>
                     <div role="alert">
                         <p data-test="test-queue-no-ats-p">
-                            Please configure your preferred Assistive Technologies
-                            in the {settingsLink} page.
+                            Please configure your preferred Assistive
+                            Technologies in the {settingsLink} page.
                         </p>
                         <p>
-                            If you have configured your Assistive Technologies and
-                            are still not seeing any Test Plans in this page, it
-                            could be that there are no Test Plans available under
-                            your configuration.
+                            If you have configured your Assistive Technologies
+                            and are still not seeing any Test Plans in this
+                            page, it could be that there are no Test Plans
+                            available under your configuration.
                             <p></p>
                             Please{' '}
                             <a href="mailto: public-aria-at@w3.org">

--- a/client/components/TestQueueRun/TestQueueRun.css
+++ b/client/components/TestQueueRun/TestQueueRun.css
@@ -1,6 +1,6 @@
 .testers-wrapper {
     display: flex;
-    flex-direction: row
+    flex-direction: row;
 }
 
 .testers-wrapper div {
@@ -8,7 +8,7 @@
 }
 
 .testers-wrapper .dropdown {
-    padding-right: .75em;
+    padding-right: 0.75em;
 }
 
 .testers-wrapper .assign-actions {
@@ -16,7 +16,7 @@
 }
 
 .assignees {
-    margin-top: .3em;
+    margin-top: 0.3em;
     font-size: 0.9rem;
     text-align: center;
 }
@@ -25,7 +25,7 @@
     border-radius: 25px;
     height: 2.5em;
     border-style: dashed;
-    padding: .4em .6em;
+    padding: 0.4em 0.6em;
 }
 
 .assign-tester .fa-user-plus {
@@ -100,6 +100,6 @@ button.more-actions:active {
 .reports-link {
     display: block;
     text-align: center;
-    margin: .45em 0 0;
-    font-size: .9rem;
+    margin: 0.45em 0 0;
+    font-size: 0.9rem;
 }

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -7,7 +7,7 @@ import {
     faUserPlus
 } from '@fortawesome/free-solid-svg-icons';
 import nextId from 'react-id-generator';
-import { Button, Dropdown} from 'react-bootstrap';
+import { Button, Dropdown } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import checkForConflict from '../../utils/checkForConflict';
@@ -131,7 +131,7 @@ class TestQueueRow extends Component {
                 >
                     {usersById[uid].username}
                 </a>
-                <br/>
+                <br />
                 {` (${testsCompleted} of ${totalTests} tests complete)`}
             </li>
         );
@@ -194,7 +194,11 @@ class TestQueueRow extends Component {
             let pluralizedStatus = `${this.state.totalConflicts} Conflict${
                 this.state.totalConflicts === 1 ? '' : 's'
             }`;
-            status = <span className="status-label conflicts">{pluralizedStatus}</span>
+            status = (
+                <span className="status-label conflicts">
+                    {pluralizedStatus}
+                </span>
+            );
         } else if (
             this.state.testsWithResults > 0 &&
             this.state.testsWithResults !== testsForRun.length
@@ -207,10 +211,16 @@ class TestQueueRow extends Component {
         }
 
         if (runStatus === 'draft') {
-            results = <Link className="reports-link"  to={`/results/run/${runId}`}>View Draft Reports</Link>;
+            results = (
+                <Link className="reports-link" to={`/results/run/${runId}`}>
+                    View Draft Reports
+                </Link>
+            );
         } else if (runStatus === 'final') {
             results = (
-                <Link className="reports-link" to={`/results/run/${runId}`}>View Published Results</Link>
+                <Link className="reports-link" to={`/results/run/${runId}`}>
+                    View Published Results
+                </Link>
             );
         }
 
@@ -445,7 +455,9 @@ class TestQueueRow extends Component {
                             {testerList.length !== 0 ? (
                                 testerList
                             ) : (
-                                <li className="no-assignees">No testers assigned</li>
+                                <li className="no-assignees">
+                                    No testers assigned
+                                </li>
                             )}
                         </ul>
                     </div>
@@ -454,16 +466,12 @@ class TestQueueRow extends Component {
                     <div className="status-wrapper">{status}</div>
                     <div className="secondary-actions">
                         {admin && newStatus && (
-                        
                             <Button
                                 variant="secondary"
-                                onClick={() =>
-                                    this.updateRunStatus(newStatus)
-                                }
+                                onClick={() => this.updateRunStatus(newStatus)}
                             >
                                 Mark as {newStatus}
                             </Button>
-                        
                         )}
                         {results}
                     </div>

--- a/client/components/UserSettings/index.jsx
+++ b/client/components/UserSettings/index.jsx
@@ -125,7 +125,7 @@ class UserSettings extends Component {
                         </a>
                     </p>
                     <p>{email}</p>
-                    <h2>Assistive Technology</h2>
+                    <h2>Assistive Technology Settings</h2>
                     <div tabIndex={0} ref={this.currentAtsRef}>
                         {currentUserAts.length > 0
                             ? currentAtDisplay
@@ -136,7 +136,8 @@ class UserSettings extends Component {
                         technologies you can test:
                     </p>
                     <Form>
-                        <Form.Group controlId="formBasicCheckbox">
+                        <h3 id="at-group-label">ATs</h3>
+                        <Form.Group controlId="formBasicCheckbox" role="group" aria-labeled-by="at-group-label">
                             {ats &&
                                 ats.map(at => {
                                     return (


### PR DESCRIPTION
Tickets: 
- https://app.asana.com/0/1193055321453706/1199542482316140
- https://app.asana.com/0/1193055321453706/1199542482316150

Description:
- Remove the form disabled state
- Remove the Edit/Save button and always make it a save button
- Add a list of which ATs are currently saved which is always displayed
- When the user saves change focus to be on the list of saved ATs
- Group checkbox https://www.w3.org/TR/wai-aria-practices-1.1/examples/checkbox/checkbox-1/checkbox-1.html

QA:
- Go to the user setting page and change the ATs. 