### PR TITLE
Fix typo on index

### DIFF
--- a/client/components/Home/index.jsx
+++ b/client/components/Home/index.jsx
@@ -89,7 +89,7 @@ class Home extends Component {
                             <article>
                                 <img src={iconReviewAssertions} alt="" />
                                 <a href="https://w3c.github.io/aria-at/">
-                                    Review existing test plans assesrtions
+                                    Review existing test plans
                                 </a>
                             </article>
                             <article>


### PR DESCRIPTION
I noticed the start page has typo of the word assertion on it. Clicking around the app, I think deleting that misspelled word is a good solution.

Take a look @isaacdurazo ?