### PR TITLE
Sign in redirect

### DIFF
--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Container, Table } from 'react-bootstrap';
+import { Container, Table, Alert } from 'react-bootstrap';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { getAllUsers } from '../../actions/users';
@@ -146,24 +146,14 @@ class TestQueue extends Component {
                         <title>{noAts} | ARIA-AT</title>
                     </Helmet>
                     <h2 data-test="test-queue-no-ats-h2">{noAts}</h2>
-                    <div role="alert">
-                        <p data-test="test-queue-no-ats-p">
-                            Please configure your preferred Assistive
-                            Technologies in the {settingsLink} page.
-                        </p>
-                        <p>
-                            If you have configured your Assistive Technologies
-                            and are still not seeing any Test Plans in this
-                            page, it could be that there are no Test Plans
-                            available under your configuration.
-                            <p></p>
-                            Please{' '}
-                            <a href="mailto: public-aria-at@w3.org">
-                                contact the ARIA AT community group
-                            </a>
-                            .
-                        </p>
-                    </div>
+                    <Alert
+                        key="alert-configure"
+                        variant="danger"
+                        data-test="test-queue-no-ats-p"
+                    >
+                        Please configure your preferred Assistive Technologies
+                        in the {settingsLink} page.
+                    </Alert>
                 </Container>
             );
         }
@@ -206,6 +196,31 @@ class TestQueue extends Component {
                     runs: [run.id]
                 });
             }
+        }
+
+        if (atBrowserRunSets.length === 0) {
+            return (
+                <Container as="main">
+                    <Helmet>
+                        <title>No Test Plans | ARIA-AT</title>
+                    </Helmet>
+                    <h2 data-test="test-queue-no-ats-h2">No Test Plans</h2>
+                    <div role="alert">
+                        <p>
+                            If you have configured your Assistive Technologies
+                            and are still not seeing any Test Plans in this
+                            page, it could be that there are no Test Plans
+                            available under your configuration.
+                            <p></p>
+                            Please{' '}
+                            <a href="mailto: public-aria-at@w3.org">
+                                contact the ARIA AT community group
+                            </a>
+                            .
+                        </p>
+                    </div>
+                </Container>
+            );
         }
 
         return (

--- a/server/controllers/AuthController.js
+++ b/server/controllers/AuthController.js
@@ -48,7 +48,6 @@ module.exports = {
             authorizationError = error;
         }
         let authorized = false;
-        let newUser = false;
 
         if (req.session.authType === OAUTH) {
             let user;
@@ -66,7 +65,6 @@ module.exports = {
             // ...otherwise, add them as a new user.
             if (!user) {
                 try {
-                    newUser = true;
                     user = await UsersService.signupUser({
                         accessToken: req.session.accessToken,
                         user: userToAuthorize
@@ -86,9 +84,7 @@ module.exports = {
             }
         }
         if (authorized && userToAuthorize) {
-            const redirectUrl = newUser
-                ? `${req.session.referer}/test-queue`
-                : req.session.referer;
+            const redirectUrl = `${req.session.referer}/test-queue`;
             req.session.user = userToAuthorize;
             res.redirect(303, redirectUrl);
             res.end(() => {

--- a/server/tests/unit/controllers.test.js
+++ b/server/tests/unit/controllers.test.js
@@ -108,7 +108,7 @@ describe('AuthController', () => {
             await AuthController.authorize(req, res, next);
             expect(res.statusCode).toBe(303);
             expect(res._isEndCalled()).toBeTruthy();
-            expect(res._getRedirectUrl()).toBe('localhost:5000');
+            expect(res._getRedirectUrl()).toBe('localhost:5000/test-queue');
         });
         it('should provide a user with updated roles assigned on sign in', async () => {
             req.session.authType = OAUTH;


### PR DESCRIPTION
- Redirect sign in to test queue
- Separate output for when there are no configured ATs and when for when there are no ATs for the user's configuration

QA:
- Sign in as a tester and uncheck all ATs from configuration
- Sign in as tester and check an AT that has no test plan