### PR TITLE
Remove Unneeded ARIA attribute

### DIFF
--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -348,11 +348,6 @@ const TestQueueRow = ({
                             <Button
                                 variant="secondary"
                                 onClick={() => toggleTesterAssign(username)}
-                                aria-label={
-                                    !currentUserAssigned
-                                        ? 'Assign Yourself'
-                                        : 'Unassign Yourself'
-                                }
                                 className="assign-self"
                             >
                                 {!currentUserAssigned


### PR DESCRIPTION
This change removes the `aria-label` attribute for each assign/un-assign test row queue control.
The "Assign Yourself" / "Un-assign Yourself" `aria-label` for this button is redundant since the button's text content is identical.