### PR TITLE
Add Descriptive Heading Before Each "Assertions" Table

### DIFF
--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -697,8 +697,14 @@ const TestRenderer = ({
                                                 }
                                             />
                                         </Text>
-                                        <h4>Assertions {header}</h4>
-                                        <Table>
+                                        <h4
+                                            id={`command-${commandIndex}-assertions-heading`}
+                                        >
+                                            Assertions {header}
+                                        </h4>
+                                        <Table
+                                            aria-labelledby={`command-${commandIndex}-assertions-heading`}
+                                        >
                                             <tbody>
                                                 <tr>
                                                     <th>

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -697,6 +697,7 @@ const TestRenderer = ({
                                                 }
                                             />
                                         </Text>
+                                        <h4>Assertions {header}</h4>
                                         <Table>
                                             <tbody>
                                                 <tr>


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> In the command-specific areas of the "Record Results" section for a test, there is no heading between the "After ..." input and assertions table.

--- 
Effective changes:

- Introducing a level 4 heading with the text `Assertions [description]` before each assertions table.