### PR TITLE
Fix contrast issue with Draft label

### DIFF
--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -301,7 +301,7 @@ ul li {
 
 .status-label.not-started {
     background: #e7ecef;
-    color: #748193;
+    color: #63697E;
 }
 
 .status-label.complete {


### PR DESCRIPTION
This PR addresses a contrast issue with the Draft label that causess failure to meet WCAG level AA. 

**Before:**
`background: #e7ecef; color: #748193;`
<img width="267" alt="Screen Shot 2021-07-21 at 9 10 47 AM" src="https://user-images.githubusercontent.com/1379244/126522596-9ae07e4d-6cce-443c-a65b-e9daf624121e.png">

**After:**
`background: #e7ecef; color: #63697E;`
<img width="261" alt="Screen Shot 2021-07-21 at 9 11 01 AM" src="https://user-images.githubusercontent.com/1379244/126522598-4481f6c2-aff3-43a2-881e-1695609e850b.png">
