### PR TITLE
Fix up: indicate tests complete when all tests are complete

### DIFF
--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
+import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     faCheckCircle,
@@ -86,15 +87,38 @@ class TestRun extends Component {
         }
     }
 
+    /**
+     * This function checks if all the tests in a run
+     * are complete and returns a boolean value.
+     */
+    isTestsComplete() {
+        const { openAsUser, run, userId } = this.props;
+        const uid = openAsUser || userId;
+        let testsComplete = true;
+
+        for (let test of run.tests) {
+            const hasResults =
+                Object.keys(test.results).length > 0 && test.results[uid];
+            if (!hasResults) return false;
+            testsComplete =
+                testsComplete && test.results[uid].status === 'complete';
+            if (!testsComplete) return false;
+        }
+
+        return testsComplete;
+    }
+
     displayNextTest() {
         const { run } = this.props;
         let newIndex = this.state.currentTestIndex + 1;
         if (newIndex > run.tests.length) {
-            this.setState({
-                runComplete: true,
-                resultsStatus: '',
-                saveButtonClicked: false
-            });
+            if (this.isTestsComplete()) {
+                this.setState({
+                    runComplete: true,
+                    resultsStatus: '',
+                    saveButtonClicked: false
+                });
+            }
         } else {
             this.setState({
                 currentTestIndex: newIndex,
@@ -441,7 +465,10 @@ class TestRun extends Component {
                 Previous Test
             </Button>
         );
-        let primaryButtons = [prevButton, nextButton];
+
+        const endOfRun = this.state.currentTestIndex + 1 > run.tests.length;
+        let primaryButtons = []; // These are the list of buttons that will appear below the tests
+        let forwardButtons = []; // These are buttons that navigate to next tests and continue
 
         if (this.testResultsCompleted) {
             const editButton = (
@@ -453,19 +480,32 @@ class TestRun extends Component {
                     Edit Results
                 </Button>
             );
+
             const continueButton = (
-                <Button variant="primary" onClick={this.handleNextTestClick}>
+                <Button
+                    variant="primary"
+                    disabled={endOfRun && !this.isTestsComplete()}
+                    onClick={this.handleNextTestClick}
+                >
                     Continue
                 </Button>
             );
-            primaryButtons = [...primaryButtons, editButton, continueButton];
+
+            if (!endOfRun) forwardButtons = [nextButton];
+            primaryButtons = [
+                prevButton,
+                editButton,
+                ...forwardButtons,
+                continueButton
+            ];
         } else {
             const saveResultsButton = (
                 <Button variant="primary" onClick={this.handleSaveClick}>
                     Submit Results
                 </Button>
             );
-            primaryButtons = [...primaryButtons, saveResultsButton];
+            if (!endOfRun) forwardButtons = [nextButton];
+            primaryButtons = [prevButton, ...forwardButtons, saveResultsButton];
         }
 
         primaryButtonGroup = (
@@ -689,7 +729,10 @@ class TestRun extends Component {
                 content = (
                     <div>
                         {heading}
-                        <p>Tests are complete.</p>
+                        <p>
+                            Tests are complete. Please return to the{' '}
+                            <Link to="/test-queue">Test Queue</Link>.
+                        </p>
                     </div>
                 );
             }


### PR DESCRIPTION
Asana task: https://app.asana.com/0/1193055321453706/1199634503793980
Loom: https://www.loom.com/share/75d0473cb8814021bac1036b0f54b3e5

The Loom demonstrates:
- a run with a user that doesn't have all results complete
- a run with a user whose results are all complete

This PR does the following:
- Allows the user to skip around to the tests and even go to the end. If the user hasn't completed all tests, the "Continue" button is disabled.
- When the user has completed all tests and clicks "Continue", the "runComplete" flag is turned, and shows the text "Tests are complete. Please return to the Test Queue".
  - **This is by no means a perfect solution upon completion of tests. Once the "runComplete" flag in the state is set, the user can no longer edit tests, unless they start again from the Test Queue or refresh the page**. This could be solved in the next contract (cc: @s3ththompson)