### PR TITLE
Ensure Each TestQueueRow Uses a Unique ID-ref.

### DIFF
--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -337,6 +337,15 @@ const TestQueueRow = ({
     const { status, results } = evaluateStatusAndResults();
     const nextReportStatus = evaluateNewReportStatus();
 
+    const getRowId = tester =>
+        [
+            'plan',
+            testPlanReport.id,
+            'assignee',
+            tester.username,
+            'completed'
+        ].join('-');
+
     return (
         <tr className="test-queue-run-row">
             <th>{renderAssignedUserToTestPlan()}</th>
@@ -378,19 +387,11 @@ const TestQueueRow = ({
                                             // Allows ATs to read the number of
                                             // completed tests when tabbing to this
                                             // link
-                                            aria-describedby={
-                                                `assignee-${tester.username}-` +
-                                                `completed`
-                                            }
+                                            aria-describedby={getRowId(tester)}
                                         >
                                             {tester.username}
                                         </a>
-                                        <div
-                                            id={
-                                                `assignee-${tester.username}-` +
-                                                `completed`
-                                            }
-                                        >
+                                        <div id={getRowId(tester)}>
                                             {`(${testResults.reduce(
                                                 (acc, { completedAt }) =>
                                                     acc + (completedAt ? 1 : 0),

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -341,6 +341,8 @@ const TestQueueRow = ({
         [
             'plan',
             testPlanReport.id,
+            'run',
+            currentUserTestPlanRun.id,
             'assignee',
             tester.username,
             'completed'


### PR DESCRIPTION
This change ensures each id generated for a Test Queue Row combines its test plan ID and tester name. This addresses a problem where two test rows assigned to the same tester generate (elements with) duplicate IDs.