### PR TITLE
Browser Version Operations

### DIFF
--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -999,15 +999,15 @@ const graphqlSchema = gql`
         """
         at(id: ID!): AtOperations!
         """
-        Get the available mutations for the given AT Version.
+        Get the available mutations for the given AT version.
         """
         atVersion(id: ID!): AtVersionOperations!
         """
-        Get the available mutations for the given Browser.
+        Get the available mutations for the given browser.
         """
         browser(id: ID!): BrowserOperations!
         """
-        Get the available mutations for the given Browser Version.
+        Get the available mutations for the given browser version.
         """
         browserVersion(id: ID!): BrowserVersionOperations!
         """

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -900,6 +900,19 @@ const graphqlSchema = gql`
         deleteAtVersion: NoResponse
     }
     """
+    Mutations scoped to an Browser version
+    """
+    type BrowserOperations {
+        createBrowserVersion(name: String!): BrowserVersion!
+    }
+    type AtVersionOperations {
+        editAtVersion(
+            updatedName: String!
+            updatedReleasedAt: Timestamp!
+        ): AtVersion!
+        deleteAtVersion: NoResponse
+    }
+    """
     Mutations scoped to a previously-created TestPlanReport.
     """
     type TestPlanReportOperations {
@@ -986,6 +999,7 @@ const graphqlSchema = gql`
     type Mutation {
         at(id: ID!): AtOperations!
         atVersion(id: ID!): AtVersionOperations!
+        browser(id: ID!): BrowserOperations!
         """
         Adds a report with the given TestPlanVersion and TestPlanTarget and a
         state of "DRAFT", resulting in the report appearing in the Test Queue.

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -74,7 +74,18 @@ const graphqlSchema = gql`
         Browser name like "Chrome".
         """
         name: String!
-        browserVersions: [String]!
+        browserVersions: [BrowserVersion]!
+    }
+
+    type BrowserVersion {
+        """
+        Postgres-provided numeric ID
+        """
+        id: ID!
+        """
+        Version string
+        """
+        name: String!
     }
 
     """

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -905,12 +905,9 @@ const graphqlSchema = gql`
     type BrowserOperations {
         createBrowserVersion(name: String!): BrowserVersion!
     }
-    type AtVersionOperations {
-        editAtVersion(
-            updatedName: String!
-            updatedReleasedAt: Timestamp!
-        ): AtVersion!
-        deleteAtVersion: NoResponse
+    type BrowserVersionOperations {
+        editBrowserVersion(updatedName: String!): BrowserVersion!
+        deleteBrowserVersion: NoResponse
     }
     """
     Mutations scoped to a previously-created TestPlanReport.
@@ -997,9 +994,22 @@ const graphqlSchema = gql`
     }
 
     type Mutation {
+        """
+        Get the available mutations for the given AT.
+        """
         at(id: ID!): AtOperations!
+        """
+        Get the available mutations for the given AT Version.
+        """
         atVersion(id: ID!): AtVersionOperations!
+        """
+        Get the available mutations for the given Browser.
+        """
         browser(id: ID!): BrowserOperations!
+        """
+        Get the available mutations for the given Browser Version.
+        """
+        browserVersion(id: ID!): BrowserVersionOperations!
         """
         Adds a report with the given TestPlanVersion and TestPlanTarget and a
         state of "DRAFT", resulting in the report appearing in the Test Queue.

--- a/server/migrations/20220503193406-alterBrowserVersionTable.js
+++ b/server/migrations/20220503193406-alterBrowserVersionTable.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                'BrowserVersion',
+                'id',
+                {
+                    type: Sequelize.DataTypes.INTEGER,
+                    allowNull: false,
+                    primaryKey: true,
+                    autoIncrement: true
+                },
+                { transaction }
+            );
+            await queryInterface.removeConstraint(
+                'BrowserVersion',
+                'BrowserVersion_pkey',
+                { transaction }
+            );
+            await queryInterface.addConstraint('BrowserVersion', ['id'], {
+                type: 'primary key',
+                name: 'BrowserVersion_pkey',
+                transaction
+            });
+            await queryInterface.renameColumn(
+                'BrowserVersion',
+                'browserVersion',
+                'name',
+                { transaction }
+            );
+        });
+    },
+
+    down: queryInterface => {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeColumn('BrowserVersion', 'id', {
+                transaction
+            });
+            await queryInterface.renameColumn(
+                'BrowserVersion',
+                'name',
+                'browserVersion',
+                { transaction }
+            );
+            await queryInterface.addConstraint(
+                'BrowserVersion',
+                ['browserId', 'browserVersion'],
+                {
+                    type: 'primary key',
+                    name: 'BrowserVersion_pkey',
+                    transaction
+                }
+            );
+        });
+    }
+};

--- a/server/models/BrowserVersion.js
+++ b/server/models/BrowserVersion.js
@@ -4,19 +4,23 @@ module.exports = function(sequelize, DataTypes) {
     const Model = sequelize.define(
         MODEL_NAME,
         {
-            browserId: {
+            id: {
                 type: DataTypes.INTEGER,
                 allowNull: false,
                 primaryKey: true,
+                autoIncrement: true
+            },
+            browserId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
                 references: {
                     model: 'Browser',
                     key: 'id'
                 }
             },
-            browserVersion: {
+            name: {
                 type: DataTypes.TEXT,
-                allowNull: false,
-                primaryKey: true
+                allowNull: false
             }
         },
         {

--- a/server/models/TestPlanTarget.js
+++ b/server/models/TestPlanTarget.js
@@ -55,7 +55,7 @@ module.exports = function(sequelize, DataTypes) {
 
         Model.belongsTo(models.BrowserVersion, {
             ...Model.BROWSER_VERSION_ASSOCIATION,
-            targetKey: 'browserVersion',
+            targetKey: 'name',
             constraints: false
         });
     };

--- a/server/models/services/BrowserService.js
+++ b/server/models/services/BrowserService.js
@@ -316,6 +316,18 @@ const removeBrowserVersionByQuery = async (
     );
 };
 
+/**
+ * @param {object} id - id of the BrowserVersion record to be removed
+ * @param {object} deleteOptions - Sequelize specific deletion options that could be passed
+ * @returns {Promise<boolean>}
+ */
+const removeBrowserVersionById = async (
+    id,
+    deleteOptions = { truncate: false }
+) => {
+    return await ModelService.removeById(BrowserVersion, id, deleteOptions);
+};
+
 module.exports = {
     // Basic CRUD [Browser]
     getBrowserById,
@@ -330,5 +342,6 @@ module.exports = {
     createBrowserVersion,
     updateBrowserVersionByQuery,
     updateBrowserVersionById,
-    removeBrowserVersionByQuery
+    removeBrowserVersionByQuery,
+    removeBrowserVersionById
 };

--- a/server/models/services/BrowserService.js
+++ b/server/models/services/BrowserService.js
@@ -161,14 +161,14 @@ const removeBrowser = async (id, deleteOptions = { truncate: false }) => {
  * @returns {Promise<*>}
  */
 const getBrowserVersionByQuery = async (
-    { browserId, browserVersion },
+    { browserId, name },
     browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
     browserAttributes = BROWSER_ATTRIBUTES,
     options = {}
 ) => {
     return ModelService.getByQuery(
         BrowserVersion,
-        { browserId, browserVersion },
+        { browserId, name },
         browserVersionAttributes,
         [browserAssociation(browserAttributes)],
         options
@@ -200,8 +200,7 @@ const getBrowserVersions = async (
     // search and filtering options
     let where = { ...filter };
     const searchQuery = search ? `%${search}%` : '';
-    if (searchQuery)
-        where = { ...where, browserVersion: { [Op.iLike]: searchQuery } };
+    if (searchQuery) where = { ...where, name: { [Op.iLike]: searchQuery } };
 
     return await ModelService.get(
         BrowserVersion,
@@ -222,21 +221,17 @@ const getBrowserVersions = async (
  * @returns {Promise<*>}
  */
 const createBrowserVersion = async (
-    { browserId, browserVersion },
+    { browserId, name },
     browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
     browserAttributes = BROWSER_ATTRIBUTES,
     options = {}
 ) => {
-    await ModelService.create(
-        BrowserVersion,
-        { browserId, browserVersion },
-        options
-    );
+    await ModelService.create(BrowserVersion, { browserId, name }, options);
 
     // to ensure the structure being returned matches what we expect for simple queries and can be controlled
     return await ModelService.getByQuery(
         BrowserVersion,
-        { browserId, browserVersion },
+        { browserId, name },
         browserVersionAttributes,
         [browserAssociation(browserAttributes)],
         options
@@ -253,7 +248,7 @@ const createBrowserVersion = async (
  * @returns {Promise<*>}
  */
 const updateBrowserVersionByQuery = async (
-    { browserId, browserVersion },
+    { browserId, name },
     updateParams = {},
     browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
     browserAttributes = BROWSER_ATTRIBUTES,
@@ -261,7 +256,7 @@ const updateBrowserVersionByQuery = async (
 ) => {
     await ModelService.update(
         BrowserVersion,
-        { browserId, browserVersion },
+        { browserId, name },
         updateParams,
         options
     );
@@ -270,7 +265,7 @@ const updateBrowserVersionByQuery = async (
         BrowserVersion,
         {
             browserId,
-            browserVersion: updateParams.browserVersion || browserVersion
+            name: updateParams.name || name
         },
         browserVersionAttributes,
         [browserAssociation(browserAttributes)],
@@ -284,12 +279,12 @@ const updateBrowserVersionByQuery = async (
  * @returns {Promise<boolean>}
  */
 const removeBrowserVersionByQuery = async (
-    { browserId, browserVersion },
+    { browserId, name },
     deleteOptions = { truncate: false }
 ) => {
     return await ModelService.removeByQuery(
         BrowserVersion,
-        { browserId, browserVersion },
+        { browserId, name },
         deleteOptions
     );
 };

--- a/server/models/services/BrowserService.js
+++ b/server/models/services/BrowserService.js
@@ -274,6 +274,33 @@ const updateBrowserVersionByQuery = async (
 };
 
 /**
+ * @param {number} id - Postgres ID of BrowserVersion record to be updated
+ * @param {object} updateParams - values to be used to update columns for the record being referenced for {@param queryParams}
+ * @param {string[]} browserVersionAttributes  - BrowserVersion attributes to be returned in the result
+ * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
+ * @param {object} options - Generic options for Sequelize
+ * @param {*} options.transaction - Sequelize transaction
+ * @returns {Promise<*>}
+ */
+const updateBrowserVersionById = async (
+    id,
+    updateParams = {},
+    browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
+    browserAttributes = BROWSER_ATTRIBUTES,
+    options = {}
+) => {
+    await ModelService.update(BrowserVersion, { id }, updateParams, options);
+
+    return await ModelService.getById(
+        BrowserVersion,
+        id,
+        browserVersionAttributes,
+        [browserAssociation(browserAttributes)],
+        options
+    );
+};
+
+/**
  * @param {object} queryParams - values of the BrowserVersion record to be removed
  * @param {object} deleteOptions - Sequelize specific deletion options that could be passed
  * @returns {Promise<boolean>}
@@ -302,5 +329,6 @@ module.exports = {
     getBrowserVersions,
     createBrowserVersion,
     updateBrowserVersionByQuery,
+    updateBrowserVersionById,
     removeBrowserVersionByQuery
 };

--- a/server/models/services/TestPlanReportService.js
+++ b/server/models/services/TestPlanReportService.js
@@ -338,10 +338,7 @@ const getOrCreateTestPlanReport = async (
                 {
                     get: getBrowserVersions,
                     create: createBrowserVersion,
-                    values: {
-                        browserId,
-                        browserVersion: providedBrowserVersion
-                    },
+                    values: { browserId, name: providedBrowserVersion },
                     returnAttributes: [null, []]
                 },
                 {

--- a/server/resolvers/Browser/browserVersionsResolver.js
+++ b/server/resolvers/Browser/browserVersionsResolver.js
@@ -1,5 +1,0 @@
-const browserVersionsResolver = parent => {
-    return parent.browserVersions.map(each => each.browserVersion);
-};
-
-module.exports = browserVersionsResolver;

--- a/server/resolvers/Browser/index.js
+++ b/server/resolvers/Browser/index.js
@@ -1,7 +1,0 @@
-const browserVersions = require('./browserVersionsResolver');
-
-const Browser = {
-    browserVersions
-};
-
-module.exports = Browser;

--- a/server/resolvers/BrowserOperations/createBrowserVersionResolver.js
+++ b/server/resolvers/BrowserOperations/createBrowserVersionResolver.js
@@ -1,0 +1,25 @@
+const { AuthenticationError } = require('apollo-server');
+const {
+    getBrowserVersionByQuery,
+    createBrowserVersion
+} = require('../../models/services/BrowserService');
+
+const createBrowserVersionResolver = async (
+    { parentContext: { id: browserId } },
+    { name },
+    { user }
+) => {
+    if (!user?.roles.find(role => role.name === 'ADMIN')) {
+        throw new AuthenticationError();
+    }
+
+    let version = await getBrowserVersionByQuery({ browserId, name });
+
+    if (!version) {
+        version = await createBrowserVersion({ browserId, name });
+    }
+
+    return version;
+};
+
+module.exports = createBrowserVersionResolver;

--- a/server/resolvers/BrowserOperations/index.js
+++ b/server/resolvers/BrowserOperations/index.js
@@ -1,0 +1,3 @@
+const createBrowserVersion = require('./createBrowserVersionResolver');
+
+module.exports = { createBrowserVersion };

--- a/server/resolvers/BrowserVersionOperations/deleteBrowserVersionResolver.js
+++ b/server/resolvers/BrowserVersionOperations/deleteBrowserVersionResolver.js
@@ -1,0 +1,18 @@
+const { AuthenticationError } = require('apollo-server');
+const {
+    removeBrowserVersionById
+} = require('../../models/services/BrowserService');
+
+const deleteBrowserVersionResolver = async (
+    { parentContext: { id } },
+    _,
+    { user }
+) => {
+    if (!user?.roles.find(role => role.name === 'ADMIN')) {
+        throw new AuthenticationError();
+    }
+
+    return await removeBrowserVersionById(id);
+};
+
+module.exports = deleteBrowserVersionResolver;

--- a/server/resolvers/BrowserVersionOperations/editBrowserVersionResolver.js
+++ b/server/resolvers/BrowserVersionOperations/editBrowserVersionResolver.js
@@ -1,0 +1,25 @@
+const { AuthenticationError } = require('apollo-server');
+const {
+    updateBrowserVersionById
+} = require('../../models/services/BrowserService');
+
+const editBrowserVersionResolver = async (
+    { parentContext: { id } },
+    { updatedName },
+    { user }
+) => {
+    if (
+        !(
+            (
+                user?.roles.find(role => role.name === 'ADMIN') ||
+                user?.roles.find(role => role.name === 'TESTER')
+            ) // Tester is allowed to change Browser Version when it cannot be automatically detected
+        )
+    ) {
+        throw new AuthenticationError();
+    }
+
+    return await updateBrowserVersionById(id, { name: updatedName });
+};
+
+module.exports = editBrowserVersionResolver;

--- a/server/resolvers/BrowserVersionOperations/editBrowserVersionResolver.js
+++ b/server/resolvers/BrowserVersionOperations/editBrowserVersionResolver.js
@@ -8,14 +8,7 @@ const editBrowserVersionResolver = async (
     { updatedName },
     { user }
 ) => {
-    if (
-        !(
-            (
-                user?.roles.find(role => role.name === 'ADMIN') ||
-                user?.roles.find(role => role.name === 'TESTER')
-            ) // Tester is allowed to change Browser Version when it cannot be automatically detected
-        )
-    ) {
+    if (user === null) {
         throw new AuthenticationError();
     }
 

--- a/server/resolvers/BrowserVersionOperations/index.js
+++ b/server/resolvers/BrowserVersionOperations/index.js
@@ -1,0 +1,3 @@
+const editBrowserVersion = require('./editBrowserVersionResolver');
+
+module.exports = { editBrowserVersion };

--- a/server/resolvers/BrowserVersionOperations/index.js
+++ b/server/resolvers/BrowserVersionOperations/index.js
@@ -1,3 +1,4 @@
 const editBrowserVersion = require('./editBrowserVersionResolver');
+const deleteBrowserVersion = require('./deleteBrowserVersionResolver');
 
-module.exports = { editBrowserVersion };
+module.exports = { editBrowserVersion, deleteBrowserVersion };

--- a/server/resolvers/browsersResolver.js
+++ b/server/resolvers/browsersResolver.js
@@ -1,7 +1,7 @@
 const { getBrowsers } = require('../models/services/BrowserService');
 
 const browsersResolver = () => {
-    return getBrowsers(undefined, undefined, undefined, undefined, {
+    return getBrowsers(undefined, undefined, undefined, undefined, undefined, {
         order: [['name', 'asc']]
     });
 };

--- a/server/resolvers/browsersResolver.js
+++ b/server/resolvers/browsersResolver.js
@@ -1,7 +1,7 @@
 const { getBrowsers } = require('../models/services/BrowserService');
 
 const browsersResolver = () => {
-    return getBrowsers(undefined, undefined, undefined, undefined, undefined, {
+    return getBrowsers(undefined, undefined, undefined, undefined, {
         order: [['name', 'asc']]
     });
 };

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -20,7 +20,6 @@ const populateData = require('./populateDataResolver');
 const User = require('./User');
 const AtOperations = require('./AtOperations');
 const AtVersionOperations = require('./AtVersionOperations');
-const Browser = require('./Browser');
 const TestPlanVersion = require('./TestPlanVersion');
 const TestPlanReport = require('./TestPlanReport');
 const TestPlanReportOperations = require('./TestPlanReportOperations');
@@ -56,7 +55,6 @@ const resolvers = {
     },
     AtOperations,
     AtVersionOperations,
-    Browser,
     User,
     TestPlanVersion,
     TestPlanReport,

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -12,7 +12,8 @@ const testPlanRun = require('./testPlanRunResolver');
 const findOrCreateTestPlanReport = require('./findOrCreateTestPlanReportResolver');
 const mutateAt = require('./mutateAtResolver');
 const mutationAtVersion = require('./mutateAtVersionResolver');
-const mutateBrowserResolver = require('./mutateBrowserResolver');
+const mutateBrowser = require('./mutateBrowserResolver');
+const mutateBrowserVersion = require('./mutateBrowserVersionResolver');
 const mutateTestPlanReport = require('./mutateTestPlanReportResolver');
 const mutateTestPlanRun = require('./mutateTestPlanRunResolver');
 const mutateTestResult = require('./mutateTestResultResolver');
@@ -22,6 +23,7 @@ const User = require('./User');
 const AtOperations = require('./AtOperations');
 const AtVersionOperations = require('./AtVersionOperations');
 const BrowserOperations = require('./BrowserOperations');
+const BrowserVersionOperations = require('./BrowserVersionOperations');
 const TestPlanVersion = require('./TestPlanVersion');
 const TestPlanReport = require('./TestPlanReport');
 const TestPlanReportOperations = require('./TestPlanReportOperations');
@@ -49,7 +51,8 @@ const resolvers = {
     Mutation: {
         at: mutateAt,
         atVersion: mutationAtVersion,
-        browser: mutateBrowserResolver,
+        browser: mutateBrowser,
+        browserVersion: mutateBrowserVersion,
         testPlanReport: mutateTestPlanReport,
         testPlanRun: mutateTestPlanRun,
         testResult: mutateTestResult,
@@ -59,6 +62,7 @@ const resolvers = {
     AtOperations,
     AtVersionOperations,
     BrowserOperations,
+    BrowserVersionOperations,
     User,
     TestPlanVersion,
     TestPlanReport,

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -12,6 +12,7 @@ const testPlanRun = require('./testPlanRunResolver');
 const findOrCreateTestPlanReport = require('./findOrCreateTestPlanReportResolver');
 const mutateAt = require('./mutateAtResolver');
 const mutationAtVersion = require('./mutateAtVersionResolver');
+const mutateBrowserResolver = require('./mutateBrowserResolver');
 const mutateTestPlanReport = require('./mutateTestPlanReportResolver');
 const mutateTestPlanRun = require('./mutateTestPlanRunResolver');
 const mutateTestResult = require('./mutateTestResultResolver');
@@ -20,6 +21,7 @@ const populateData = require('./populateDataResolver');
 const User = require('./User');
 const AtOperations = require('./AtOperations');
 const AtVersionOperations = require('./AtVersionOperations');
+const BrowserOperations = require('./BrowserOperations');
 const TestPlanVersion = require('./TestPlanVersion');
 const TestPlanReport = require('./TestPlanReport');
 const TestPlanReportOperations = require('./TestPlanReportOperations');
@@ -47,6 +49,7 @@ const resolvers = {
     Mutation: {
         at: mutateAt,
         atVersion: mutationAtVersion,
+        browser: mutateBrowserResolver,
         testPlanReport: mutateTestPlanReport,
         testPlanRun: mutateTestPlanRun,
         testResult: mutateTestResult,
@@ -55,6 +58,7 @@ const resolvers = {
     },
     AtOperations,
     AtVersionOperations,
+    BrowserOperations,
     User,
     TestPlanVersion,
     TestPlanReport,

--- a/server/resolvers/mutateBrowserResolver.js
+++ b/server/resolvers/mutateBrowserResolver.js
@@ -1,0 +1,5 @@
+const mutateBrowserResolver = (_, { id }) => {
+    return { parentContext: { id } };
+};
+
+module.exports = mutateBrowserResolver;

--- a/server/resolvers/mutateBrowserVersionResolver.js
+++ b/server/resolvers/mutateBrowserVersionResolver.js
@@ -1,0 +1,5 @@
+const mutateBrowserVersionResolver = (_, { id }) => {
+    return { parentContext: { id } };
+};
+
+module.exports = mutateBrowserVersionResolver;

--- a/server/scripts/populate-test-data/pg_dump_2021_05_test_data.sql
+++ b/server/scripts/populate-test-data/pg_dump_2021_05_test_data.sql
@@ -52,17 +52,17 @@ INSERT INTO "AtVersion" ("atId", "name", "releasedAt") VALUES (3, '11.5.2', '202
 -- Data for Name: BrowserVersion; Type: TABLE DATA; Schema: public; Owner: atr
 --
 
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (1, '86.0');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (1, '86.0.1');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (1, '87.0');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (1, '88.0');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (1, '88.0.1');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (2, '90.0.4430');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (2, '91.0.4472');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (3, '13.0');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (3, '13.1');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (3, '14.0');
-INSERT INTO "BrowserVersion" ("browserId", "browserVersion") VALUES (3, '14.1');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (1, '86.0');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (1, '86.0.1');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (1, '87.0');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (1, '88.0');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (1, '88.0.1');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (2, '90.0.4430');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (2, '91.0.4472');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (3, '13.0');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (3, '13.1');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (3, '14.0');
+INSERT INTO "BrowserVersion" ("browserId", "name") VALUES (3, '14.1');
 
 
 --

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -537,6 +537,13 @@ describe('graphql', () => {
                                 name
                             }
                         }
+                        browserVersion(id: 1) {
+                            __typename
+                            editBrowserVersion(updatedName: "2022.5.4") {
+                                id
+                                name
+                            }
+                        }
                     }
                 `,
                 {

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -544,6 +544,10 @@ describe('graphql', () => {
                                 name
                             }
                         }
+                        deleteBrowserVersion: browserVersion(id: 2) {
+                            __typename
+                            deleteBrowserVersion
+                        }
                     }
                 `,
                 {

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -166,7 +166,11 @@ describe('graphql', () => {
                         __typename
                         id
                         name
-                        browserVersions
+                        browserVersions {
+                            __typename
+                            id
+                            name
+                        }
                     }
                     ats {
                         __typename
@@ -522,9 +526,16 @@ describe('graphql', () => {
                                 releasedAt
                             }
                         }
-                        deleteVersion: atVersion(id: 2) {
+                        deleteAtVersion: atVersion(id: 2) {
                             __typename
                             deleteAtVersion
+                        }
+                        browser(id: 1) {
+                            __typename
+                            createBrowserVersion(name: "2022.5.4") {
+                                id
+                                name
+                            }
                         }
                     }
                 `,

--- a/server/tests/integration/test-queue.test.js
+++ b/server/tests/integration/test-queue.test.js
@@ -253,7 +253,10 @@ describe('test queue', () => {
                 browsers {
                     id
                     name
-                    browserVersions
+                    browserVersions {
+                        id
+                        name
+                    }
                 }
                 testPlans {
                     latestTestPlanVersion {
@@ -279,7 +282,9 @@ describe('test queue', () => {
                     expect.objectContaining({
                         id: expect.anything(),
                         name: 'Firefox',
-                        browserVersions: expect.arrayContaining(['88.0'])
+                        browserVersions: expect.arrayContaining([
+                            expect.objectContaining({ name: '88.0' })
+                        ])
                     })
                 ])
             })

--- a/server/tests/models/BrowserVersion.spec.js
+++ b/server/tests/models/BrowserVersion.spec.js
@@ -18,9 +18,7 @@ describe('BrowserVersionModel', () => {
 
     describe('properties', () => {
         // A3
-        ['browserId', 'browserVersion'].forEach(
-            checkPropertyExists(modelInstance)
-        );
+        ['id', 'browserId', 'name'].forEach(checkPropertyExists(modelInstance));
     });
 
     describe('associations', () => {

--- a/server/tests/models/services/BrowserService.test.js
+++ b/server/tests/models/services/BrowserService.test.js
@@ -244,11 +244,12 @@ describe('BrowserVersionModel Data Checks', () => {
             null,
             []
         );
-        const { browserId, name } = browserVersionInstance;
+        const { id, browserId, name } = browserVersionInstance;
 
         // A3
         expect(browserId).toBeTruthy();
         expect(name).toBeTruthy();
+        expect(id).toBeTruthy();
         expect(browserVersionInstance).toEqual(
             expect.objectContaining({
                 id: expect.anything(),
@@ -289,13 +290,10 @@ describe('BrowserVersionModel Data Checks', () => {
                     name: _name
                 }
             );
-            const { browserId, name, browser } = browserVersionInstance;
+            const { id, browserId, name, browser } = browserVersionInstance;
 
             // A2
-            await BrowserService.removeBrowserVersionByQuery({
-                browserId,
-                name
-            });
+            await BrowserService.removeBrowserVersionById(id);
 
             const deletedBrowserVersion = await BrowserService.getBrowserVersionByQuery(
                 {
@@ -305,6 +303,7 @@ describe('BrowserVersionModel Data Checks', () => {
             );
 
             // after BrowserVersion created
+            expect(id).toBeTruthy();
             expect(browserId).toEqual(_browserId);
             expect(name).toEqual(_name);
             expect(browser).toHaveProperty('id');
@@ -329,16 +328,17 @@ describe('BrowserVersionModel Data Checks', () => {
                     name: _name
                 }
             );
-            const { browserId, name, browser } = browserVersionInstance;
+            const { id, browserId, name, browser } = browserVersionInstance;
 
             // A2
-            const updatedBrowserVersion = await BrowserService.updateBrowserVersionByQuery(
-                { browserId, name },
+            const updatedBrowserVersion = await BrowserService.updateBrowserVersionById(
+                id,
                 { name: _updatedName }
             );
             const { name: updatedName } = updatedBrowserVersion;
 
             // after BrowserVersion created
+            expect(id).toBeTruthy();
             expect(browserId).toEqual(_browserId);
             expect(name).toEqual(_name);
             expect(browser).toHaveProperty('id');

--- a/server/tests/models/services/BrowserService.test.js
+++ b/server/tests/models/services/BrowserService.test.js
@@ -200,25 +200,27 @@ describe('BrowserVersionModel Data Checks', () => {
     it('should return valid browserVersion with browser for query with all associations', async () => {
         // A1
         const _browserId = 1;
-        const _browserVersion = '86.0';
+        const _name = '86.0';
 
         // A2
         const browserVersionInstance = await BrowserService.getBrowserVersionByQuery(
             {
                 browserId: _browserId,
-                browserVersion: _browserVersion
+                name: _name
             }
         );
-        const { browserId, browserVersion, browser } = browserVersionInstance;
+        const { id, browserId, name, browser } = browserVersionInstance;
 
         // A3
         expect(browserId).toBeTruthy();
-        expect(browserVersion).toBeTruthy();
+        expect(name).toBeTruthy();
         expect(browser).toBeTruthy();
+        expect(id).toBeTruthy();
         expect(browserVersionInstance).toEqual(
             expect.objectContaining({
+                id: expect.anything(),
                 browserId: _browserId,
-                browserVersion: _browserVersion,
+                name: _name,
                 browser: expect.objectContaining({
                     id: _browserId,
                     name: expect.any(String)
@@ -231,26 +233,27 @@ describe('BrowserVersionModel Data Checks', () => {
     it('should return valid browserVersionInstance for query with no associations', async () => {
         // A1
         const _browserId = 1;
-        const _browserVersion = '86.0';
+        const _name = '86.0';
 
         // A2
         const browserVersionInstance = await BrowserService.getBrowserVersionByQuery(
             {
                 browserId: _browserId,
-                browserVersion: _browserVersion
+                name: _name
             },
             null,
             []
         );
-        const { browserId, browserVersion } = browserVersionInstance;
+        const { browserId, name } = browserVersionInstance;
 
         // A3
         expect(browserId).toBeTruthy();
-        expect(browserVersion).toBeTruthy();
+        expect(name).toBeTruthy();
         expect(browserVersionInstance).toEqual(
             expect.objectContaining({
+                id: expect.anything(),
                 browserId: _browserId,
-                browserVersion: _browserVersion
+                name: _name
             })
         );
         expect(browserVersionInstance).not.toHaveProperty('browser');
@@ -259,13 +262,13 @@ describe('BrowserVersionModel Data Checks', () => {
     it('should not be valid browserVersion query', async () => {
         // A1
         const _browserId = 53935;
-        const _browserVersion = randomStringGenerator();
+        const _name = randomStringGenerator();
 
         // A2
         const browserVersionInstance = await BrowserService.getBrowserVersionByQuery(
             {
                 browserId: _browserId,
-                browserVersion: _browserVersion
+                name: _name
             }
         );
 
@@ -277,37 +280,33 @@ describe('BrowserVersionModel Data Checks', () => {
         await dbCleaner(async () => {
             // A1
             const _browserId = 1;
-            const _browserVersion = randomStringGenerator();
+            const _name = randomStringGenerator();
 
             // A2
             const browserVersionInstance = await BrowserService.createBrowserVersion(
                 {
                     browserId: _browserId,
-                    browserVersion: _browserVersion
+                    name: _name
                 }
             );
-            const {
-                browserId,
-                browserVersion,
-                browser
-            } = browserVersionInstance;
+            const { browserId, name, browser } = browserVersionInstance;
 
             // A2
             await BrowserService.removeBrowserVersionByQuery({
                 browserId,
-                browserVersion
+                name
             });
 
             const deletedBrowserVersion = await BrowserService.getBrowserVersionByQuery(
                 {
                     browserId,
-                    browserVersion
+                    name
                 }
             );
 
             // after BrowserVersion created
             expect(browserId).toEqual(_browserId);
-            expect(browserVersion).toEqual(_browserVersion);
+            expect(name).toEqual(_name);
             expect(browser).toHaveProperty('id');
             expect(browser).toHaveProperty('name');
 
@@ -320,39 +319,35 @@ describe('BrowserVersionModel Data Checks', () => {
         await dbCleaner(async () => {
             // A1
             const _browserId = 1;
-            const _browserVersion = randomStringGenerator();
-            const _updatedVersion = randomStringGenerator();
+            const _name = randomStringGenerator();
+            const _updatedName = randomStringGenerator();
 
             // A2
             const browserVersionInstance = await BrowserService.createBrowserVersion(
                 {
                     browserId: _browserId,
-                    browserVersion: _browserVersion
+                    name: _name
                 }
             );
-            const {
-                browserId,
-                browserVersion,
-                browser
-            } = browserVersionInstance;
+            const { browserId, name, browser } = browserVersionInstance;
 
             // A2
             const updatedBrowserVersion = await BrowserService.updateBrowserVersionByQuery(
-                { browserId, browserVersion },
-                { browserVersion: _updatedVersion }
+                { browserId, name },
+                { name: _updatedName }
             );
-            const { browserVersion: updatedVersion } = updatedBrowserVersion;
+            const { name: updatedName } = updatedBrowserVersion;
 
             // after BrowserVersion created
             expect(browserId).toEqual(_browserId);
-            expect(browserVersion).toEqual(_browserVersion);
+            expect(name).toEqual(_name);
             expect(browser).toHaveProperty('id');
             expect(browser).toHaveProperty('name');
 
             // after browserVersion updated
-            expect(_browserVersion).not.toEqual(_updatedVersion);
-            expect(browserVersion).not.toEqual(updatedVersion);
-            expect(updatedVersion).toEqual(_updatedVersion);
+            expect(_name).not.toEqual(_updatedName);
+            expect(name).not.toEqual(updatedName);
+            expect(updatedName).toEqual(_updatedName);
         });
     });
 
@@ -360,19 +355,19 @@ describe('BrowserVersionModel Data Checks', () => {
         await dbCleaner(async () => {
             // A1
             const _browserId = 1;
-            const _browserVersion = '86.0';
+            const _name = '86.0';
 
             // A2
             const originalBrowserVersion = await BrowserService.getBrowserVersionByQuery(
                 {
                     browserId: _browserId,
-                    browserVersion: _browserVersion
+                    name: _name
                 }
             );
             const updatedBrowserVersion = await BrowserService.updateBrowserVersionByQuery(
                 {
                     browserId: _browserId,
-                    browserVersion: _browserVersion
+                    name: _name
                 }
             );
 
@@ -390,8 +385,9 @@ describe('BrowserVersionModel Data Checks', () => {
         expect(result).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
+                    id: expect.anything(),
                     browserId: expect.any(Number),
-                    browserVersion: expect.any(String),
+                    name: expect.any(String),
                     browser: expect.objectContaining({
                         id: expect.any(Number),
                         name: expect.any(String)
@@ -415,7 +411,7 @@ describe('BrowserVersionModel Data Checks', () => {
             expect.arrayContaining([
                 expect.objectContaining({
                     browserId: expect.any(Number),
-                    browserVersion: expect.stringMatching(/87/gi),
+                    name: expect.stringMatching(/87/gi),
                     browser: expect.objectContaining({
                         id: expect.any(Number),
                         name: expect.any(String)
@@ -430,7 +426,7 @@ describe('BrowserVersionModel Data Checks', () => {
         const result = await BrowserService.getBrowserVersions(
             '',
             {},
-            ['browserVersion'],
+            ['id', 'name'],
             [],
             { enablePagination: true }
         );
@@ -446,7 +442,8 @@ describe('BrowserVersionModel Data Checks', () => {
                 pagesCount: expect.any(Number),
                 data: expect.arrayContaining([
                     expect.objectContaining({
-                        browserVersion: expect.any(String)
+                        id: expect.anything(),
+                        name: expect.any(String)
                     })
                 ])
             })


### PR DESCRIPTION
This PR handles [ENV DATA: 20. Update Browser table and resolvers](https://app.asana.com/0/1201709804960055/1202219817103347). The following changes have been made:

- Migration for the BrowserVersion table to support id primary keys and column change from `browserVersion` to `name`
- Update GraphQL schema to support BrowserVersion type and CRUD mutations for Browser and Browser Version
- Update backend Models and tests to handle database changes and support the resolver functions

To test in dev:
- Run the latest migration for dev: `yarn sequelize db:migrate;`
- Go to localhost:3000/api/graphql to try out the mutations

For running jest tests, rebuild the test database by dropping the `aria_at_report_test` database and afterwards, running through [these docs](https://github.com/w3c/aria-at-app/blob/main/docs/database.md#test-database)
