### PR TITLE
Sort TestPlanVersion records by updatedAt by default

### DIFF
--- a/server/resolvers/testPlanVersionsResolver.js
+++ b/server/resolvers/testPlanVersionsResolver.js
@@ -5,6 +5,7 @@ const {
 const testPlanVersionsResolver = async () => {
     return getTestPlanVersions(null, {}, null, null, null, null, null, {
         order: [
+            ['updatedAt', 'desc'],
             ['title', 'asc'],
             ['metadata.directory', 'asc']
         ]


### PR DESCRIPTION
Updates `testPlanVersionsResolver` to additionally sort the results of `TestPlanVersion` by the `updatedAt` column, by default.