### PR TITLE
Address Incorrect Mark-Up for Test Navigator Landmark

### DIFF
--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -39,11 +39,14 @@ const TestNavigator = ({
                         <FontAwesomeIcon icon={faAlignLeft} />
                     </button>
                 </div>
-                {show && <h2>Test Navigator</h2>}
+                {show && <h2 id="test-navigator-heading">Test Navigator</h2>}
             </div>
             {show && (
-                <nav role="complementary">
-                    <ol className="test-navigator-list">
+                <nav aria-labelledby="test-navigator-heading">
+                    <ol
+                        aria-labelledby="test-navigator-heading"
+                        className="test-navigator-list"
+                    >
                         {tests.map(test => {
                             let resultClassName = 'not-started';
                             let resultStatus = 'Not Started';

--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -39,10 +39,10 @@ const TestNavigator = ({
                         <FontAwesomeIcon icon={faAlignLeft} />
                     </button>
                 </div>
-                {show && <h2 id="test-navigator-heading">Test Navigation</h2>}
             </div>
             {show && (
                 <nav aria-label="Test">
+                    <h2 id="test-navigator-heading">Test Navigation</h2>
                     <ol
                         aria-labelledby="test-navigator-heading"
                         className="test-navigator-list"

--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -39,10 +39,10 @@ const TestNavigator = ({
                         <FontAwesomeIcon icon={faAlignLeft} />
                     </button>
                 </div>
-                {show && <h2 id="test-navigator-heading">Test Navigator</h2>}
+                {show && <h2 id="test-navigator-heading">Test Navigation</h2>}
             </div>
             {show && (
-                <nav aria-labelledby="test-navigator-heading">
+                <nav aria-label="Test">
                     <ol
                         aria-labelledby="test-navigator-heading"
                         className="test-navigator-list"


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> The landmark wrapping the "Test Navigator" is marked up as a `<nav>`, but has been given a role of "complementary". This is incorrect; the entire section is used for navigation and as such, the default role implied by the `<nav>` would be more semantically accurate.
> 
> Meanwhile, the `<nav>` has no accessible name, and doesn't encompass the " Test Navigator" heading or toggle button. We recommend changing the heading to "Test Navigation", moving it and button inside the `<nav>`, removing the role attribute from the `<nav>`, and then applying an aria-label attribute to the `<nav>` with a value of "Test". The` <ol>` of tests should also be `aria-labelledby` the heading.

---

Effective changes:

* the `complementary` role on the `nav` element has been removed;
* the `nav` element is labelled by its leading `h2` via `aria-labelledby` IDREF; and
* the `ol` element containing the tests is similarly labelled by this `h2`.



