### PR TITLE
Redirect to 404 on invalid run/test-plan ids

### DIFF
--- a/client/components/RunResultsPage/index.jsx
+++ b/client/components/RunResultsPage/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react';
+import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
@@ -87,10 +88,18 @@ class RunResultsPage extends Component {
     }
 
     render() {
-        const { run, allTests, testVersion } = this.props;
+        const { run, allTests, testVersion, publishedRunsById } = this.props;
+
+        if (publishedRunsById && !run) {
+            return <Redirect to={{ pathname: '/404' }} />;
+        }
 
         if (!run || !allTests || !testVersion) {
-            return <div>Loading</div>;
+            return (
+                <Container as="main">
+                    <div>Loading Run Report...</div>
+                </Container>
+            );
         }
 
         const {
@@ -350,7 +359,8 @@ RunResultsPage.propTypes = {
     dispatch: PropTypes.func,
     allTests: PropTypes.array,
     run: PropTypes.object,
-    testVersion: PropTypes.object
+    testVersion: PropTypes.object,
+    publishedRunsById: PropTypes.object
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -372,7 +382,8 @@ const mapStateToProps = (state, ownProps) => {
     return {
         run,
         allTests,
-        testVersion
+        testVersion,
+        publishedRunsById
     };
 };
 

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Redirect } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { Table, Container, Breadcrumb } from 'react-bootstrap';
 import { connect } from 'react-redux';
@@ -17,7 +18,7 @@ class TestPlanReportPage extends Component {
     constructor() {
         super();
         this.state = {
-            techPairs: [],
+            techPairs: null,
             apgExample: null
         };
 
@@ -186,7 +187,11 @@ class TestPlanReportPage extends Component {
     }
 
     render() {
-        const { apgExample } = this.state;
+        const { techPairs, apgExample } = this.state;
+
+        if (techPairs && !apgExample) {
+            return <Redirect to={{ pathname: '/404' }} />;
+        }
 
         if (!apgExample) {
             return <div>Loading Test Plan Report...</div>;


### PR DESCRIPTION
Before these reports pages were just hanging on "Loading..." screens forever. 