### PR TITLE
Conditionally Hide "Unexpected Behaviors" Fieldset

### DIFF
--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -965,7 +965,13 @@ const TestRenderer = ({
                                                 </label>
                                             </div>
 
-                                            <Fieldset className="problem-select">
+                                            <Fieldset
+                                                className="problem-select"
+                                                hidden={
+                                                    !unexpectedBehaviors
+                                                        .failChoice.checked
+                                                }
+                                            >
                                                 <legend>
                                                     {
                                                         unexpectedBehaviors
@@ -1013,11 +1019,6 @@ const TestRenderer = ({
                                                                                 .target
                                                                                 .checked
                                                                         )
-                                                                    }
-                                                                    disabled={
-                                                                        !unexpectedBehaviors
-                                                                            .failChoice
-                                                                            .checked
                                                                     }
                                                                 />
                                                                 <label


### PR DESCRIPTION
This PR addresses the following item from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document:

> The "Undesirable behaviors" checkboxes (and "other" input) are always accessible, albeit in a disabled state if "No, there were no additional undesirable behaviors." is checked. This means that people must navigate past things that aren't relevant to them in that moment, rather than non-applicable controls being hidden.

---

Effective changes:

- remove `disabled` attribute from `fieldset` input fields.
- add `hidden` attribute to `fieldset` when "No" is answered.