### PR TITLE
Fix copy and behavior of confirmation modal on Configure Active Runs page

### DIFF
--- a/client/components/ConfigurationModal/index.jsx
+++ b/client/components/ConfigurationModal/index.jsx
@@ -8,8 +8,7 @@ class ConfigurationModal extends Component {
             show,
             handleClose,
             saveRunConfiguration,
-            configurationChanges,
-            resultsDeleted
+            configurationChanges
         } = this.props;
         return (
             <Modal show={show} onHide={handleClose}>
@@ -17,32 +16,21 @@ class ConfigurationModal extends Component {
                     <Modal.Title>Update Active Test Runs</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    {resultsDeleted ? (
-                        <React.Fragment>
-                            <p>
-                                <b>
-                                    The draft results for the following test
-                                    plans will be lost:
-                                </b>
-                            </p>
-                            <ul>
-                                {configurationChanges.map(runDeleted => (
-                                    <li
-                                        key={runDeleted.id}
-                                    >{`${runDeleted.apg_example_name} - ${runDeleted.at_name} ${runDeleted.at_version} with ${runDeleted.browser_name} ${runDeleted.browser_version}`}</li>
-                                ))}
-                            </ul>
-                        </React.Fragment>
-                    ) : (
-                        <React.Fragment>
-                            <p>
-                                This new configuration does not remove any runs
-                                that are in a draft state, but it might delete
-                                runs that have test results. Are you sure you
-                                want to make this change?
-                            </p>
-                        </React.Fragment>
-                    )}
+                    <React.Fragment>
+                        <p>
+                            <b>
+                                The draft and in review results for the
+                                following test plans will be lost:
+                            </b>
+                        </p>
+                        <ul>
+                            {configurationChanges.map(runDeleted => (
+                                <li
+                                    key={runDeleted.id}
+                                >{`${runDeleted.apg_example_name} - ${runDeleted.at_name} ${runDeleted.at_version} with ${runDeleted.browser_name} ${runDeleted.browser_version}`}</li>
+                            ))}
+                        </ul>
+                    </React.Fragment>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" onClick={handleClose}>

--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -210,7 +210,8 @@ class ConfigureActiveRuns extends Component {
         if (oldVersionId !== newVersionId) {
             configurationChanges = configurationChanges.concat(
                 Object.values(activeRunsById).filter(
-                    run => run.run_status === 'draft'
+                    run =>
+                        run.run_status === 'draft' || run.run_status === 'raw'
                 )
             );
         }
@@ -373,17 +374,27 @@ class ConfigureActiveRuns extends Component {
                 newConfiguration: config,
                 resultsDeleted: true
             };
-        }
 
-        this.setState(stateConfiguration, () => {
-            this.showChanges();
-        });
+            this.setState(stateConfiguration, () => {
+                this.showChanges();
+            });
+        } else {
+            stateConfiguration = {
+                newConfiguration: config,
+                resultsDeleted: false
+            };
+            this.setState(stateConfiguration, () => {
+                this.saveNewConfiguration();
+            });
+        }
     }
 
     saveNewConfiguration() {
         this.props.dispatch(saveRunConfiguration(this.state.newConfiguration));
 
-        this.closeChanges();
+        if (this.state.showChangeModal) {
+            this.closeChanges();
+        }
     }
 
     handleVersionChange(event) {
@@ -772,13 +783,14 @@ class ConfigureActiveRuns extends Component {
                         Update Active Run Configuration
                     </Button>
                 </div>
-                <ConfigurationModal
-                    show={this.state.showChangeModal}
-                    handleClose={this.closeChanges}
-                    saveRunConfiguration={this.saveNewConfiguration}
-                    configurationChanges={this.state.configurationChanges}
-                    resultsDeleted={this.state.resultsDeleted}
-                />
+                {this.state.resultsDeleted && (
+                    <ConfigurationModal
+                        show={this.state.showChangeModal}
+                        handleClose={this.closeChanges}
+                        saveRunConfiguration={this.saveNewConfiguration}
+                        configurationChanges={this.state.configurationChanges}
+                    />
+                )}
             </Container>
         );
     }


### PR DESCRIPTION
Asana issue: https://app.asana.com/0/1193055321453706/1199634503793961


- Show the changes modal only when there are draft / in review results present