### PR TITLE
Describe and Waypoint Main Menu via Signpost Heading.

### DIFF
--- a/client/components/App/App.jsx
+++ b/client/components/App/App.jsx
@@ -36,10 +36,13 @@ const App = () => {
     return (
         <ScrollFixer>
             <Container fluid>
+                <h2 id="main-menu-heading" className="sr-only">
+                    Main Menu
+                </h2>
                 <Navbar
                     bg="light"
                     expand="lg"
-                    aria-label="Main Menu"
+                    aria-labelledby="main-menu-heading"
                     expanded={isNavbarExpanded}
                     onToggle={() => setIsNavbarExpanded(previous => !previous)}
                 >


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> The navigation bar items ("Test Reports", " Test Queue", etc.) are not marked up inside an unordered list to convey their grouped nature to screen reader users. They are also not preceded by a heading, either visible or off-screen/screen-reader-only.

The "The navigation bar items ("Test Reports", " Test Queue", etc.) are not marked up inside an unordered list to convey their grouped nature to screen reader users" has previously been addressed.

---

Effective changes:

- A visually hidden `h2` element containing "Main Menu" was added to precede the main menu `nav`; and
- the main menu `nav` is described by this `h2`.