### PR TITLE
Create TestPlanVersion service

### DIFF
--- a/server/models/TestPlanVersion.js
+++ b/server/models/TestPlanVersion.js
@@ -46,5 +46,15 @@ module.exports = function(sequelize, DataTypes) {
     Model.IN_REVIEW = STATUS.IN_REVIEW;
     Model.FINALIZED = STATUS.FINALIZED;
 
+    Model.TEST_PLAN_REPORT_ASSOCIATION = { as: 'testPlanReports' };
+
+    Model.associate = function(models) {
+        Model.hasMany(models.TestPlanReport, {
+            ...Model.TEST_PLAN_REPORT_ASSOCIATION,
+            foreignKey: 'testPlanVersionId',
+            sourceKey: 'id'
+        });
+    };
+
     return Model;
 };

--- a/server/models/services/TestPlanVersionService.js
+++ b/server/models/services/TestPlanVersionService.js
@@ -1,0 +1,227 @@
+const ModelService = require('./ModelService');
+const {
+    TEST_PLAN_VERSION_ATTRIBUTES,
+    TEST_PLAN_REPORT_ATTRIBUTES,
+    TEST_PLAN_TARGET_ATTRIBUTES,
+    TEST_PLAN_RUN_ATTRIBUTES,
+    USER_ATTRIBUTES
+} = require('./helpers');
+const { Sequelize, TestPlanVersion } = require('../');
+const { Op } = Sequelize;
+
+// association helpers to be included with Models' results
+
+/**
+ * @param {string[]} testPlanReportAttributes - TestPlanReport attributes
+ * @param {string[]} testPlanTargetAttributes - TestPlanTarget attributes
+ * @param {string[]} testPlanRunAttributes - TestPlanRun attributes
+ * @param {string[]} userAttributes - User attributes
+ * @returns {{association: string, attributes: string[]}}
+ */
+const testPlanReportAssociation = (
+    testPlanReportAttributes,
+    testPlanTargetAttributes,
+    testPlanRunAttributes,
+    userAttributes
+) => ({
+    association: 'testPlanReports',
+    attributes: testPlanReportAttributes,
+    include: [
+        // eslint-disable-next-line no-use-before-define
+        testPlanTargetAssociation(testPlanTargetAttributes),
+        // eslint-disable-next-line no-use-before-define
+        testPlanRunAssociation(testPlanRunAttributes, userAttributes)
+    ]
+});
+
+/**
+ * @param {string[]} testPlanTargetAttributes - TestPlanTarget attributes
+ * @returns {{association: string, attributes: string[]}}
+ */
+const testPlanTargetAssociation = testPlanTargetAttributes => ({
+    association: 'testPlanTarget',
+    attributes: testPlanTargetAttributes
+});
+
+/**
+ * @param {string[]} testPlanRunAttributes - TestPlanRun attributes
+ * @param {string[]} userAttributes - User attributes
+ * @returns {{association: string, attributes: string[]}}
+ */
+const testPlanRunAssociation = (testPlanRunAttributes, userAttributes) => ({
+    association: 'testPlanRuns',
+    attributes: testPlanRunAttributes,
+    include: [
+        // eslint-disable-next-line no-use-before-define
+        userAssociation(userAttributes)
+    ]
+});
+
+/**
+ * @param {string[]} userAttributes - User attributes
+ * @returns {{association: string, attributes: string[]}}
+ */
+const userAssociation = userAttributes => ({
+    association: 'tester',
+    attributes: userAttributes
+});
+
+/**
+ * You can pass any of the attribute arrays as '[]' to exclude that related association
+ * @param {number} id - unique id of the TestPlanReport model being queried
+ * @param {string[]} testPlanVersionAttributes - TestPlanVersion attributes to be returned in the result
+ * @param {string[]} testPlanReportAttributes - TestPlanReport attributes to be returned in the result
+ * @param {string[]} testPlanTargetAttributes - TestPlanTarget attributes to be returned in the result
+ * @param {string[]} testPlanRunAttributes - TestPlanRun attributes to be returned in the result
+ * @param {string[]} userAttributes - User attributes to be returned in the result
+ * @returns {Promise<*>}
+ */
+const getTestPlanVersionById = async (
+    id,
+    testPlanVersionAttributes = TEST_PLAN_VERSION_ATTRIBUTES,
+    testPlanReportAttributes = TEST_PLAN_REPORT_ATTRIBUTES,
+    testPlanTargetAttributes = TEST_PLAN_TARGET_ATTRIBUTES,
+    testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
+    userAttributes = USER_ATTRIBUTES
+) => {
+    return await ModelService.getById(
+        TestPlanVersion,
+        id,
+        testPlanVersionAttributes,
+        [
+            testPlanReportAssociation(
+                testPlanReportAttributes,
+                testPlanTargetAttributes,
+                testPlanRunAttributes,
+                userAttributes
+            )
+        ]
+    );
+};
+
+/**
+ * @param {string|any} search - use this to combine with {@param filter} to be passed to Sequelize's where clause
+ * @param {object} filter - use this define conditions to be passed to Sequelize's where clause
+ * @param {string[]} testPlanReportAttributes - TestPlanReport attributes to be returned in the result
+ * @param {string[]} testPlanRunAttributes - TestPlanRun attributes to be returned in the result
+ * @param {string[]} testPlanVersionAttributes - TestPlanVersion attributes to be returned in the result
+ * @param {string[]} testPlanTargetAttributes - TestPlanTarget attributes to be returned in the result
+ * @param {string[]} userAttributes - User attributes to be returned in the result
+ * @param {object} pagination - pagination options for query
+ * @param {number} [pagination.page=0] - page to be queried in the pagination result (affected by {@param pagination.enablePagination})
+ * @param {number} [pagination.limit=10] - amount of results to be returned per page (affected by {@param pagination.enablePagination})
+ * @param {string[][]} [pagination.order=[]] - expects a Sequelize structured input dataset for sorting the Sequelize Model results (NOT affected by {@param pagination.enablePagination}). See {@link https://sequelize.org/v5/manual/querying.html#ordering} and {@example [ [ 'username', 'DESC' ], [..., ...], ... ]}
+ * @param {boolean} [pagination.enablePagination=false] - use to enable pagination for a query result as well useful values. Data for all items matching query if not enabled
+ * @returns {Promise<*>}
+ */
+const getTestPlanVersions = async (
+    search,
+    filter = {},
+    testPlanVersionAttributes = TEST_PLAN_VERSION_ATTRIBUTES,
+    testPlanReportAttributes = TEST_PLAN_REPORT_ATTRIBUTES,
+    testPlanTargetAttributes = TEST_PLAN_TARGET_ATTRIBUTES,
+    testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
+    userAttributes = USER_ATTRIBUTES,
+    pagination = {}
+) => {
+    // search and filtering options
+    let where = { ...filter };
+    const searchQuery = search ? `%${search}%` : '';
+    if (searchQuery) where = { ...where, title: { [Op.iLike]: searchQuery } };
+
+    return await ModelService.get(
+        TestPlanVersion,
+        where,
+        testPlanVersionAttributes,
+        [
+            testPlanReportAssociation(
+                testPlanReportAttributes,
+                testPlanTargetAttributes,
+                testPlanRunAttributes,
+                userAttributes
+            )
+        ],
+        pagination
+    );
+};
+
+/**
+ * @param {object} createParams - values to be used to create the TestPlanVersion
+ * @param {string[]} testPlanVersionAttributes - TestPlanVersion attributes to be returned in the result
+ * @param {string[]} testPlanReportAttributes - TestPlanReport attributes to be returned in the result
+ * @param {string[]} testPlanTargetAttributes - TestPlanTarget attributes to be returned in the result
+ * @param {string[]} testPlanRunAttributes - TestPlanRun attributes to be returned in the result
+ * @param {string[]} userAttributes - User attributes to be returned in the result
+ * @returns {Promise<*>}
+ */
+const createTestPlanVersion = async (
+    { title, status, gitSha, gitMessage, exampleUrl, updatedAt, parsed },
+    testPlanVersionAttributes = TEST_PLAN_VERSION_ATTRIBUTES,
+    testPlanReportAttributes = TEST_PLAN_REPORT_ATTRIBUTES,
+    testPlanTargetAttributes = TEST_PLAN_TARGET_ATTRIBUTES,
+    testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
+    userAttributes = USER_ATTRIBUTES
+) => {
+    const testPlanVersionResult = await ModelService.create(TestPlanVersion, {
+        title,
+        status,
+        gitSha,
+        gitMessage,
+        exampleUrl,
+        updatedAt,
+        parsed
+    });
+    const { id } = testPlanVersionResult;
+
+    return await getTestPlanVersionById(
+        id,
+        testPlanVersionAttributes,
+        testPlanReportAttributes,
+        testPlanTargetAttributes,
+        testPlanRunAttributes,
+        userAttributes
+    );
+};
+
+/**
+ * @param {number} id - id of the TestPlanVersion record to be updated
+ * @param {object} updateParams - values to be used to updated on the TestPlanVersion
+ * @param {string[]} testPlanVersionAttributes - TestPlanVersion attributes to be returned in the result
+ * @param {string[]} testPlanReportAttributes - TestPlanReport attributes to be returned in the result
+ * @param {string[]} testPlanTargetAttributes - TestPlanTarget attributes to be returned in the result
+ * @param {string[]} testPlanRunAttributes - TestPlanRun attributes to be returned in the result
+ * @param {string[]} userAttributes - User attributes to be returned in the result
+ * @returns {Promise<*>}
+ */
+const updateTestPlanVersion = async (
+    id,
+    { title, status, gitSha, gitMessage, exampleUrl, updatedAt, parsed },
+    testPlanVersionAttributes = TEST_PLAN_VERSION_ATTRIBUTES,
+    testPlanReportAttributes = TEST_PLAN_REPORT_ATTRIBUTES,
+    testPlanTargetAttributes = TEST_PLAN_TARGET_ATTRIBUTES,
+    testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
+    userAttributes = USER_ATTRIBUTES
+) => {
+    await ModelService.update(
+        TestPlanVersion,
+        { id },
+        { title, status, gitSha, gitMessage, exampleUrl, updatedAt, parsed }
+    );
+
+    return await getTestPlanVersionById(
+        id,
+        testPlanVersionAttributes,
+        testPlanReportAttributes,
+        testPlanTargetAttributes,
+        testPlanRunAttributes,
+        userAttributes
+    );
+};
+
+module.exports = {
+    // Basic CRUD
+    getTestPlanVersionById,
+    getTestPlanVersions,
+    createTestPlanVersion,
+    updateTestPlanVersion
+};

--- a/server/tests/models/TestPlanVersion.spec.js
+++ b/server/tests/models/TestPlanVersion.spec.js
@@ -6,6 +6,7 @@ const {
 } = require('sequelize-test-helpers');
 
 const TestPlanVersionModel = require('../../models/TestPlanVersion');
+const TestPlanReportModel = require('../../models/TestPlanReport');
 
 describe('TestPlanVersionModel', () => {
     // A1
@@ -26,5 +27,21 @@ describe('TestPlanVersionModel', () => {
             'updatedAt',
             'parsed'
         ].forEach(checkPropertyExists(modelInstance));
+    });
+
+    describe('associations', () => {
+        // A1
+        const TEST_PLAN_REPORT_ASSOCIATION = { as: 'testPlanReports' };
+
+        beforeAll(() => {
+            Model.hasMany(TestPlanReportModel, TEST_PLAN_REPORT_ASSOCIATION);
+        });
+
+        it('defined a hasMany association with TestPlanReport', () => {
+            expect(Model.hasMany).toHaveBeenCalledWith(
+                TestPlanReportModel,
+                expect.objectContaining(Model.TEST_PLAN_REPORT_ASSOCIATION)
+            );
+        });
     });
 });

--- a/server/tests/models/services/TestPlanReportService.test.js
+++ b/server/tests/models/services/TestPlanReportService.test.js
@@ -25,7 +25,7 @@ describe('TestPlanReportModel Data Checks', () => {
         } = testPlanReport;
 
         expect(id).toEqual(_id);
-        expect(status).toMatch(/(DRAFT)|(IN_REVIEW)|(FINALIZED)/g);
+        expect(status).toMatch(/^(DRAFT|IN_REVIEW|FINALIZED)$/);
         expect(testPlanTargetId).toBeTruthy();
         expect(testPlanVersionId).toBeTruthy();
         expect(createdAt).toBeTruthy();
@@ -34,9 +34,11 @@ describe('TestPlanReportModel Data Checks', () => {
     it('should not be valid testPlanReport query', async () => {
         const _id = 53935;
 
-        const user = await TestPlanReportService.getTestPlanReportById(_id);
+        const testPlanReport = await TestPlanReportService.getTestPlanReportById(
+            _id
+        );
 
-        expect(user).toBeNull();
+        expect(testPlanReport).toBeNull();
     });
 
     it('should update testPlanReport status to final', async () => {

--- a/server/tests/models/services/TestPlanVersionService.test.js
+++ b/server/tests/models/services/TestPlanVersionService.test.js
@@ -20,7 +20,6 @@ describe('TestPlanReportModel Data Checks', () => {
             status,
             gitSha,
             gitMessage,
-            exampleUrl,
             updatedAt,
             parsed,
             testPlanReports
@@ -31,7 +30,6 @@ describe('TestPlanReportModel Data Checks', () => {
         expect(status).toMatch(/^(DRAFT|IN_REVIEW|FINALIZED)$/);
         expect(gitSha).toBeTruthy();
         expect(gitMessage).toBeTruthy();
-        expect(exampleUrl).toBeTruthy();
         expect(updatedAt).toBeTruthy();
         expect(parsed).toBeTruthy();
         expect(testPlanReports).toBeInstanceOf(Array);

--- a/server/tests/models/services/TestPlanVersionService.test.js
+++ b/server/tests/models/services/TestPlanVersionService.test.js
@@ -1,0 +1,166 @@
+const { sequelize } = require('../../../models');
+const TestPlanVersionService = require('../../../models/services/TestPlanVersionService');
+const { dbCleaner } = require('../../util/db-cleaner');
+const randomStringGenerator = require('../../util/random-character-generator');
+
+describe('TestPlanReportModel Data Checks', () => {
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    it('should return valid testPlanVersion for id query', async () => {
+        const _id = 1;
+
+        const testPlanVersion = await TestPlanVersionService.getTestPlanVersionById(
+            _id
+        );
+        const {
+            id,
+            title,
+            status,
+            gitSha,
+            gitMessage,
+            exampleUrl,
+            updatedAt,
+            parsed,
+            testPlanReports
+        } = testPlanVersion;
+
+        expect(id).toEqual(_id);
+        expect(title).toBeTruthy();
+        expect(status).toMatch(/^(DRAFT|IN_REVIEW|FINALIZED)$/);
+        expect(gitSha).toBeTruthy();
+        expect(gitMessage).toBeTruthy();
+        expect(exampleUrl).toBeTruthy();
+        expect(updatedAt).toBeTruthy();
+        expect(parsed).toBeTruthy();
+        expect(testPlanReports).toBeInstanceOf(Array);
+        expect(testPlanReports.length).not.toBe(0);
+        expect(testPlanReports).toContainEqual(
+            expect.objectContaining({ id: expect.any(Number) })
+        );
+    });
+
+    it('should not be valid testPlanVersion query', async () => {
+        const _id = 90210;
+
+        const testPlanVersion = await TestPlanVersionService.getTestPlanVersionById(
+            _id
+        );
+
+        expect(testPlanVersion).toBeNull();
+    });
+
+    it('should create and update testPlanVersion', async () => {
+        await dbCleaner(async () => {
+            // A1
+            const _title = randomStringGenerator();
+            const _status = 'DRAFT';
+            const _gitSha = randomStringGenerator();
+            const _gitMessage = randomStringGenerator();
+            const _exampleUrl = randomStringGenerator();
+            const _updatedAt = new Date();
+            const _parsed = [{ rawMockData: true }];
+
+            const _updatedStatus = 'FINALIZED';
+
+            // A2
+            const testPlanVersion = await TestPlanVersionService.createTestPlanVersion(
+                {
+                    title: _title,
+                    status: _status,
+                    gitSha: _gitSha,
+                    gitMessage: _gitMessage,
+                    exampleUrl: _exampleUrl,
+                    updatedAt: _updatedAt,
+                    parsed: _parsed
+                }
+            );
+            const {
+                id: createdId,
+                title: createdTitle,
+                status: createdStatus,
+                gitSha: createdGitSha,
+                gitMessage: createdGitMessage,
+                exampleUrl: createdExampleUrl,
+                updatedAt: createdUpdatedAt,
+                parsed: createdParsed
+            } = testPlanVersion;
+
+            // A2
+            const updatedTestPlanVersion = await TestPlanVersionService.updateTestPlanVersion(
+                createdId,
+                { status: _updatedStatus }
+            );
+            const {
+                title: updatedTitle,
+                status: updatedStatus,
+                updatedAt: updatedUpdatedAt
+            } = updatedTestPlanVersion;
+
+            // A3
+            // After testPlanVersion created
+            expect(createdId).toBeTruthy();
+            expect(createdTitle).toBe(_title);
+            expect(createdStatus).toBe(_status);
+            expect(createdGitSha).toBe(_gitSha);
+            expect(createdGitMessage).toBe(_gitMessage);
+            expect(createdExampleUrl).toBe(_exampleUrl);
+            expect(createdUpdatedAt).toEqual(_updatedAt);
+            expect(createdParsed).toEqual(_parsed);
+
+            // After updated status
+            expect(updatedTitle).toBe(createdTitle);
+            expect(updatedStatus).toBe(_updatedStatus);
+
+            // Confirm that updates are not automatically managed - this
+            // updatedAt refers to the source code.
+            expect(updatedUpdatedAt).toEqual(createdUpdatedAt);
+        });
+    });
+
+    it('should return collection of testPlanVersions', async () => {
+        const result = await TestPlanVersionService.getTestPlanVersions('');
+        expect(result.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should return collection of testPlanVersions for title query', async () => {
+        const search = 'checkbo';
+
+        const result = await TestPlanVersionService.getTestPlanVersions(
+            search,
+            {}
+        );
+
+        expect(result).toBeInstanceOf(Array);
+        expect(result.length).toBeGreaterThanOrEqual(1);
+        expect(result).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: expect.any(Number),
+                    title: expect.stringMatching(/checkbo/gi)
+                })
+            ])
+        );
+    });
+
+    it('should return collection of testPlanVersions with paginated structure', async () => {
+        const result = await TestPlanVersionService.getTestPlanVersions(
+            '',
+            {},
+            ['id'],
+            [],
+            [],
+            [],
+            [],
+            {
+                page: -1,
+                limit: -1,
+                enablePagination: true
+            }
+        );
+        expect(result).toHaveProperty('page');
+        expect(result).toHaveProperty('data');
+        expect(result.data.length).toBeGreaterThanOrEqual(1);
+    });
+});


### PR DESCRIPTION
NOTE: After test-queue-migrations is merged the base of this PR will need to be changed to develop.

Adds a TestPlanVersion service and tests, needed for the GraphQL Test Queue Backend task. I did my best to follow the established styles.

A separate PR was easier to write, and it should be easier to review as well.