### PR TITLE
New test plan modal accessibility fixes

### DIFF
--- a/client/components/NewTestPlanReport/NewTestPlanReportContainer.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportContainer.jsx
@@ -4,10 +4,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import PropTypes from 'prop-types';
 
-const NewTestPlanReportContainer = ({ handleOpenDialog = () => {} }) => {
+const NewTestPlanReportContainer = ({
+    handleOpenDialog = () => {},
+    openDialogTriggerId
+}) => {
     return (
         <div className="add-test-plan-queue-container">
             <Button
+                id={openDialogTriggerId}
                 className="add-test-plan-queue-button"
                 variant="primary"
                 onClick={handleOpenDialog}
@@ -21,7 +25,8 @@ const NewTestPlanReportContainer = ({ handleOpenDialog = () => {} }) => {
 };
 
 NewTestPlanReportContainer.propTypes = {
-    handleOpenDialog: PropTypes.func
+    handleOpenDialog: PropTypes.func,
+    openDialogTriggerId: PropTypes.string
 };
 
 export default NewTestPlanReportContainer;

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.css
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.css
@@ -1,0 +1,14 @@
+[aria-labelledby='add-test-plan-to-queue-modal'] h1 {
+    border: 0;
+    font-size: 1.5em;
+}
+
+[aria-labelledby='add-test-plan-to-queue-modal'] h2 {
+    font-size: 0.8em;
+    margin: 0;
+    padding: 0;
+}
+
+[aria-labelledby='add-test-plan-to-queue-modal'] fieldset + fieldset {
+    margin-top: 0.5em;
+}

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -171,7 +171,7 @@ const NewTestPlanReportModal = ({
             aria-labelledby="add-test-plan-to-queue-modal"
         >
             <Modal.Header closeButton>
-                <Modal.Title as="h1">
+                <Modal.Title as="h1" id="add-test-plan-to-queue-modal">
                     Add a Test Plan to the Test Queue
                 </Modal.Title>
             </Modal.Header>

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -140,7 +140,7 @@ const NewTestPlanReportModal = ({
 
     const dropdownsRow = ({ heading, dropdowns }) => {
         return (
-            <fieldset className="add-test-plan-queue-modal-row">
+            <fieldset>
                 <legend>
                     <h2>{heading}</h2>
                 </legend>

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -8,6 +8,12 @@ import {
 } from '../TestQueue/queries';
 import './NewTestPlanReportModal.css';
 
+const handleOpen = function() {
+    document
+        .querySelector('[role="dialog"].modal select:first-of-type')
+        .focus();
+};
+
 const NewTestPlanReportModal = ({
     show = false,
     handleClose = () => {},
@@ -161,6 +167,7 @@ const NewTestPlanReportModal = ({
         <Modal
             show={show}
             onHide={handleClose}
+            onShow={handleOpen}
             aria-labelledby="add-test-plan-to-queue-modal"
         >
             <Modal.Header closeButton>

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -91,9 +91,9 @@ const NewTestPlanReportModal = ({
         await addTestPlanReport({
             variables: {
                 testPlanVersionId: selectedTestPlanVersion,
-                atId: selectedAt,
+                atId: selectedAt.id,
                 atVersion: atVersion,
-                browserId: selectedBrowser,
+                browserId: selectedBrowser.id,
                 browserVersion: browserVersion
             }
         });

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -51,9 +51,9 @@ const NewTestPlanReportModal = ({
 
             setAllTestPlanVersions(allTestPlanVersions);
 
-            // set the defaults, since all dropdown fields are mandatory
-            setSelectedAt(ats[0]);
-            setSelectedBrowser(browsers[0]);
+            // set the default AT and Browser dropdown values, since all dropdown fields are mandatory
+            setSelectedAt(ats[0].id);
+            setSelectedBrowser(browsers[0].id);
         }
     }, [data]);
 
@@ -91,9 +91,9 @@ const NewTestPlanReportModal = ({
         await addTestPlanReport({
             variables: {
                 testPlanVersionId: selectedTestPlanVersion,
-                atId: selectedAt.id,
+                atId: selectedAt,
                 atVersion: atVersion,
-                browserId: selectedBrowser.id,
+                browserId: selectedBrowser,
                 browserVersion: browserVersion
             }
         });

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -7,6 +7,7 @@ import {
     POPULATE_ADD_TEST_PLAN_TO_QUEUE_MODAL_QUERY
 } from '../TestQueue/queries';
 import './NewTestPlanReportModal.css';
+import { gitUpdatedDateToString } from '../../utils/gitUtils';
 
 const handleOpen = function() {
     document
@@ -262,7 +263,9 @@ const NewTestPlanReportModal = ({
                                         key={`${item.gitSha}-${item.id}`}
                                         value={item.id}
                                     >
-                                        {item.gitSha}
+                                        {gitUpdatedDateToString(item.updatedAt)}{' '}
+                                        {item.gitMessage} (
+                                        {item.gitSha.substring(0, 7)})
                                     </option>
                                 ),
                                 value: selectedTestPlanVersion,

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -6,7 +6,6 @@ import {
     ADD_TEST_QUEUE_MUTATION,
     POPULATE_ADD_TEST_PLAN_TO_QUEUE_MODAL_QUERY
 } from '../TestQueue/queries';
-import { gitUpdatedDateToString } from '../../utils/gitUtils';
 
 const NewTestPlanReportModal = ({
     show = false,
@@ -28,9 +27,7 @@ const NewTestPlanReportModal = ({
     const [selectedTestPlanVersion, setSelectedTestPlanVersion] = useState('');
 
     // eslint-disable-next-line no-unused-vars
-    const { loading, error, data } = useQuery(
-        POPULATE_ADD_TEST_PLAN_TO_QUEUE_MODAL_QUERY
-    );
+    const { data } = useQuery(POPULATE_ADD_TEST_PLAN_TO_QUEUE_MODAL_QUERY);
     const [addTestPlanReport] = useMutation(ADD_TEST_QUEUE_MUTATION);
 
     useEffect(() => {
@@ -44,7 +41,12 @@ const NewTestPlanReportModal = ({
                     ...version
                 }))
                 .flat();
+
             setAllTestPlanVersions(allTestPlanVersions);
+
+            // set the defaults, since all dropdown fields are mandatory
+            setSelectedAt(ats[0]);
+            setSelectedBrowser(browsers[0]);
         }
     }, [data]);
 
@@ -57,7 +59,25 @@ const NewTestPlanReportModal = ({
                         t.testPlan.directory === v.testPlan.directory
                 ) === i
         );
+
         setFilteredTestPlanVersions(filteredTestPlanVersions);
+
+        // mark the first testPlanVersion as selected
+        if (filteredTestPlanVersions.length) {
+            const plan = filteredTestPlanVersions[0];
+
+            setSelectedTestPlan(plan.id);
+
+            // find the versions that apply and pre-set these
+            const matchingTestPlanVersions = filteredTestPlanVersions.filter(
+                item =>
+                    item.title === plan.title &&
+                    item.testPlan.directory === plan.testPlan.directory
+            );
+
+            setSelectedTestPlanVersion(matchingTestPlanVersions[0].id);
+            setTestPlanVersions(matchingTestPlanVersions);
+        }
     }, [allTestPlanVersions]);
 
     const handleCreateTestPlanReport = async () => {
@@ -73,30 +93,20 @@ const NewTestPlanReportModal = ({
         await handleAddToTestQueue();
     };
 
-    const dropdownRowWithInputField = ({
-        controlId,
-        label,
-        dropdownOptions,
-        dropdownPlaceholder,
-        inputFieldPlaceholder,
-        dropdownValue,
-        inputFieldValue,
-        handleDropdownSelected,
-        handleInputFieldUpdated
-    }) => {
+    const dropdownRowWithInputField = ({ heading, dropdown, input }) => {
         return (
-            <div className="add-test-plan-queue-modal-row">
-                <Form.Group controlId={controlId}>
-                    <Form.Label>{label}</Form.Label>
+            <fieldset className="add-test-plan-queue-modal-row">
+                <legend>
+                    <h2>{heading}</h2>
+                </legend>
+                <Form.Group controlId={dropdown.id}>
+                    <Form.Label>{dropdown.label}</Form.Label>
                     <Form.Control
                         as="select"
-                        onChange={e => handleDropdownSelected(e.target.value)}
-                        value={dropdownValue}
+                        onChange={e => dropdown.onSelect(e.target.value)}
+                        value={dropdown.value}
                     >
-                        <option disabled value={''}>
-                            {dropdownPlaceholder}
-                        </option>
-                        {dropdownOptions.map(item => (
+                        {dropdown.options.map(item => (
                             <option
                                 key={`${item.name}-${item.id}`}
                                 value={item.id}
@@ -106,84 +116,43 @@ const NewTestPlanReportModal = ({
                         ))}
                     </Form.Control>
                 </Form.Group>
-                <Form.Group className="add-test-plan-queue-modal-normalize-row">
+                <Form.Group
+                    controlId={input.id}
+                    className="add-test-plan-queue-modal-normalize-row"
+                >
+                    <Form.Label>{input.label}</Form.Label>
                     <Form.Control
                         type="text"
-                        value={inputFieldValue}
-                        placeholder={inputFieldPlaceholder}
-                        disabled={!dropdownValue}
-                        onChange={e => handleInputFieldUpdated(e.target.value)}
+                        value={input.value}
+                        onChange={e => input.onChange(e.target.value)}
                     />
                 </Form.Group>
-            </div>
+            </fieldset>
         );
     };
 
-    const dropdownsRow = ({
-        label,
-        primaryControlId,
-        secondaryControlId,
-        primaryDropdownOptions,
-        secondaryDropdownOptions,
-        primaryDropdownPlaceholder,
-        secondaryDropdownPlaceholder,
-        primaryDropdownValue,
-        secondaryDropdownValue,
-        handlePrimaryDropdownSelected,
-        handleSecondaryDropdownSelected
-    }) => {
+    const dropdownsRow = ({ heading, dropdowns }) => {
         return (
-            <div className="add-test-plan-queue-modal-row">
-                <Form.Group controlId={primaryControlId}>
-                    <Form.Label>{label}</Form.Label>
-                    <Form.Control
-                        as="select"
-                        onChange={e =>
-                            handlePrimaryDropdownSelected(e.target.value)
-                        }
-                        value={primaryDropdownValue}
-                    >
-                        <option disabled value={''}>
-                            {primaryDropdownPlaceholder}
-                        </option>
-                        {primaryDropdownOptions.map(item => (
-                            <option
-                                key={`${item.title ||
-                                    item.testPlan.directory}-${item.id}`}
-                                value={item.id}
-                            >
-                                {item.title || `"${item.testPlan.directory}"`}
-                            </option>
-                        ))}
-                    </Form.Control>
-                </Form.Group>
-                <Form.Group
-                    controlId={secondaryControlId}
-                    className="add-test-plan-queue-modal-normalize-row"
-                >
-                    <Form.Control
-                        as="select"
-                        onChange={e =>
-                            handleSecondaryDropdownSelected(e.target.value)
-                        }
-                        value={secondaryDropdownValue}
-                    >
-                        <option disabled value={''}>
-                            {secondaryDropdownPlaceholder}
-                        </option>
-                        {secondaryDropdownOptions.map(item => (
-                            <option
-                                key={`${item.gitSha}-${item.id}`}
-                                value={item.id}
-                            >
-                                {gitUpdatedDateToString(item.updatedAt)}{' '}
-                                {item.gitMessage} ({item.gitSha.substring(0, 7)}
-                                )
-                            </option>
-                        ))}
-                    </Form.Control>
-                </Form.Group>
-            </div>
+            <fieldset className="add-test-plan-queue-modal-row">
+                <legend>
+                    <h2>{heading}</h2>
+                </legend>
+                {dropdowns.map(dropdown => (
+                    <Form.Group key={dropdown.id} controlId={dropdown.id}>
+                        <Form.Label>{dropdown.label}</Form.Label>
+                        <Form.Control
+                            as="select"
+                            onChange={e => dropdown.onSelect(e.target.value)}
+                            value={dropdown.value}
+                            disabled={
+                                dropdown.isDisabled && dropdown.isDisabled()
+                            }
+                        >
+                            {dropdown.options.map(dropdown.renderOption)}
+                        </Form.Control>
+                    </Form.Group>
+                ))}
+            </fieldset>
         );
     };
 
@@ -194,61 +163,104 @@ const NewTestPlanReportModal = ({
             aria-labelledby="add-test-plan-to-queue-modal"
         >
             <Modal.Header closeButton>
-                <Modal.Title>Add a Test Plan to the Test Queue</Modal.Title>
+                <Modal.Title as="h1">
+                    Add a Test Plan to the Test Queue
+                </Modal.Title>
             </Modal.Header>
             <Modal.Body>
                 <div className="add-test-plan-queue-modal-container">
                     {dropdownRowWithInputField({
-                        label: 'Select an AT and Version',
-                        controlId: 'select-at',
-                        dropdownOptions: ats,
-                        dropdownPlaceholder: 'Assistive Technology',
-                        inputFieldPlaceholder: 'AT Version',
-                        dropdownValue: selectedAt,
-                        inputFieldValue: atVersion,
-                        handleDropdownSelected: setSelectedAt,
-                        handleInputFieldUpdated: setAtVersion
+                        heading: 'Select an AT and Version',
+                        dropdown: {
+                            id: 'select-at',
+                            label: 'Assistive Technology',
+                            options: ats,
+                            value: selectedAt,
+                            onSelect: setSelectedAt
+                        },
+                        input: {
+                            id: 'at-version',
+                            label: 'AT Version',
+                            value: atVersion,
+                            onChange: setAtVersion
+                        }
                     })}
 
                     {dropdownRowWithInputField({
-                        label: 'Select a Browser and Version',
-                        controlId: 'select-browser',
-                        dropdownOptions: browsers,
-                        dropdownPlaceholder: 'Browser',
-                        inputFieldPlaceholder: 'Browser Version',
-                        dropdownValue: selectedBrowser,
-                        inputFieldValue: browserVersion,
-                        handleDropdownSelected: setSelectedBrowser,
-                        handleInputFieldUpdated: setBrowserVersion
+                        heading: 'Select a Browser and Version',
+                        dropdown: {
+                            id: 'select-browser',
+                            label: 'Browser',
+                            options: browsers,
+                            value: selectedBrowser,
+                            onSelect: setSelectedBrowser
+                        },
+                        input: {
+                            id: 'browser-version',
+                            label: 'Browser Version',
+                            value: browserVersion,
+                            onChange: setBrowserVersion
+                        }
                     })}
 
                     {dropdownsRow({
-                        label: 'Select a Test Plan and Version',
-                        primaryControlId: 'select-test-plan',
-                        secondaryControlId: 'select-test-plan-version',
-                        primaryDropdownOptions: filteredTestPlanVersions,
-                        secondaryDropdownOptions: testPlanVersions,
-                        primaryDropdownPlaceholder: 'Select Test Plan',
-                        secondaryDropdownPlaceholder: 'Select Version',
-                        primaryDropdownValue: selectedTestPlan,
-                        secondaryDropdownValue: selectedTestPlanVersion,
-                        handlePrimaryDropdownSelected: value => {
-                            // update test plan versions based on selected test plan
-                            const retrievedTestPlan = allTestPlanVersions.find(
-                                testPlanVersion => testPlanVersion.id == value
-                            );
-                            const testPlanVersions = allTestPlanVersions.filter(
-                                testPlanVersion =>
-                                    testPlanVersion.title ==
-                                        retrievedTestPlan.title &&
-                                    testPlanVersion.testPlan.directory ==
-                                        retrievedTestPlan.testPlan.directory
-                            );
-                            setTestPlanVersions(testPlanVersions);
-                            setSelectedTestPlanVersion('');
-                            setSelectedTestPlan(value);
-                        },
-                        handleSecondaryDropdownSelected: setSelectedTestPlanVersion
+                        heading: 'Select a Test Plan and Version',
+                        dropdowns: [
+                            {
+                                id: 'select-test-plan',
+                                label: 'Select Test Plan',
+                                options: filteredTestPlanVersions,
+                                renderOption: item => (
+                                    <option
+                                        key={`${item.title ||
+                                            item.testPlan.directory}-${
+                                            item.id
+                                        }`}
+                                        value={item.id}
+                                    >
+                                        {item.title ||
+                                            `"${item.testPlan.directory}"`}
+                                    </option>
+                                ),
+                                onSelect: value => {
+                                    // update test plan versions based on selected test plan
+                                    const retrievedTestPlan = allTestPlanVersions.find(
+                                        testPlanVersion =>
+                                            testPlanVersion.id === value
+                                    );
+                                    const testPlanVersions = allTestPlanVersions.filter(
+                                        testPlanVersion =>
+                                            testPlanVersion.title ===
+                                                retrievedTestPlan.title &&
+                                            testPlanVersion.testPlan
+                                                .directory ===
+                                                retrievedTestPlan.testPlan
+                                                    .directory
+                                    );
+                                    setTestPlanVersions(testPlanVersions);
+                                    setSelectedTestPlanVersion(
+                                        testPlanVersions[0].id
+                                    );
+                                    setSelectedTestPlan(value);
+                                }
+                            },
+                            {
+                                id: 'select-test-plan-version',
+                                label: 'Select Version',
+                                isDisabled: () => !selectedTestPlan,
+                                options: testPlanVersions,
+                                renderOption: item => (
+                                    <option
+                                        key={`${item.gitSha}-${item.id}`}
+                                        value={item.id}
+                                    >
+                                        {item.gitSha}
+                                    </option>
+                                ),
+                                value: selectedTestPlanVersion,
+                                onSelect: setSelectedTestPlanVersion
+                            }
+                        ]
                     })}
                 </div>
             </Modal.Body>

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -209,7 +209,7 @@ const NewTestPlanReportModal = ({
                         dropdowns: [
                             {
                                 id: 'select-test-plan',
-                                label: 'Select Test Plan',
+                                label: 'Test Plan',
                                 options: filteredTestPlanVersions,
                                 renderOption: item => (
                                     <option
@@ -247,7 +247,7 @@ const NewTestPlanReportModal = ({
                             },
                             {
                                 id: 'select-test-plan-version',
-                                label: 'Select Version',
+                                label: 'Test Plan Version',
                                 isDisabled: () => !selectedTestPlan,
                                 options: testPlanVersions,
                                 renderOption: item => (

--- a/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
+++ b/client/components/NewTestPlanReport/NewTestPlanReportModal.jsx
@@ -6,6 +6,7 @@ import {
     ADD_TEST_QUEUE_MUTATION,
     POPULATE_ADD_TEST_PLAN_TO_QUEUE_MODAL_QUERY
 } from '../TestQueue/queries';
+import './NewTestPlanReportModal.css';
 
 const NewTestPlanReportModal = ({
     show = false,

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -16,6 +16,8 @@ import { TEST_QUEUE_PAGE_QUERY } from './queries';
 import { evaluateAuth } from '../../utils/evaluateAuth';
 import './TestQueue.css';
 
+const ADD_TEST_PLAN_DIALOG_TRIGGER_ID = 'add-test-plan-to-queue-dialog-trigger';
+
 const TestQueue = () => {
     const { loading, data, refetch } = useQuery(TEST_QUEUE_PAGE_QUERY);
 
@@ -41,6 +43,16 @@ const TestQueue = () => {
     const auth = evaluateAuth(data && data.me ? data.me : {});
     const { id, isAdmin } = auth;
     const isSignedIn = !!id;
+
+    useEffect(() => {
+        if (!isShowingAddToQueueModal) {
+            const trigger = document.querySelector(
+                `#${ADD_TEST_PLAN_DIALOG_TRIGGER_ID}`
+            );
+
+            trigger && trigger.focus();
+        }
+    }, [isShowingAddToQueueModal]);
 
     useEffect(() => {
         if (data) {
@@ -225,6 +237,7 @@ const TestQueue = () => {
                 {isAdmin && (
                     <NewTestPlanReportContainer
                         handleOpenDialog={() => setAddToQueueModal(true)}
+                        openDialogTriggerId={ADD_TEST_PLAN_DIALOG_TRIGGER_ID}
                     />
                 )}
 


### PR DESCRIPTION
Note: this PR was originally authored by @jkva here: https://github.com/w3c/aria-at-app/pull/361. After merging we got a 400 error when adding a new test plan to the queue, so we decided to revert the merge and continue reviewing this PR here.

The original description is below.

--

This PR addresses the following items from PAC's "ARIA-AT App Screen Reader Accessibility Observations" document where applicable to the "Add New Test Plan" modal dialog:

> There is no level 1 title heading at the start of the modal content, nor an accessible name on the modal dialog container.

A level 1 title heading now exists in the modal dialog header, and it describes the dialog document via an `aria-labelledby` IDREF.

> When the modal is opened, keyboard focus is incorrectly placed on the entire dialog container rather than an appropriate element inside it.

Keyboard focus is now placed on the first interactive input field within the dialog body.

> When the dialog is closed, keyboard focus is temporarily lost before being restored to the button that was used to open it. This causes superfluous and verbose screen reader feedback.

Keyboard focus is now explicitly placed on the dialog's trigger once the dialog is closed.

**Question**: the [React Bootstrap Modal Dialog API documentation](https://react-bootstrap.github.io/components/modal/#modal-props) mentions a `restoreFocus` option that should cover this functionality and is enabled by default; is it obvious why this is currently not working and a workaround was needed?

> There are no labels for the form fields.

Each form field has been given an accessible label which is associated via `for=` IDREF.

---

Besides this:

- Each category of input (AT, Browser, Test Plan) has been grouped within a `fieldset`, each `fieldset`'s `legend` containing a `h2` describing the `fieldset` context; and
- each `select` element automatically selects its first option given that none of these values are mandatory.

---

Issues created out of work on this PR:

* #359 
* #360

---
 
![A screenshot showing the modified modal dialog](https://user-images.githubusercontent.com/217264/143232418-28affa93-6fee-49b3-af1d-58f68a08b85c.png) 