### PR TITLE
Implement Test Navigator Toggle button as Disclosure Widget

### DIFF
--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -41,64 +41,61 @@ const TestNavigator = ({
                     </button>
                 </h2>
             </div>
-            {show && (
-                <nav id="test-navigator-nav">
-                    <ol
-                        aria-labelledby="test-navigator-heading"
-                        className="test-navigator-list"
-                    >
-                        {tests.map(test => {
-                            let resultClassName = 'not-started';
-                            let resultStatus = 'Not Started';
+            <nav id="test-navigator-nav" hidden={!show}>
+                <ol
+                    aria-labelledby="test-navigator-heading"
+                    className="test-navigator-list"
+                >
+                    {tests.map(test => {
+                        let resultClassName = 'not-started';
+                        let resultStatus = 'Not Started';
 
-                            if (test) {
-                                if (test.hasConflicts) {
-                                    resultClassName = 'conflicts';
-                                    resultStatus = 'Has Conflicts';
-                                } else if (test.testResult) {
-                                    resultClassName = test.testResult
-                                        .completedAt
-                                        ? 'complete'
-                                        : 'in-progress';
-                                    resultStatus = test.testResult.completedAt
-                                        ? 'Complete Test'
-                                        : 'In Progress';
-                                } else if (
-                                    !isSignedIn &&
-                                    test.index === currentTestIndex
-                                ) {
-                                    resultClassName = 'in-progress';
-                                    resultStatus = 'In Progress:';
-                                }
+                        if (test) {
+                            if (test.hasConflicts) {
+                                resultClassName = 'conflicts';
+                                resultStatus = 'Has Conflicts';
+                            } else if (test.testResult) {
+                                resultClassName = test.testResult.completedAt
+                                    ? 'complete'
+                                    : 'in-progress';
+                                resultStatus = test.testResult.completedAt
+                                    ? 'Complete Test'
+                                    : 'In Progress';
+                            } else if (
+                                !isSignedIn &&
+                                test.index === currentTestIndex
+                            ) {
+                                resultClassName = 'in-progress';
+                                resultStatus = 'In Progress:';
                             }
+                        }
 
-                            return (
-                                <li
-                                    className={`test-name-wrapper ${resultClassName}`}
-                                    key={`TestNavigatorItem_${test.id}`}
+                        return (
+                            <li
+                                className={`test-name-wrapper ${resultClassName}`}
+                                key={`TestNavigatorItem_${test.id}`}
+                            >
+                                <a
+                                    href="#"
+                                    onClick={async () =>
+                                        await handleTestClick(test.index)
+                                    }
+                                    className="test-name"
+                                    aria-current={
+                                        test.index === currentTestIndex
+                                    }
                                 >
-                                    <a
-                                        href="#"
-                                        onClick={async () =>
-                                            await handleTestClick(test.index)
-                                        }
-                                        className="test-name"
-                                        aria-current={
-                                            test.index === currentTestIndex
-                                        }
-                                    >
-                                        {test.title}
-                                    </a>
-                                    <span
-                                        className="progress-indicator"
-                                        title={`${resultStatus}`}
-                                    />
-                                </li>
-                            );
-                        })}
-                    </ol>
-                </nav>
-            )}
+                                    {test.title}
+                                </a>
+                                <span
+                                    className="progress-indicator"
+                                    title={`${resultStatus}`}
+                                />
+                            </li>
+                        );
+                    })}
+                </ol>
+            </nav>
         </Col>
     );
 };

--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -19,13 +19,14 @@ const TestNavigator = ({
     return (
         <Col className="test-navigator" md={show ? 3 : 12}>
             <div className="test-navigator-toggle-container">
-                <div className="test-navigator-toggle-inner-container">
+                <h2
+                    id="test-navigator-heading"
+                    className="test-navigator-toggle-inner-container"
+                >
                     <button
-                        aria-label={`${
-                            show
-                                ? 'Toggle button to close test navigator'
-                                : 'Toggle button to open test navigator'
-                        }`}
+                        aria-label="Test Navigator"
+                        aria-controls="test-navigator-nav"
+                        aria-expanded={show ? 'true' : 'false'}
                         onClick={toggleShowClick}
                         className={`test-navigator-toggle ${
                             show ? 'hide' : 'show'
@@ -38,11 +39,10 @@ const TestNavigator = ({
                         )}
                         <FontAwesomeIcon icon={faAlignLeft} />
                     </button>
-                </div>
+                </h2>
             </div>
             {show && (
-                <nav aria-label="Test">
-                    <h2 id="test-navigator-heading">Test Navigation</h2>
+                <nav id="test-navigator-nav">
                     <ol
                         aria-labelledby="test-navigator-heading"
                         className="test-navigator-list"

--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -24,13 +24,11 @@ const TestNavigator = ({
                     className="test-navigator-toggle-inner-container"
                 >
                     <button
-                        aria-label="Test Navigator"
+                        aria-label="Test Navigation"
                         aria-controls="test-navigator-nav"
                         aria-expanded={show ? 'true' : 'false'}
                         onClick={toggleShowClick}
-                        className={`test-navigator-toggle ${
-                            show ? 'hide' : 'show'
-                        }`}
+                        className="test-navigator-toggle"
                     >
                         {show ? (
                             <FontAwesomeIcon icon={faArrowLeft} />

--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -41,7 +41,7 @@ const TestNavigator = ({
                     </button>
                 </h2>
             </div>
-            <nav id="test-navigator-nav" hidden={!show}>
+            <nav id="test-navigator-nav" hidden={!show} aria-label="Test">
                 <ol
                     aria-labelledby="test-navigator-heading"
                     className="test-navigator-list"

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -7,6 +7,11 @@
     margin-top: 0;
 }
 
+#test-navigator-heading {
+    font-size: 1em;
+    margin-top: 0.75em;
+}
+
 button.test-navigator-toggle.hide,
 button.test-navigator-toggle.show {
     border: 0;

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -12,15 +12,14 @@
     margin-top: 0.75em;
 }
 
-button.test-navigator-toggle.hide,
-button.test-navigator-toggle.show {
+button.test-navigator-toggle {
     border: 0;
     background-color: transparent;
     color: #929292;
 }
 
-button.test-navigator-toggle.hide:hover,
-button.test-navigator-toggle.show:hover {
+button.test-navigator-toggle:hover,
+button.test-navigator-toggle:focus {
     color: #0b60ab;
 }
 


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> Directly after the "Test Navigator" heading, there is a button which reads: "Toggle button to close test navigator". This label is overly verbose, and points to the fact that a Disclosure pattern is not being used (e.g. as demonstrated by the APG's example of disclosures for a navigation menu). This control would be far more usable as a button with aria-expanded, collapsed down into the previous heading. That is, the heading should wrap a button inside it, labelled "Test Navigator", which programmatically indicates its expanded/collapsed state via aria-expanded. As an aside, that will also give the button a visible label because the heading is on-screen; right now the button only has an icon.

@jscholes some duplication exists in #362. The `h2` around the `button` is now used to describe the `ol` inside the `nav`, but is not itself a child of the `nav` since it is its toggle control. This does not follow the usual pattern of placing the heading in the nav ahead of the nav list, but another specific heading seems overkill. Thoughts?

--- 

Effective changes:

- Wrap a `h2` around toggle `button`;
- set a static `aria-label` onto the `button`;
- manage `aria-expanded` attribute on the `button`;
- associate `button` with `nav` using `aria-controls` idref; and
- describe navigation list using `h2`.