### PR TITLE
Edge Case Bugfix: User Locale Date and Time Rendering

### DIFF
--- a/client/utils/gitUtils.js
+++ b/client/utils/gitUtils.js
@@ -1,17 +1,15 @@
-export const gitUpdatedDateToString = dateString => {
+const lc = (pattern, string) => string.replace(pattern, pattern.toLowerCase());
+const timeZone = 'UTC';
+const options = { month: 'short' };
+
+export const gitUpdatedDateToString = (dateString, locale = 'default') => {
     const date = new Date(dateString);
-    let formattedDateString = `${date.toLocaleString('default', {
-        month: 'short'
-    })} ${date.getDate()}, ${date.getFullYear()} at ${date.toLocaleTimeString(
-        'default',
-        { timeZone: 'UTC' }
-    )}`;
+    const month = date.toLocaleString(locale, options);
+    const day = date.getDate();
+    const year = date.getFullYear();
+    const time = date.toLocaleTimeString(locale, { timeZone: timeZone });
 
-    if (formattedDateString.includes('PM')) {
-        return formattedDateString.replace('PM', 'pm');
-    }
+    const timeStamp = `${month} ${day}, ${year} at ${time} ${timeZone}`;
 
-    if (formattedDateString.includes('AM')) {
-        return formattedDateString.replace('AM', 'am');
-    }
+    return lc('PM', lc('AM', timeStamp));
 };

--- a/client/utils/gitUtils.test.js
+++ b/client/utils/gitUtils.test.js
@@ -4,12 +4,25 @@ describe('gitUpdatedDateToString', () => {
     it('returns a formatted string AM', () => {
         const date = '2021-11-30T09:51:28.000Z';
         const formattedDate = gitUpdatedDateToString(date);
-        expect(formattedDate).toBe('Nov 30, 2021 at 9:51:28 am');
+        expect(formattedDate).toBe('Nov 30, 2021 at 9:51:28 am UTC');
     });
 
     it('returns a formatted string PM', () => {
         const date = '2021-11-30T14:51:28.000Z';
         const formattedDate = gitUpdatedDateToString(date);
-        expect(formattedDate).toBe('Nov 30, 2021 at 2:51:28 pm');
+        expect(formattedDate).toBe('Nov 30, 2021 at 2:51:28 pm UTC');
+    });
+
+    it('returns a formatted string when using 24-hour notation in a different locale (Dutch)', () => {
+        const date = '2021-11-30T14:51:28.000Z';
+        const formattedDate = gitUpdatedDateToString(date, 'nl-NL');
+        // Dutch time uses a lowercase period-terminated month notation
+        expect(formattedDate).toBe('nov. 30, 2021 at 14:51:28 UTC');
+    });
+
+    it('returns a formatted string when using a different locale (Korean)', () => {
+        const date = '2021-11-30T14:51:28.000Z';
+        const formattedDate = gitUpdatedDateToString(date, 'ko-KR');
+        expect(formattedDate).toBe('11월 30, 2021 at 오후 2:51:28 UTC');
     });
 });


### PR DESCRIPTION
PR #397 introduced the rendering of a Test Plan's git revision timestamp. There was formatting code to replace `PM` by `pm` and `AM` by `am`, yet the code used `toLocaleString` and `toLocaleTimeString` with a locale of `default` - the system locale.

This caused the function to output `undefined` when defaulting to a locale (say, `nl-NL`) which does not use `AM/PM` notation.

The timezone notation was also set to UTC but was not explicitly displayed, which can lead to confusion when the system locale does not use UTC. This PR therefore explicitly includes it in the formatted string.

~~Question: should this timestamp be this detailed to begin with? Is there a use-case for the inclusion of the entire timestamp? Would "Published on 19 Nov 2021" not suffice in detail?~~ I see @s3ththompson mentioning "Also, can we add the time in order to disambiguate between two commits on the same day?" in #397, never mind.