### PR TITLE
Delete results modal

### DIFF
--- a/client/components/DeleteResultsModal/index.jsx
+++ b/client/components/DeleteResultsModal/index.jsx
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import { Button, Modal } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+
+class DeleteResultsModal extends Component {
+    render() {
+        const { show, handleClose, deleteResults, admin, user } = this.props;
+        return (
+            <Modal show={show} onHide={handleClose}>
+                <Modal.Header closeButton>
+                    <Modal.Title>
+                        {admin
+                            ? `You are about to delete results for ${user}`
+                            : 'You are about to delete your results'}
+                    </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {admin ? (
+                        <React.Fragment>
+                            <p>
+                                Results for {user} will be deleted. Please press{' '}
+                                <b>Delete</b> to confirm this action.
+                            </p>
+                        </React.Fragment>
+                    ) : (
+                        <React.Fragment>
+                            <p>
+                                Your results will be deleted. Please press{' '}
+                                <b>Delete</b> to confirm this action.
+                            </p>
+                        </React.Fragment>
+                    )}
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="secondary" onClick={handleClose}>
+                        Cancel
+                    </Button>
+                    <Button variant="danger" onClick={deleteResults}>
+                        Delete
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}
+
+DeleteResultsModal.propTypes = {
+    admin: PropTypes.bool,
+    deleteResults: PropTypes.func,
+    handleClose: PropTypes.func,
+    show: PropTypes.bool,
+    user: PropTypes.string
+};
+
+export default DeleteResultsModal;

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -8,9 +8,24 @@ import { getAllUsers } from '../../actions/users';
 import { getActiveRuns } from '../../actions/runs';
 import nextId from 'react-id-generator';
 import TestQueueRun from '@components/TestQueueRun';
+import DeleteResultsModal from '@components/DeleteResultsModal';
 import './TestQueue.css';
 
 class TestQueue extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            showDeleteResultsModal: false,
+            userForResultsDelete: null,
+            deleteFunction: null
+        };
+
+        this.deleteResults = this.deleteResults.bind(this);
+        this.showDeleteResultsModal = this.showDeleteResultsModal.bind(this);
+        this.closeDeleteResultsModal = this.closeDeleteResultsModal.bind(this);
+    }
+
     componentDidMount() {
         const { dispatch, activeRunsById, usersById } = this.props;
 
@@ -21,6 +36,23 @@ class TestQueue extends Component {
         if (!Object.keys(usersById).length) {
             dispatch(getAllUsers());
         }
+    }
+
+    async deleteResults() {
+        await this.state.deleteFunction();
+        this.closeDeleteResultsModal();
+    }
+
+    showDeleteResultsModal(username, deleteFunction) {
+        this.setState({
+            showDeleteResultsModal: true,
+            userForResultsDelete: username,
+            deleteFunction
+        });
+    }
+
+    closeDeleteResultsModal() {
+        this.setState({ showDeleteResultsModal: false });
     }
 
     renderAtBrowserList(runIds) {
@@ -63,6 +95,10 @@ class TestQueue extends Component {
                                     atName={atName}
                                     browserName={browserName}
                                     admin={admin}
+                                    deleteResults={this.deleteResults}
+                                    showDeleteResultsModal={
+                                        this.showDeleteResultsModal
+                                    }
                                 />
                             );
                         })}
@@ -188,6 +224,13 @@ class TestQueue extends Component {
                 {atBrowserRunSets.map(abr =>
                     this.renderAtBrowserList(abr.runs)
                 )}
+                <DeleteResultsModal
+                    show={this.state.showDeleteResultsModal}
+                    handleClose={this.closeDeleteResultsModal}
+                    user={this.state.userForResultsDelete}
+                    admin={admin}
+                    deleteResults={this.deleteResults}
+                />
             </Container>
         );
     }

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -351,6 +351,7 @@ class TestQueueRow extends Component {
     }
 
     renderDeleteMenu() {
+        const { showDeleteResultsModal } = this.props;
         let testersWithResults = this.generateTestersWithResults();
 
         if (testersWithResults.length) {
@@ -370,8 +371,12 @@ class TestQueueRow extends Component {
                                         as="button"
                                         key={nextId()}
                                         onClick={() =>
-                                            this.handleDeleteResultsForUser(
-                                                t.id
+                                            showDeleteResultsModal(
+                                                t.username,
+                                                async () =>
+                                                    await this.handleDeleteResultsForUser(
+                                                        t.id
+                                                    )
                                             )
                                         }
                                     >
@@ -401,10 +406,12 @@ class TestQueueRow extends Component {
         const {
             admin,
             userId,
+            usersById,
             runId,
             testers,
             testsForRun,
-            apgExampleName
+            apgExampleName,
+            showDeleteResultsModal
         } = this.props;
 
         let currentUserAssigned = testers.includes(userId);
@@ -512,7 +519,13 @@ class TestQueueRow extends Component {
                             <Button
                                 variant="danger"
                                 onClick={() =>
-                                    this.handleDeleteResultsForUser(userId)
+                                    showDeleteResultsModal(
+                                        usersById[userId].username,
+                                        async () =>
+                                            await this.handleDeleteResultsForUser(
+                                                userId
+                                            )
+                                    )
                                 }
                                 aria-label="Delete my results"
                             >
@@ -540,7 +553,8 @@ TestQueueRow.propTypes = {
     atNameId: PropTypes.number,
     browserName: PropTypes.string,
     dispatch: PropTypes.func,
-    testsForRun: PropTypes.array
+    testsForRun: PropTypes.array,
+    showDeleteResultsModal: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => {


### PR DESCRIPTION
This PR adds a modal confirmation dialog when an admin or tester is about to delete results.

To test:

- Go to the Test Queue
- If admin, select "Delete For..." and click on a user. Confirm there is a dialog and works
- If tester, select "Delete Results" and click button. Confirm there is a dialog and works