### PR TITLE
Remove Duplicate Level One Heading

### DIFF
--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -29,11 +29,13 @@ const ErrorSection = styled.section`
 
 const InstructionsSection = styled.section``;
 
-const HeadingText = styled.h1``;
+const HeadingText = styled.h2`
+    margin-top: 0;
+`;
 
-const SubHeadingText = styled.h2``;
+const SubHeadingText = styled.h3``;
 
-const InnerSectionHeadingText = styled.h3``;
+const InnerSectionHeadingText = styled.h4``;
 
 const Text = styled.p`
     > textarea {


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> There are two level 1 headings for each testing task, making it potentially unclear where the main content of interest begins. There should only ever be one level 1 heading on a page.

--- 

**Question**: since the `h1` and `h2` on this page are quite similar:

- `h1` Testing task: 1. Open a Modal Dialog
- `h2` Testing task: Open a Modal Dialog

Could the `h2` not be done without? That way this PR can be simplified by just removing the duplicate `h1` altogether and thus keeping the rest of the heading structure intact. This would then also ensure no changes need to be made to #375.

---

Effective changes:

- Move second h1 (Testing task title) to h2; and
- any h2 to h3, h3 to h4.