### PR TITLE
Clarify Progress Column in Test Plan Report Table

### DIFF
--- a/client/components/Reports/Reports.css
+++ b/client/components/Reports/Reports.css
@@ -132,6 +132,7 @@
     height: 1.2rem;
     border-radius: 1rem;
     margin-top: 0.2em;
+    border: 1px solid gray;
 }
 
 .progress .progress-bar.bg-info {

--- a/client/components/Reports/SummarizeTestPlanReports.jsx
+++ b/client/components/Reports/SummarizeTestPlanReports.jsx
@@ -81,9 +81,7 @@ const SummarizeTestPlanReports = ({ testPlanReports }) => {
                         <th>Test Plan</th>
                         {Object.values(testPlanTargetsById).map(
                             testPlanTarget => (
-                                <th key={testPlanTarget.id}>
-                                    {getTestPlanTargetTitle(testPlanTarget)}
-                                </th>
+                                <th key={testPlanTarget.id}>Target Progress</th>
                             )
                         )}
                     </tr>
@@ -128,18 +126,19 @@ const SummarizeTestPlanReports = ({ testPlanReports }) => {
                                                             `/targets/${testPlanReport.id}`
                                                         }
                                                     >
+                                                        {getTestPlanTargetTitle(
+                                                            testPlanTarget
+                                                        )}
+                                                        {` `}(
+                                                        {metrics.supportPercent}
+                                                        % completed)
                                                         <div className="progress">
                                                             <div
                                                                 className="progress-bar bg-info"
                                                                 style={{
                                                                     width: `${metrics.supportPercent}%`
                                                                 }}
-                                                            >
-                                                                {
-                                                                    metrics.supportPercent
-                                                                }
-                                                                %
-                                                            </div>
+                                                            />
                                                         </div>
                                                     </Link>
                                                 </td>


### PR DESCRIPTION
Previously, each test target report link would have as its displayed link "[n]" progress, and a visual progress bar.
This PR ensures each target report link contains its testing target (browser and version) and its completed progress.

This also addresses a potential rendering problem in the progress bar where the progress is low enough to cause text contrast issues (<5%).