### PR TITLE
Correct Test Options Heading Level from 3 to 2

### DIFF
--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -275,7 +275,7 @@ main.container-fluid .test-iframe-container > .row {
     border-radius: 3px;
 }
 
-.current-test-options h3 {
+.current-test-options h2 {
     margin-top: 0;
     padding: 0.9em;
     background: #e9ebee;

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -480,7 +480,7 @@ const TestRun = () => {
         const isFirstTest = index === 0;
         const isLastTest = currentTest.seq === tests.length;
 
-        let primaryButtons = []; // These are the list of buttons that will appear below the tests
+        let primaryButtons; // These are the list of buttons that will appear below the tests
         let forwardButtons = []; // These are buttons that navigate to next tests and continue
 
         const nextButton = (
@@ -545,8 +545,11 @@ const TestRun = () => {
 
         const menuRightOfContent = (
             <div role="complementary">
-                <h3>Test Options</h3>
-                <ul className="options-wrapper">
+                <h2 id="test-options-heading">Test Options</h2>
+                <ul
+                    className="options-wrapper"
+                    aria-labelledby="test-options-heading"
+                >
                     <li>
                         <OptionButton
                             text="Raise An Issue"


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> The "Test Options" heading is incorrectly marked up at level 3 instead of level 2. It is logically a sibling of "Record Results" and not a child of it, and the incorrect level makes it pretty difficult to find.

--- 

Effective changes:

* The heading level and associated CSS rules have been modified from `h3` to `h2`; and 
* a redundant variable initialisation has been removed.
