### PR TITLE
Import tests TestPlanVersion title update

### DIFF
--- a/server/seeders/20210824151240-at.js
+++ b/server/seeders/20210824151240-at.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { Browser } = require('../models');
+
+module.exports = {
+    up: async queryInterface => {
+        if ((await Browser.findAll()).length) return;
+        return queryInterface.bulkInsert(
+            'At',
+            [
+                { name: 'JAWS' },
+                { name: 'NVDA' },
+                { name: 'VoiceOver for macOS' }
+            ],
+            {}
+        );
+    },
+
+    down: async queryInterface => {
+        await queryInterface.bulkDelete('At', null, {});
+    }
+};


### PR DESCRIPTION
References https://github.com/w3c/aria-at/issues/471.

In an ongoing attempt to drop support for `support.json` and added benefit to test writing procedures, this changes the location of where to pull the client facing names of the Test Plans from.
Instead of `<root>/tests/support.json`, this pulls from `<root>/tests/<directory>/data/references.csv` by a `title` key.

Example Import
```bash
# -b is a newly introduced flag to specify the branch when importing
yarn db-import-tests:dev -b issue-471 -c 2a31524ca2d0d229ad3e8db1d2f6a04577d857bd;
```