### PR TITLE
Swap Positions of "Signed in as" and "Sign out" Elements

### DIFF
--- a/client/components/App/App.jsx
+++ b/client/components/App/App.jsx
@@ -95,14 +95,6 @@ const App = () => {
                                         </Nav.Link>
                                     </li>
                                     <li className="signed-in-wrapper">
-                                        <Nav.Link
-                                            as={Link}
-                                            to="/"
-                                            onClick={signOut}
-                                            aria-describedby="signed-in"
-                                        >
-                                            Sign out
-                                        </Nav.Link>
                                         <div
                                             className="signed-in"
                                             id="signed-in"
@@ -112,6 +104,14 @@ const App = () => {
                                             />
                                             Signed in as <b>{username}</b>
                                         </div>
+                                        <Nav.Link
+                                            as={Link}
+                                            to="/"
+                                            onClick={signOut}
+                                            aria-describedby="signed-in"
+                                        >
+                                            Sign out
+                                        </Nav.Link>
                                     </li>
                                 </>
                             )}


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> The " Signed in as …" text, which displays the currently authorized GitHub username, is positioned after the "Sign out" link. Screen reader users who make use of multiple GitHub accounts, e.g. for testing, must navigate past the link to determine the current account, then backwards again if they wish to end the session.

---

Effective changes:

- the "Signed in as [account]" and "Sign out" elements have swapped positions.