### PR TITLE
Update import tests support

### DIFF
--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -164,6 +164,7 @@ const ariaAtImport = {
                     const testPath = path.join(testPlanDirPath, testFile);
                     if (
                         path.extname(testFile) === '.html' &&
+                        !testFile.includes('.collected.html') &&
                         testFile !== 'index.html'
                     ) {
                         // Get the testFile name from the html file


### PR DESCRIPTION
Following the merge of https://github.com/w3c/aria-at/pull/472, further support had to be added to ignore `.collected.html` files when importing tests.