### PR TITLE
Add Test Controls Heading

### DIFF
--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -275,7 +275,7 @@ main.container-fluid .test-iframe-container > .row {
     border-radius: 3px;
 }
 
-.current-test-options h3 {
+.current-test-options h2 {
     margin-top: 0;
     padding: 0.9em;
     background: #e9ebee;

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -545,8 +545,11 @@ const TestRun = () => {
 
         const menuRightOfContent = (
             <div role="complementary">
-                <h3>Test Options</h3>
-                <ul className="options-wrapper">
+                <h2 id="test-options-heading">Test Options</h2>
+                <ul
+                    aria-labelledby="test-options-heading"
+                    className="options-wrapper"
+                >
                     <li>
                         <OptionButton
                             text="Raise An Issue"

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -631,7 +631,16 @@ const TestRun = () => {
                                 </Row>
                                 {isRendererReady && (
                                     <Row>
-                                        <ul className="test-run-toolbar mt-1">
+                                        <h2
+                                            id="test-toolbar-heading"
+                                            className="sr-only"
+                                        >
+                                            Test Controls
+                                        </h2>
+                                        <ul
+                                            aria-labelledby="test-toolbar-heading"
+                                            className="test-run-toolbar mt-1"
+                                        >
                                             {primaryButtons.map(button => (
                                                 <li key={nextId()}>{button}</li>
                                             ))}


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> The group of "Previous Test", "Next Test" and "Submit Results" buttons isn't preceded by a heading, nor are the buttons grouped inside a list. Similarly, there is no list mark-up wrapping the "Raise An Issue", "Start Over" and "Save and Close" buttons.

---

Effective changes:

- Add a visually hidden heading atop the `ul` containing the test controls;
- label the `ul` using the heading;
- move the "Test Options" `h3` to `h2`; and
- label the "Test Options" `ul` by that `h2`.