### PR TITLE
Add Legend Semantics to Undesirable Behaviors Fieldset

### DIFF
--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -886,7 +886,12 @@ const TestRenderer = ({
                                         <Fieldset
                                             id={`cmd-${commandIndex}-problems`}
                                         >
-                                            {unexpectedBehaviors.description[0]}
+                                            <legend>
+                                                {
+                                                    unexpectedBehaviors
+                                                        .description[0]
+                                                }
+                                            </legend>
                                             {isSubmitted && (
                                                 <Feedback
                                                     className={`${unexpectedBehaviors


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> The "Were there additional undesirable behaviors?" radio buttons aren't programmatically grouped under their title/legend text. When a screen reader user navigates into the radio group, their purpose won't be spoken.

---
Effective changes:

The "Were there additional undesirable behaviors?" text at the top of its `fieldset` has been converted into a `legend` element.