### PR TITLE
Add missing title for Configure Active Run

### DIFF
--- a/client/components/ConfigureActiveRuns/index.jsx
+++ b/client/components/ConfigureActiveRuns/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { connect } from 'react-redux';
 import { Container, Table, Form, Button } from 'react-bootstrap';
+import { Helmet } from 'react-helmet';
 import {
     saveRunConfiguration,
     getActiveRunConfiguration,
@@ -651,6 +652,9 @@ class ConfigureActiveRuns extends Component {
 
         return (
             <Container as="main">
+                <Helmet>
+                    <title>Configure Active Runs | ARIA-AT</title>
+                </Helmet>
                 <h1 data-test="configure-run-h2">Configure Active Runs</h1>
                 <h2 data-test="configure-run-h3">Update Versions</h2>
                 <Form className="init-box">


### PR DESCRIPTION
Asana issue: https://app.asana.com/0/1193055321453706/1199542482316248

I added the missing title for Configure Active Run. There's a larger issue where the `<title>` element is not reliably read out by screen readers and potentially not the most accessible solution.