### PR TITLE
Label Breadcrumb Navigation and Item List

### DIFF
--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -47,13 +47,10 @@ const SummarizeTestPlanReport = ({ testPlanReport }) => {
                 {getTestPlanVersionTitle(testPlanVersion)}&nbsp;with&nbsp;
                 {getTestPlanTargetTitle(testPlanTarget)}
             </h1>
-            <h2 id="breadcrumb-navigation-heading" className="sr-only">
-                Breadcrumb Navigation
-            </h2>
             <Breadcrumb
                 label="Breadcrumb"
                 listProps={{
-                    'aria-labelledby': 'breadcrumb-navigation-heading'
+                    'aria-label': 'Breadcrumb Navigation'
                 }}
             >
                 <LinkContainer to="/reports">

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -47,7 +47,15 @@ const SummarizeTestPlanReport = ({ testPlanReport }) => {
                 {getTestPlanVersionTitle(testPlanVersion)}&nbsp;with&nbsp;
                 {getTestPlanTargetTitle(testPlanTarget)}
             </h1>
-            <Breadcrumb>
+            <h2 id="breadcrumb-navigation-heading" className="sr-only">
+                Breadcrumb Navigation
+            </h2>
+            <Breadcrumb
+                label="Breadcrumb"
+                listProps={{
+                    'aria-labelledby': 'breadcrumb-navigation-heading'
+                }}
+            >
                 <LinkContainer to="/reports">
                     <Breadcrumb.Item>
                         <FontAwesomeIcon icon={faHome} />

--- a/client/components/Reports/SummarizeTestPlanVersion.jsx
+++ b/client/components/Reports/SummarizeTestPlanVersion.jsx
@@ -27,13 +27,10 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
             </Helmet>
             <h1>{getTestPlanVersionTitle(testPlanVersion)}</h1>
 
-            <h2 id="breadcrumb-navigation-heading" className="sr-only">
-                Breadcrumb Navigation
-            </h2>
             <Breadcrumb
                 label="Breadcrumb"
                 listProps={{
-                    'aria-labelledby': 'breadcrumb-navigation-heading'
+                    'aria-label': 'Breadcrumb Navigation'
                 }}
             >
                 <LinkContainer to="/reports">

--- a/client/components/Reports/SummarizeTestPlanVersion.jsx
+++ b/client/components/Reports/SummarizeTestPlanVersion.jsx
@@ -26,7 +26,16 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
                 </title>
             </Helmet>
             <h1>{getTestPlanVersionTitle(testPlanVersion)}</h1>
-            <Breadcrumb>
+
+            <h2 id="breadcrumb-navigation-heading" className="sr-only">
+                Breadcrumb Navigation
+            </h2>
+            <Breadcrumb
+                label="Breadcrumb"
+                listProps={{
+                    'aria-labelledby': 'breadcrumb-navigation-heading'
+                }}
+            >
                 <LinkContainer to="/reports">
                     <Breadcrumb.Item>
                         <FontAwesomeIcon icon={faHome} />


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> When present, the breadcrumb navigation isn't preceded by a heading, either visible or off-screen/screen-reader-only. The list of breadcrumbs therefore also has no accessible name, as there is no heading to label it by.

---
Effective changes:

- Label the breadcrumb `nav` as "Breadcrumb" via `aria-label` ; and
- add visually-hidden "Breadcrumb navigation" heading and `aria-labelledby` associate it with the `ol` nav items.

@jscholes the React Bootstrap `BreadCrumb` component does not support adding a child that's not a breadcrumb item; it will position it inside the unordered list. Hence it does not seem possible to place the `h2` inside the `nav` while it precedes the `ol`. 

The only possible alternative that I can see is to forego the `h2` and `aria-label` the `ol` directly, which _is_ possible.