### PR TITLE
Fix bugs in aria-labelledby and aria-describedby, closes #307

### DIFF
--- a/client/components/ReportsPage/index.jsx
+++ b/client/components/ReportsPage/index.jsx
@@ -68,7 +68,7 @@ class ReportsPage extends Component {
                         scope="col"
                         key={`${at} ${atVersion} with ${browser} ${browserVersion}`}
                         className="text-center text-wrap"
-                        aria-describedby="#tech-pair-description"
+                        aria-describedby="tech-pair-description"
                     >
                         {at} {atVersion} / {browser} {browserVersion}
                     </th>
@@ -187,7 +187,7 @@ class ReportsPage extends Component {
                     Each AT / Browser Pair shows the Percentage of Required
                     Passing Tests for the pairing.
                 </p>
-                <Table bordered hover aria-labelledby="#table-header">
+                <Table bordered hover aria-labelledby="table-header">
                     <thead>
                         <tr>
                             <th key="design-pattern-examples">Test Plan</th>

--- a/client/components/TestPlanReportPage/index.jsx
+++ b/client/components/TestPlanReportPage/index.jsx
@@ -157,7 +157,7 @@ class TestPlanReportPage extends Component {
                                 bordered
                                 hover
                                 key={`table-${techPairIndex}`}
-                                aria-labelledby={`tabel-${techPairIndex}`}
+                                aria-labelledby={`table-${techPairIndex}`}
                             >
                                 <thead>
                                     <tr>


### PR DESCRIPTION
Fixes two small typos:
- `table` misspelled as `tabel`
- ids incorrectly prefixed with `#` character

Closes #307 