### PR TITLE
Improvements to the new Reports Pages

### DIFF
--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -647,6 +647,7 @@ class ConfigureActiveRuns extends Component {
                     {Object.keys(activeRunConfiguration.active_test_version)
                         .length > 0 ? (
                         <CurrentGitCommit
+                          label="Current Git Commit"
                           gitHash={activeRunConfiguration.active_test_version.git_hash}
                           gitCommitMessage={activeRunConfiguration.active_test_version.git_commit_msg}
                         />

--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../actions/runs';
 import ConfigureTechnologyRow from '@components/ConfigureTechnologyRow';
 import ConfigurationModal from '@components/ConfigurationModal';
+import CurrentGitCommit from '@components/CurrentGitCommit';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
@@ -645,30 +646,10 @@ class ConfigureActiveRuns extends Component {
                 <Form className="init-box">
                     {Object.keys(activeRunConfiguration.active_test_version)
                         .length > 0 ? (
-                        <Form.Group
-                            className="current-commit"
-                            controlId="testVersion"
-                        >
-                            <Form.Label data-test="configure-run-current-commit-label">
-                                Current Git Commit
-                            </Form.Label>
-                            <p>
-                                <FontAwesomeIcon
-                                    icon={faCheck}
-                                    aria-hidden="true"
-                                ></FontAwesomeIcon>
-                                {activeRunConfiguration.active_test_version.git_hash.slice(
-                                    0,
-                                    7
-                                ) +
-                                    ' - ' +
-                                    activeRunConfiguration.active_test_version.git_commit_msg.slice(
-                                        0,
-                                        80
-                                    ) +
-                                    '...'}
-                            </p>
-                        </Form.Group>
+                        <CurrentGitCommit
+                          gitHash={activeRunConfiguration.active_test_version.git_hash}
+                          gitCommitMessage={activeRunConfiguration.active_test_version.git_commit_msg}
+                        />
                     ) : null}
                     {renderedTestVersions !== null ? (
                         <Form.Group

--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -14,7 +14,6 @@ import ConfigurationModal from '@components/ConfigurationModal';
 import CurrentGitCommit from '@components/CurrentGitCommit';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import './ConfigureActiveRuns.css';
 
@@ -647,9 +646,15 @@ class ConfigureActiveRuns extends Component {
                     {Object.keys(activeRunConfiguration.active_test_version)
                         .length > 0 ? (
                         <CurrentGitCommit
-                          label="Current Git Commit"
-                          gitHash={activeRunConfiguration.active_test_version.git_hash}
-                          gitCommitMessage={activeRunConfiguration.active_test_version.git_commit_msg}
+                            label="Current Git Commit"
+                            gitHash={
+                                activeRunConfiguration.active_test_version
+                                    .git_hash
+                            }
+                            gitCommitMessage={
+                                activeRunConfiguration.active_test_version
+                                    .git_commit_msg
+                            }
                         />
                     ) : null}
                     {renderedTestVersions !== null ? (

--- a/client/components/CurrentGitCommit/index.jsx
+++ b/client/components/CurrentGitCommit/index.jsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import { Form } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+
+class CurrentGitCommit extends Component {
+  render() {
+    return (
+      <Form.Group
+        className="current-commit"
+        controlId="testVersion"
+      >
+        <Form.Label data-test="configure-run-current-commit-label">
+          Current Git Commit
+        </Form.Label>
+        <p>
+          <FontAwesomeIcon
+            icon={faCheck}
+            aria-hidden="true"
+          ></FontAwesomeIcon>
+        {this.props.gitHash.slice(
+          0,
+          7
+        ) +
+          ' - ' +
+          this.props.gitCommitMessage.slice(
+            0,
+            80
+          ) +
+          '...'}
+        </p>
+      </Form.Group>
+  );
+  }
+}
+
+CurrentGitCommit.propTypes = {
+  gitHash: PropTypes.string,
+  gitCommitMessage: PropTypes.string
+};
+
+export default CurrentGitCommit;

--- a/client/components/CurrentGitCommit/index.jsx
+++ b/client/components/CurrentGitCommit/index.jsx
@@ -5,40 +5,31 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
 
 class CurrentGitCommit extends Component {
-  render() {
-    return (
-      <Form.Group
-        className="current-commit"
-        controlId="testVersion"
-      >
-        <Form.Label data-test="configure-run-current-commit-label">
-          {this.props.label}
-        </Form.Label>
-        <p>
-          <FontAwesomeIcon
-            icon={faCheck}
-            aria-hidden="true"
-          ></FontAwesomeIcon>
-        {this.props.gitHash.slice(
-          0,
-          7
-        ) +
-          ' - ' +
-          this.props.gitCommitMessage.slice(
-            0,
-            80
-          ) +
-          '...'}
-        </p>
-      </Form.Group>
-  );
-  }
+    render() {
+        return (
+            <Form.Group className="current-commit" controlId="testVersion">
+                <Form.Label data-test="configure-run-current-commit-label">
+                    {this.props.label}
+                </Form.Label>
+                <p>
+                    <FontAwesomeIcon
+                        icon={faCheck}
+                        aria-hidden="true"
+                    ></FontAwesomeIcon>
+                    {this.props.gitHash.slice(0, 7) +
+                        ' - ' +
+                        this.props.gitCommitMessage.slice(0, 80) +
+                        '...'}
+                </p>
+            </Form.Group>
+        );
+    }
 }
 
 CurrentGitCommit.propTypes = {
-  label: PropTypes.string,
-  gitHash: PropTypes.string,
-  gitCommitMessage: PropTypes.string
+    label: PropTypes.string,
+    gitHash: PropTypes.string,
+    gitCommitMessage: PropTypes.string
 };
 
 export default CurrentGitCommit;

--- a/client/components/CurrentGitCommit/index.jsx
+++ b/client/components/CurrentGitCommit/index.jsx
@@ -12,7 +12,7 @@ class CurrentGitCommit extends Component {
         controlId="testVersion"
       >
         <Form.Label data-test="configure-run-current-commit-label">
-          Current Git Commit
+          {this.props.label}
         </Form.Label>
         <p>
           <FontAwesomeIcon
@@ -36,6 +36,7 @@ class CurrentGitCommit extends Component {
 }
 
 CurrentGitCommit.propTypes = {
+  label: PropTypes.string,
   gitHash: PropTypes.string,
   gitCommitMessage: PropTypes.string
 };

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -58,14 +58,14 @@ class ReportsPage extends Component {
     }
 
     generateTechPairTableHeaders() {
-        return this.state.techPairs.map(({ browser, at }) => {
+        return this.state.techPairs.map(({ browser, browserVersion,  at, atVersion }) => {
             return (
                 <th
                     scope="col"
-                    key={`${at} with ${browser}`}
+                    key={`${at} ${atVersion} with ${browser} ${browserVersion}`}
                     className="text-center text-wrap"
                 >
-                    {at}/{browser} Passing Tests
+                    {at} {atVersion} / {browser} {browserVersion}
                 </th>
             );
         });

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
-import { Table, Container } from 'react-bootstrap';
+import { Table, Container, Breadcrumb } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { getPublishedRuns, getTestVersions } from '../../actions/runs';
 import CurrentGitCommit from '@components/CurrentGitCommit';
@@ -160,6 +160,9 @@ class ReportsPage extends Component {
                 <Helmet>
                     <title>ARIA-AT Reports</title>
                 </Helmet>
+                <Breadcrumb>
+                    <Breadcrumb.Item active>Summary Report</Breadcrumb.Item>
+                </Breadcrumb>
                 <h1 id="table-header">Summary Report</h1>
                 { this.props.testVersion ?
                   <CurrentGitCommit
@@ -168,7 +171,7 @@ class ReportsPage extends Component {
                     gitCommitMessage={this.props.testVersion.git_commit_msg}
                   /> : <></>}
                 <p id="tech-pair-description">
-                  Each At/Brower Pair shows the Percentage of Required Passing Tests for the pairing.
+                  Each AT / Browser Pair shows the Percentage of Required Passing Tests for the pairing.
                 </p>
                 <Table bordered hover aria-labelledby="#table-header">
                     <thead>

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -64,6 +64,7 @@ class ReportsPage extends Component {
                     scope="col"
                     key={`${at} ${atVersion} with ${browser} ${browserVersion}`}
                     className="text-center text-wrap"
+                    aria-describedby="#tech-pair-description"
                 >
                     {at} {atVersion} / {browser} {browserVersion}
                 </th>
@@ -131,14 +132,14 @@ class ReportsPage extends Component {
                             testsWithMetaData.requiredAssertions
                         );
                         exampleRow.push(
-                            <td key={`data-${exampleName}-${at}-${browser}`}>
+                            <td key={`data-${exampleName}-${techPairIndex}`}>
                                 {this.generateProgressBar(percentage)}
                             </td>
                         );
                     } else {
                         exampleRow.push(
                             <td
-                                key={`data-${exampleName}-${at}-${browser}`}
+                                key={`data-${exampleName}-${techPairIndex}`}
                                 aria-label={`No results`}
                             >
                                 {formatNoResults()}
@@ -159,21 +160,17 @@ class ReportsPage extends Component {
                 <Helmet>
                     <title>ARIA-AT Reports</title>
                 </Helmet>
-                <h1>Summary Report</h1>
+                <h1 id="table-header">Summary Report</h1>
                 { this.props.testVersion ?
                   <CurrentGitCommit
                     label="Results shown are from the most recent test version:"
                     gitHash={this.props.testVersion.git_hash}
                     gitCommitMessage={this.props.testVersion.git_commit_msg}
                   /> : <></>}
-                <Table bordered hover>
-                    <caption>
-                        This table shows the percentage of required passing
-                        tests for all finalized test results for the most
-                        recently tested version of the ARIA-AT tests. The first
-                        row is a summary of results from all examples. All other
-                        rows are the summary of results for a single example.
-                    </caption>
+                <p id="tech-pair-description">
+                  Each At/Brower Pair shows the Percentage of Required Passing Tests for the pairing.
+                </p>
+                <Table bordered hover aria-labelledby="#table-header">
                     <thead>
                         <tr>
                             <th key="design-pattern-examples">Test Plan</th>

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -58,18 +58,20 @@ class ReportsPage extends Component {
     }
 
     generateTechPairTableHeaders() {
-        return this.state.techPairs.map(({ browser, browserVersion,  at, atVersion }) => {
-            return (
-                <th
-                    scope="col"
-                    key={`${at} ${atVersion} with ${browser} ${browserVersion}`}
-                    className="text-center text-wrap"
-                    aria-describedby="#tech-pair-description"
-                >
-                    {at} {atVersion} / {browser} {browserVersion}
-                </th>
-            );
-        });
+        return this.state.techPairs.map(
+            ({ browser, browserVersion, at, atVersion }) => {
+                return (
+                    <th
+                        scope="col"
+                        key={`${at} ${atVersion} with ${browser} ${browserVersion}`}
+                        className="text-center text-wrap"
+                        aria-describedby="#tech-pair-description"
+                    >
+                        {at} {atVersion} / {browser} {browserVersion}
+                    </th>
+                );
+            }
+        );
     }
 
     generateProgressBar(percentage) {
@@ -122,7 +124,7 @@ class ReportsPage extends Component {
                         <a href={`/reports/test-plans/${id}`}>{exampleName}</a>
                     </th>
                 );
-                techPairs.forEach(({ browser, at }, techPairIndex) => {
+                techPairs.forEach((_, techPairIndex) => {
                     const testsWithMetaData =
                         testsWithMetaDataIndexedByTechPair[techPairIndex];
 
@@ -164,14 +166,18 @@ class ReportsPage extends Component {
                     <Breadcrumb.Item active>Summary Report</Breadcrumb.Item>
                 </Breadcrumb>
                 <h1 id="table-header">Summary Report</h1>
-                { this.props.testVersion ?
-                  <CurrentGitCommit
-                    label="Results shown are from the most recent test version:"
-                    gitHash={this.props.testVersion.git_hash}
-                    gitCommitMessage={this.props.testVersion.git_commit_msg}
-                  /> : <></>}
+                {this.props.testVersion ? (
+                    <CurrentGitCommit
+                        label="Results shown are from the most recent test version:"
+                        gitHash={this.props.testVersion.git_hash}
+                        gitCommitMessage={this.props.testVersion.git_commit_msg}
+                    />
+                ) : (
+                    <></>
+                )}
                 <p id="tech-pair-description">
-                  Each AT / Browser Pair shows the Percentage of Required Passing Tests for the pairing.
+                    Each AT / Browser Pair shows the Percentage of Required
+                    Passing Tests for the pairing.
                 </p>
                 <Table bordered hover aria-labelledby="#table-header">
                     <thead>
@@ -197,13 +203,13 @@ const mapStateToProps = state => {
     const { publishedRunsById, testVersions } = state.runs;
     let testVersion = null;
     if (publishedRunsById && testVersions) {
-      const runs = Object.values(publishedRunsById);
+        const runs = Object.values(publishedRunsById);
 
-      if (runs.length > 0) {
-          testVersion = (testVersions || []).find(
-              v => v.id === runs[0].test_version_id
-          );
-      }
+        if (runs.length > 0) {
+            testVersion = (testVersions || []).find(
+                v => v.id === runs[0].test_version_id
+            );
+        }
     }
     return { publishedRunsById, testVersion };
 };

--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -162,7 +162,7 @@ class ReportsPage extends Component {
                 <h1>Summary Report</h1>
                 { this.props.testVersion ?
                   <CurrentGitCommit
-                    label="Results shown are from the most recent test version."
+                    label="Results shown are from the most recent test version:"
                     gitHash={this.props.testVersion.git_hash}
                     gitCommitMessage={this.props.testVersion.git_commit_msg}
                   /> : <></>}

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -130,19 +130,23 @@ export function generateApgExample(publishedRunsById, techPairs, apgExampleId) {
  * @typedef TechPair
  * @type {object}
  * @property {string} browser
+ * @property {string} browserVersion
  * @property {string} at
+ * @property {string} atVersion
  */
 export function generateTechPairs(publishedRunsById) {
     let techPairs = [];
     const runs = Object.values(publishedRunsById);
     runs.forEach(run => {
         const match = techPairs.find(
-            pair => pair.browser === run.browser_name && pair.at === run.at_name
+            pair => pair.browser === run.browser_name && pair.at === run.at_name && pair.browserVersion === run.browser_version && pair.atVersion === run.at_version
         );
         if (!match) {
             techPairs.push({
                 browser: run.browser_name,
-                at: run.at_name
+                browserVersion: run.browser_version,
+                at: run.at_name,
+                atVersion: run.at_version
             });
         }
     });

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -69,6 +69,8 @@ function generateTestsWithMetaData(runs, techPairs) {
  * @typedef Example
  * @type {object}
  * @property {string} exampleName
+ * @property {string} exampleUrl
+ * @property {string} designPatternUrl
  * @property {number} id
  * @property {Array.<string>} testNames - Name of every test for an example
  * @property {Array.<TestWithMetaData>} testsWithMetaDataIndexedByTechPair
@@ -101,6 +103,8 @@ export function generateApgExamples(publishedRunsById, techPairs) {
         return {
             exampleName: example,
             id: exampleRuns[0].apg_example_id,
+            exampleUrl: exampleRuns[0].example,
+            designPatternUrl: exampleRuns[0].design_pattern,
             testNames: exampleRuns[0].tests.map(({ name }) => name),
             testsWithMetaDataIndexedByTechPair: generateTestsWithMetaData(
                 exampleRuns,

--- a/client/components/ReportsPage/utils.js
+++ b/client/components/ReportsPage/utils.js
@@ -143,7 +143,11 @@ export function generateTechPairs(publishedRunsById) {
     const runs = Object.values(publishedRunsById);
     runs.forEach(run => {
         const match = techPairs.find(
-            pair => pair.browser === run.browser_name && pair.at === run.at_name && pair.browserVersion === run.browser_version && pair.atVersion === run.at_version
+            pair =>
+                pair.browser === run.browser_name &&
+                pair.at === run.at_name &&
+                pair.browserVersion === run.browser_version &&
+                pair.atVersion === run.at_version
         );
         if (!match) {
             techPairs.push({

--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -2,7 +2,14 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
-import { Col, Container, Row, Table, Button, Breadcrumb } from 'react-bootstrap';
+import {
+    Col,
+    Container,
+    Row,
+    Table,
+    Button,
+    Breadcrumb
+} from 'react-bootstrap';
 import { getPublishedRuns, getTestVersions } from '../../actions/runs';
 import checkForConflict from '../../utils/checkForConflict';
 import TestResult from '@components/TestResult';
@@ -180,9 +187,18 @@ class RunResultsPage extends Component {
                         <Col>
                             <Fragment>
                                 <Breadcrumb>
-                                    <Breadcrumb.Item href="/reports">Summary Report</Breadcrumb.Item>
-                                    <Breadcrumb.Item href={`/reports/test-plans/${apg_example_id}`}>Test Plan Report: {apg_example_name}</Breadcrumb.Item>
-                                    <Breadcrumb.Item active>Tech Pair Report: {at_name} {at_version} on {browser_name} {browser_version}</Breadcrumb.Item>
+                                    <Breadcrumb.Item href="/reports">
+                                        Summary Report
+                                    </Breadcrumb.Item>
+                                    <Breadcrumb.Item
+                                        href={`/reports/test-plans/${apg_example_id}`}
+                                    >
+                                        Test Plan Report: {apg_example_name}
+                                    </Breadcrumb.Item>
+                                    <Breadcrumb.Item active>
+                                        Tech Pair Report: {at_name} {at_version}{' '}
+                                        on {browser_name} {browser_version}
+                                    </Breadcrumb.Item>
                                 </Breadcrumb>
                                 <h1>{title}</h1>
                             </Fragment>
@@ -300,7 +316,10 @@ class RunResultsPage extends Component {
                                                 </Button>
                                             </div>
                                         </div>
-                                        <TestResult testResult={t.result} label={`test-${t.execution_order}`} />
+                                        <TestResult
+                                            testResult={t.result}
+                                            label={`test-${t.execution_order}`}
+                                        />
                                         <RaiseIssueModal
                                             at_key={at_key}
                                             git_hash={git_hash}

--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -269,6 +269,7 @@ class RunResultsPage extends Component {
                                                     ] = ref;
                                                 }}
                                                 id={`test-${t.execution_order}`}
+                                                tabIndex="-1"
                                                 className="float-left"
                                             >
                                                 Details for test: {t.name}

--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
-import { Col, Container, Row, Table, Button } from 'react-bootstrap';
+import { Col, Container, Row, Table, Button, Breadcrumb } from 'react-bootstrap';
 import { getPublishedRuns, getTestVersions } from '../../actions/runs';
 import checkForConflict from '../../utils/checkForConflict';
 import TestResult from '@components/TestResult';
@@ -89,6 +89,7 @@ class RunResultsPage extends Component {
         const {
             at_key,
             apg_example_name,
+            apg_example_id,
             at_name,
             at_version,
             browser_name,
@@ -167,7 +168,7 @@ class RunResultsPage extends Component {
             }
         }
 
-        title = `${run_status.toUpperCase()} results for ${apg_example_name} tested with ${at_name} ${at_version} on ${browser_name} ${browser_version}`;
+        title = `${apg_example_name} with ${at_name} ${at_version} on ${browser_name} ${browser_version} Report`;
 
         return (
             <Container as="main">
@@ -178,6 +179,11 @@ class RunResultsPage extends Component {
                     <Row>
                         <Col>
                             <Fragment>
+                                <Breadcrumb>
+                                    <Breadcrumb.Item href="/reports">Summary Report</Breadcrumb.Item>
+                                    <Breadcrumb.Item href={`/reports/test-plans/${apg_example_id}`}>Test Plan Report: {apg_example_name}</Breadcrumb.Item>
+                                    <Breadcrumb.Item active>Tech Pair Report: {at_name} {at_version} on {browser_name} {browser_version}</Breadcrumb.Item>
+                                </Breadcrumb>
                                 <h1>{title}</h1>
                             </Fragment>
                         </Col>

--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -294,7 +294,7 @@ class RunResultsPage extends Component {
                                                 </Button>
                                             </div>
                                         </div>
-                                        <TestResult testResult={t.result} />
+                                        <TestResult testResult={t.result} label={`test-${t.execution_order}`} />
                                         <RaiseIssueModal
                                             at_key={at_key}
                                             git_hash={git_hash}

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import { Table, Container, Breadcrumb } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -68,9 +68,7 @@ class TestPlanReportPage extends Component {
         rows.push(
             <tr key="summary">
                 <th scope="row" key="summary">
-                    <a href='/reports'>
-                        All Tests
-                    </a>
+                    <a href="/reports">All Tests</a>
                 </th>
 
                 <td key="summary-required">
@@ -139,40 +137,50 @@ class TestPlanReportPage extends Component {
         const { apgExample, techPairs } = this.state;
         let tables = [];
 
-        techPairs.forEach(({ browser, browserVersion, at, atVersion }, techPairIndex) => {
-            const testsWithMetaData =
-                apgExample.testsWithMetaDataIndexedByTechPair[techPairIndex];
-            if (testsWithMetaData.testsWithResults.length > 0) {
-                tables.push(
-                    <div>
-                        <h2 id={`table-${techPairIndex}`}>
-                            {browser} {browserVersion} with {at} {atVersion} Results
-                        </h2>
-                        <Table bordered hover key={`table-${techPairIndex}`} aria-labelledby={`tabel-${techPairIndex}`}>
-                            <thead>
-                                <tr>
-                                    <th key="tests" scope="col">
-                                        Test Name
-                                    </th>
-                                    <th key="required" scope="col">
-                                        Required Assertions
-                                    </th>
-                                    <th key="optional" scope="col">
-                                        Optional Assertions
-                                    </th>
-                                    <th key="unexpected" scope="col">
-                                        Unexpected Behaviors
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {this.generateTableRows(testsWithMetaData)}
-                            </tbody>
-                        </Table>
-                    </div>
-                );
+        techPairs.forEach(
+            ({ browser, browserVersion, at, atVersion }, techPairIndex) => {
+                const testsWithMetaData =
+                    apgExample.testsWithMetaDataIndexedByTechPair[
+                        techPairIndex
+                    ];
+                if (testsWithMetaData.testsWithResults.length > 0) {
+                    tables.push(
+                        <div>
+                            <h2 id={`table-${techPairIndex}`}>
+                                {browser} {browserVersion} with {at} {atVersion}{' '}
+                                Results
+                            </h2>
+                            <Table
+                                bordered
+                                hover
+                                key={`table-${techPairIndex}`}
+                                aria-labelledby={`tabel-${techPairIndex}`}
+                            >
+                                <thead>
+                                    <tr>
+                                        <th key="tests" scope="col">
+                                            Test Name
+                                        </th>
+                                        <th key="required" scope="col">
+                                            Required Assertions
+                                        </th>
+                                        <th key="optional" scope="col">
+                                            Optional Assertions
+                                        </th>
+                                        <th key="unexpected" scope="col">
+                                            Unexpected Behaviors
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {this.generateTableRows(testsWithMetaData)}
+                                </tbody>
+                            </Table>
+                        </div>
+                    );
+                }
             }
-        });
+        );
 
         return tables;
     }
@@ -190,20 +198,43 @@ class TestPlanReportPage extends Component {
                     <title>{`ARIA-AT Report ${apgExample.exampleName}`}</title>
                 </Helmet>
                 <Breadcrumb>
-                    <Breadcrumb.Item href="/reports">Summary Report</Breadcrumb.Item>
-                    <Breadcrumb.Item active>Test Plan Report: {apgExample.exampleName}</Breadcrumb.Item>
+                    <Breadcrumb.Item href="/reports">
+                        Summary Report
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item active>
+                        Test Plan Report: {apgExample.exampleName}
+                    </Breadcrumb.Item>
                 </Breadcrumb>
                 <h1>{apgExample.exampleName} Report</h1>
                 <ul>
-                  { apgExample.exampleUrl ? <li><a href={apgExample.exampleUrl}>Example under test</a></li> : <></> }
-                  { apgExample.designPatternUrl ? <li><a href={apgExample.designPatternUrl}>Design pattern</a></li> : <></> }
+                    {apgExample.exampleUrl ? (
+                        <li>
+                            <a href={apgExample.exampleUrl}>
+                                Example under test
+                            </a>
+                        </li>
+                    ) : (
+                        <></>
+                    )}
+                    {apgExample.designPatternUrl ? (
+                        <li>
+                            <a href={apgExample.designPatternUrl}>
+                                Design pattern
+                            </a>
+                        </li>
+                    ) : (
+                        <></>
+                    )}
                 </ul>
-                { this.props.testVersion ?
-                  <CurrentGitCommit
-                    label="Results shown are from the most recent test version:"
-                    gitHash={this.props.testVersion.git_hash}
-                    gitCommitMessage={this.props.testVersion.git_commit_msg}
-                  /> : <></>}
+                {this.props.testVersion ? (
+                    <CurrentGitCommit
+                        label="Results shown are from the most recent test version:"
+                        gitHash={this.props.testVersion.git_hash}
+                        gitCommitMessage={this.props.testVersion.git_commit_msg}
+                    />
+                ) : (
+                    <></>
+                )}
                 {this.generateTables()}
             </Container>
         );
@@ -213,7 +244,8 @@ class TestPlanReportPage extends Component {
 TestPlanReportPage.propTypes = {
     dispatch: PropTypes.func,
     publishedRunsById: PropTypes.object,
-    testPlanId: PropTypes.number
+    testPlanId: PropTypes.number,
+    testVersion: PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -221,13 +253,13 @@ const mapStateToProps = (state, ownProps) => {
     const testPlanId = parseInt(ownProps.match.params.testPlanId);
     let testVersion = null;
     if (publishedRunsById && testVersions) {
-      const runs = Object.values(publishedRunsById);
+        const runs = Object.values(publishedRunsById);
 
-      if (runs.length > 0) {
-          testVersion = (testVersions || []).find(
-              v => v.id === runs[0].test_version_id
-          );
-      }
+        if (runs.length > 0) {
+            testVersion = (testVersions || []).find(
+                v => v.id === runs[0].test_version_id
+            );
+        }
     }
     return { publishedRunsById, testVersion, testPlanId };
 };

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { Helmet } from 'react-helmet';
-import { Table, Container } from 'react-bootstrap';
+import { Table, Container, Breadcrumb } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { getPublishedRuns, getTestVersions } from '../../actions/runs';
 import CurrentGitCommit from '@components/CurrentGitCommit';
@@ -189,6 +189,10 @@ class TestPlanReportPage extends Component {
                 <Helmet>
                     <title>{`ARIA-AT Report ${apgExample.exampleName}`}</title>
                 </Helmet>
+                <Breadcrumb>
+                    <Breadcrumb.Item href="/reports">Summary Report</Breadcrumb.Item>
+                    <Breadcrumb.Item active>Test Plan Report: {apgExample.exampleName}</Breadcrumb.Item>
+                </Breadcrumb>
                 <h1>{apgExample.exampleName} Report</h1>
                 { this.props.testVersion ?
                   <CurrentGitCommit

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -64,7 +64,9 @@ class TestPlanReportPage extends Component {
         rows.push(
             <tr key="summary">
                 <th scope="row" key="summary">
-                    All Tests
+                    <a href='/reports'>
+                        All Tests
+                    </a>
                 </th>
 
                 <td key="summary-required">

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -139,14 +139,14 @@ class TestPlanReportPage extends Component {
         const { apgExample, techPairs } = this.state;
         let tables = [];
 
-        techPairs.forEach(({ browser, at }, techPairIndex) => {
+        techPairs.forEach(({ browser, browserVersion, at, atVersion }, techPairIndex) => {
             const testsWithMetaData =
                 apgExample.testsWithMetaDataIndexedByTechPair[techPairIndex];
             if (testsWithMetaData.testsWithResults.length > 0) {
                 tables.push(
                     <div>
                         <h2>
-                            {browser} with {at} Results
+                            {browser} {browserVersion} with {at} {atVersion} Results
                         </h2>
                         <Table bordered hover key={`table-${techPairIndex}`}>
                             <caption>

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -145,13 +145,10 @@ class TestPlanReportPage extends Component {
             if (testsWithMetaData.testsWithResults.length > 0) {
                 tables.push(
                     <div>
-                        <h2>
+                        <h2 id={`table-${techPairIndex}`}>
                             {browser} {browserVersion} with {at} {atVersion} Results
                         </h2>
-                        <Table bordered hover key={`table-${techPairIndex}`}>
-                            <caption>
-                                {`This table shows the number of passing required assertions, the number of passing optional assertions and the number of unexpected behaviors for results from the most recently tested version of the ARIA-AT tests. The first row is a summary of results from all tests run on ${browser} with ${at}. All other rows are data from a single test on ${browser} with ${at}. The test name in the first column is a link to the detailed results of a specific test.`}
-                            </caption>
+                        <Table bordered hover key={`table-${techPairIndex}`} aria-labelledby={`tabel-${techPairIndex}`}>
                             <thead>
                                 <tr>
                                     <th key="tests" scope="col">

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -194,6 +194,10 @@ class TestPlanReportPage extends Component {
                     <Breadcrumb.Item active>Test Plan Report: {apgExample.exampleName}</Breadcrumb.Item>
                 </Breadcrumb>
                 <h1>{apgExample.exampleName} Report</h1>
+                <ul>
+                  { apgExample.exampleUrl ? <li><a href={apgExample.exampleUrl}>Example under test</a></li> : <></> }
+                  { apgExample.designPatternUrl ? <li><a href={apgExample.designPatternUrl}>Design pattern</a></li> : <></> }
+                </ul>
                 { this.props.testVersion ?
                   <CurrentGitCommit
                     label="Results shown are from the most recent test version:"

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { Helmet } from 'react-helmet';
-import { Table } from 'react-bootstrap';
+import { Table, Container } from 'react-bootstrap';
 import { connect } from 'react-redux';
 import { getPublishedRuns } from '../../actions/runs';
 import PropTypes from 'prop-types';
@@ -182,13 +182,13 @@ class TestPlanReportPage extends Component {
         }
 
         return (
-            <Fragment>
+            <Container as="main">
                 <Helmet>
                     <title>{`ARIA-AT Report ${apgExample.exampleName}`}</title>
                 </Helmet>
                 <h1>{apgExample.exampleName} Report</h1>
                 {this.generateTables()}
-            </Fragment>
+            </Container>
         );
     }
 }

--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -497,9 +497,8 @@ class TestQueueRun extends Component {
                     </div>
                 </td>
                 <td className="actions">
-                  {currentUserAssigned && (
+                    {currentUserAssigned && (
                         <div className="test-cta-wrapper">
-
                             <Button
                                 variant="primary"
                                 href={`/run/${runId}`}
@@ -528,7 +527,7 @@ class TestQueueRun extends Component {
                             </Button>
                         )) ||
                             ''}
-                    <ATAlert message={this.state.alertMessage} />
+                        <ATAlert message={this.state.alertMessage} />
                     </div>
                 </td>
             </tr>

--- a/client/components/TestResult/index.jsx
+++ b/client/components/TestResult/index.jsx
@@ -19,7 +19,7 @@ class TestResult extends Component {
     }
 
     render() {
-        const { testResult } = this.props;
+        const { testResult, label } = this.props;
         const keys = ['pass', 'fail'];
         const commandReports = testResult.result.details.commands.map(
             command => {
@@ -43,7 +43,7 @@ class TestResult extends Component {
         );
         return (
             <Fragment>
-                <Table striped bordered hover>
+                <Table striped bordered hover aria-labelledby={label}>
                     <thead>
                         <tr>
                             <th>Command</th>
@@ -92,7 +92,8 @@ class TestResult extends Component {
 }
 
 TestResult.propTypes = {
-    testResult: PropTypes.object
+    testResult: PropTypes.object,
+    label: PropTypes.string
 };
 
 export default TestResult;

--- a/client/components/TestResult/index.jsx
+++ b/client/components/TestResult/index.jsx
@@ -12,9 +12,9 @@ class TestResult extends Component {
         return (
             <dd>
                 <ul>
-                  {outcomes.map(outcome => (
-                      <li key={nextId()}>{outcome}</li>
-                  ))}
+                    {outcomes.map(outcome => (
+                        <li key={nextId()}>{outcome}</li>
+                    ))}
                 </ul>
             </dd>
         );

--- a/client/components/TestResult/index.jsx
+++ b/client/components/TestResult/index.jsx
@@ -11,9 +11,11 @@ class TestResult extends Component {
         }
         return (
             <dd>
-                {outcomes.map(outcome => (
-                    <li key={nextId()}>{outcome}</li>
-                ))}
+                <ul>
+                  {outcomes.map(outcome => (
+                      <li key={nextId()}>{outcome}</li>
+                  ))}
+                </ul>
             </dd>
         );
     }

--- a/client/tests/ConfigureActiveRuns.test.jsx
+++ b/client/tests/ConfigureActiveRuns.test.jsx
@@ -107,13 +107,6 @@ describe('render', () => {
             expect(component.length).toBe(1);
             expect(component.text()).toContain('Update Versions');
 
-            component = findByTestAttr(
-                wrapper,
-                'configure-run-current-commit-label'
-            );
-            expect(component.length).toBe(1);
-            expect(component.text()).toContain('Current Git Commit');
-
             component = findByTestAttr(wrapper, 'configure-run-commit-select');
             expect(component.length).toBe(1);
             expect(component.text()).toContain(


### PR DESCRIPTION
- Add git version under test to new reports pages
- Fix "main" container on the new test results page
- Add breadcrumbs and improve linking between tests pages
- Remove captions and add aria-labelledby/description instead
- Add AT/Browser versions to pages
- Surface design pattern and example links
- Improve HTML on test report detail table
- Add tabindex to improve anchor behavior on test detail page