### PR TITLE
Reposition Test Plan Actions

### DIFF
--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -447,16 +447,36 @@ const TestQueueRow = ({
             <td className="actions">
                 <div className="test-cta-wrapper">
                     {currentUserAssigned && (
+                        <>
+                            <Button
+                                variant="primary"
+                                href={`/run/${currentUserTestPlanRun.id}`}
+                                disabled={!currentUserAssigned}
+                            >
+                                {currentUserTestPlanRun.testResults.length >
+                                    0 &&
+                                currentUserTestPlanRun.testResults.length <
+                                    runnableTests.length
+                                    ? 'Continue testing'
+                                    : 'Start testing'}
+                            </Button>
+                            <Button
+                                variant="secondary"
+                                onClick={() => toggleTesterAssign(username)}
+                                className="assign-self"
+                            >
+                                Un-assign Yourself
+                            </Button>
+                        </>
+                    )}
+
+                    {!currentUserAssigned && (
                         <Button
-                            variant="primary"
-                            href={`/run/${currentUserTestPlanRun.id}`}
-                            disabled={!currentUserAssigned}
+                            variant="secondary"
+                            onClick={() => toggleTesterAssign(username)}
+                            className="assign-self"
                         >
-                            {currentUserTestPlanRun.testResults.length > 0 &&
-                            currentUserTestPlanRun.testResults.length <
-                                runnableTests.length
-                                ? 'Continue testing'
-                                : 'Start testing'}
+                            Assign Yourself
                         </Button>
                     )}
 
@@ -471,7 +491,7 @@ const TestQueueRow = ({
                                 );
                             }}
                         >
-                            Remove
+                            Remove Plan
                         </Button>
                     )}
 


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> For non-admin users (i.e. testers), the "Actions" column is empty when a test plan isn't assigned to anyone. This reduces the discoverability of the " Assign Yourself" button, which is arguably a test plan action but is confusingly located in the "Testers" column. When a tester is assigned, the " Start testing" link is located in the "Actions" column as expected, but these inconsistencies make the table quite unpredictable to use.

--- 
Effective changes:

- Move the "Assign Yourself" button into the "Actions" column;
- move the "Assign User" pop-up widget into the "Actions column;
- rename "Remove" button to "Remove Plan"; and
- adjust color contrast for "danger" style. 