### PR TITLE
Announce Page Title when Routing

### DIFF
--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -97,12 +97,13 @@ main.container-fluid .row {
 nav .logo.navbar-brand {
     font-weight: 700;
     font-size: 1.6em;
-    /* The logo is focused on every page navigation, making this particular
-    outline quite distracting. It looks like part of the logo design.
-    Furthermore, the top left of the page is where focus is implicitly
-    expected to be, so the outline is not really adding anything. And
-    Browsers are not consistently showing the outline anyway. */
-    outline: none;
+    outline: 0;
+    border-bottom: 2px solid transparent;
+}
+
+nav .logo.navbar-brand:focus,
+nav .logo.navbar-brand:hover {
+    border-bottom: 2px solid black;
 }
 
 a {

--- a/client/components/App/App.jsx
+++ b/client/components/App/App.jsx
@@ -12,6 +12,7 @@ import { ME_QUERY } from './queries';
 import useSigninUrl from './useSigninUrl';
 import SkipLink from '../SkipLink';
 import './App.css';
+import TitleAnnouncer from '@client/utils/TitleAnnouncer';
 
 const App = () => {
     const location = useLocation();
@@ -35,6 +36,7 @@ const App = () => {
 
     return (
         <ScrollFixer>
+            <TitleAnnouncer />
             <Container fluid>
                 <Navbar
                     bg="light"

--- a/client/components/Reports/SummarizeTestPlanReports.jsx
+++ b/client/components/Reports/SummarizeTestPlanReports.jsx
@@ -59,7 +59,7 @@ const SummarizeTestPlanReports = ({ testPlanReports }) => {
     return (
         <FullHeightContainer id="main" as="main" tabIndex="-1">
             <Helmet>
-                <title>ARIA-AT Test Reports</title>
+                <title>Test Reports | ARIA-AT</title>
             </Helmet>
             <h1>Test Reports</h1>
             <h2>Introduction</h2>

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -197,7 +197,7 @@ const TestQueue = () => {
         return (
             <Container id="main" as="main" tabIndex="-1">
                 <Helmet>
-                    <title>{noTestPlansMessage} | ARIA-AT</title>
+                    <title>Test Queue: No Test Plans Available | ARIA-AT</title>
                 </Helmet>
                 <h2 data-testid="test-queue-no-test-plans-h2">
                     {noTestPlansMessage}
@@ -242,7 +242,7 @@ const TestQueue = () => {
     return (
         <Container id="main" as="main" tabIndex="-1">
             <Helmet>
-                <title>{`Test Queue | ARIA-AT`}</title>
+                <title>Test Queue | ARIA-AT</title>
             </Helmet>
             <h1>Test Queue</h1>
             <p data-testid="test-queue-instructions">

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -480,7 +480,7 @@ const TestRun = () => {
         const isFirstTest = index === 0;
         const isLastTest = currentTest.seq === tests.length;
 
-        let primaryButtons = []; // These are the list of buttons that will appear below the tests
+        let primaryButtons; // These are the list of buttons that will appear below the tests
         let forwardButtons = []; // These are buttons that navigate to next tests and continue
 
         const nextButton = (
@@ -805,8 +805,7 @@ const TestRun = () => {
             <Helmet>
                 <title>
                     {hasTestsToRun
-                        ? `${currentTest.title} for ${testPlanTarget.title} ` +
-                          `| ARIA-AT`
+                        ? `Testing task: ${currentTest.title} (${testPlanTarget.title}) | ARIA-AT`
                         : 'No tests for this AT and Browser | ARIA-AT'}
                 </title>
             </Helmet>

--- a/client/utils/ScrollFixer.jsx
+++ b/client/utils/ScrollFixer.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useLayoutEffect } from 'react';
-import { useLocation } from 'react-router';
+import { useLocation } from 'react-router-dom';
 
 /**
  * Fixes scroll issues inherent in single page apps such as jumping the scroll
@@ -12,14 +12,14 @@ const ScrollFixer = ({ children }) => {
     const location = useLocation();
 
     useLayoutEffect(() => {
+        if (!location.hash) {
+            return;
+        }
+
         const scrollTop = () => {
             window.scroll(0, 0);
-            // When switching pages, the focus should jump to the top. Otherwise
-            // screen readers' focus might be lingering in a nonsensical
-            // location partly down the page.
-            document.querySelector('a').focus();
         };
-        if (!location.hash) return scrollTop();
+
         (async () => {
             // The point at which the window jumping down the page would become
             // disorienting. This must include time for the page's API requests

--- a/client/utils/TitleAnnouncer.js
+++ b/client/utils/TitleAnnouncer.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+
+const TitleAnnouncer = () => {
+    const location = useLocation();
+
+    if (location.hash) {
+        return null;
+    }
+
+    const [title, setTitle] = React.useState('');
+    const titleRef = React.createRef();
+    const onHelmetChange = ({ title }) => setTitle(title);
+
+    React.useEffect(() => {
+        if (titleRef.current) titleRef.current.focus();
+    }, [location.pathname]);
+
+    return (
+        <>
+            <p tabIndex={-1} ref={titleRef} className="sr-only">
+                {title}
+            </p>
+
+            <Helmet onChangeClientState={onHelmetChange} />
+        </>
+    );
+};
+
+export default TitleAnnouncer;


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

## Home Page

> At page load, the document has no text in its <title> element. This is filled in by JavaScript once the content has been rendered, but an initially untitled page is considered invalid HTML and causes a screen reader to only announce the URL of the app when users navigate to it. This problem can be observed for all pages. Once the page title has been filled out, it only reads: "ARIA-AT App". This doesn't inform users that they are on the home page.

## Test Reports/ARIA-AT Reports

> When the page title becomes available, it reads: " ARIA-AT Reports". This doesn't match the "Test Reports" link text in the nav bar, nor does it include the "ARIA-AT App" context that is present on the home, Test Queue and Settings pages.

## Testing Task Page

> After activating the test plan name link in the " Test Plan" column, or "Start testing" link in the "Actions" column, the user is taken to an initially untitled page (as already pointed out for the home page earlier in this document). Once the content has loaded, there is no screen reader feedback whatsoever, so testers may potentially be left wondering what, if anything, has happened.

> Once the content of a test within a test plan has loaded, the page title is set to the AT/browser combination that the user is testing. For example, "NVDA Latest with Firefox Latest". This doesn't reflect where the user is, which is a specific test within a specific test plan. It also doesn't include the ARIA-AT app context that is included in the titles of other pages.

---

Effective changes:

- Add focus and hover styling to the "Home" anchor, interactive elements should not have an invisible focus or hover indicator;
- scroll the page to the top unless a location fragment exists, announce the page title via a visually-hidden paragraph;
- use a consistent page title format across the application; and
- introduce the `TitleAnnouncer` utility component.