### PR TITLE
Fix up: change redux state to keep the published run as active

### DIFF
--- a/client/reducers/runs.js
+++ b/client/reducers/runs.js
@@ -149,21 +149,23 @@ export default (state = initialState, action) => {
                     }
                 };
             } else if (oldStatus !== 'final' && run_status === 'final') {
-                const updatedActiveRunsById = { ...state.activeRunsById };
-                delete updatedActiveRunsById[runId];
                 let updatedPublishedRunsById = undefined;
 
                 // If we switched the run from active to published,
                 // Then we might not have fetched the published runs yet
                 if (state.publishedRuns) {
                     updatedPublishedRunsById = {
-                        ...this.state.publishedRunsById,
+                        ...state.publishedRunsById,
                         [runId]: updatedRun
                     };
                 }
+
                 return {
                     ...state,
-                    activeRunsById: updatedActiveRunsById,
+                    activeRunsById: {
+                        ...state.activeRunsById,
+                        [runId]: updatedRun
+                    },
                     publishedRunsById: updatedPublishedRunsById
                 };
             } else if (oldStatus === 'final' && run_status !== 'final') {


### PR DESCRIPTION
Asana issue: https://app.asana.com/0/1193055321453706/1199634503793986

Contrary to what the issue says about removing the row permanently, I decided to keep the row in the Test Queue because:
- It was an easier fix
- The concept of an active run has changed. With the concept of the "Active Run Configuration", a run is marked inactive when there is a new configuration. The reducer was enforcing the active run concept that dated back to test cycles.