### PR TITLE
Remove passive div element from tab order on Settings page.

### DIFF
--- a/client/components/UserSettings/UserSettings.jsx
+++ b/client/components/UserSettings/UserSettings.jsx
@@ -66,7 +66,7 @@ const UserSettings = () => {
                         </a>
                     </p>
                     <h2>Assistive Technology Settings</h2>
-                    <div tabIndex={0} aria-live="polite">
+                    <div aria-atomic="true" aria-live="polite">
                         {savedAts.length > 0 ? (
                             <div>
                                 <p>


### PR DESCRIPTION
The "configured ATs" `div` on the Settings page has a `tabindex` of 0, making it part of the active tab order while it is not an interactive element and lacks an accessible name. This PR corrects that.