### PR TITLE
Fix bug where admin is unable to assign testers

### DIFF
--- a/client/components/TestQueueRun/index.jsx
+++ b/client/components/TestQueueRun/index.jsx
@@ -287,9 +287,7 @@ class TestQueueRun extends Component {
         return canAssignTesters;
     }
 
-    renderAssignMenu(admin) {
-        const { userId } = this.props;
-
+    renderAssignMenu() {
         const canAssignTesters = this.generateAssignableTesters();
 
         return (
@@ -315,7 +313,6 @@ class TestQueueRun extends Component {
                                     onClick={() =>
                                         this.toggleTesterAssign(t.id)
                                     }
-                                    disabled={!admin && t.id !== userId}
                                     aria-checked={t.assigned}
                                     role="menuitemcheckbox"
                                 >


### PR DESCRIPTION
Asana issue: https://app.asana.com/0/1193055321453706/1199634503793974

To test:
- Create a new user in the database
```
insert into users(fullname, username, email) values ('Test User', 'testuser', 'test@user.com') returning id;
insert into user_to_role(user_id, role_id) values (<id returned>,2);
insert into user_to_at(at_name_id, user_id, active) values (1,<id returned>,true);
insert into user_to_at(at_name_id, user_id, active) values (2,<id returned>,true);
insert into user_to_at(at_name_id, user_id, active) values (3,<id returned>,true);
```
- Go to the Test Queue, and verify that the entries in the Assign Users dropdown are not disabled
- Verify that you can assign the new user