### PR TITLE
Fix Safari TestRenderer not correctly re-rendering

### DIFF
--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -1,4 +1,10 @@
-import React, { Fragment, useEffect, useLayoutEffect, useState } from 'react';
+import React, {
+    Fragment,
+    useEffect,
+    useLayoutEffect,
+    useState,
+    useRef
+} from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import nextId from 'react-id-generator';
@@ -222,14 +228,16 @@ const TestRenderer = ({
     testResult = {},
     testPageUrl,
     testRunStateRef,
+    recentTestRunStateRef,
     testRunResultRef,
     submitButtonRef,
     isSubmitted = false,
-    setIsRendererReady = () => {}
+    setIsRendererReady = false
 }) => {
     const { scenarioResults, test = {}, completedAt } = testResult;
     const { renderableContent } = test;
 
+    const mounted = useRef(false);
     const [testRunExport, setTestRunExport] = useState();
     const [pageContent, setPageContent] = useState(null);
     const [testRendererState, setTestRendererState] = useState(null);
@@ -280,8 +288,8 @@ const TestRenderer = ({
             resultsJSON: state => testRunIO.submitResultsJSON(state),
             state: _state
         });
-        setTestRendererState(_state);
-        setTestRunExport(testRunExport);
+        mounted.current && setTestRendererState(_state);
+        mounted.current && setTestRunExport(testRunExport);
     };
 
     const remapState = (state, scenarioResults = []) => {
@@ -368,7 +376,13 @@ const TestRenderer = ({
     };
 
     useEffect(() => {
-        (async () => await setup())();
+        (async () => {
+            mounted.current = true;
+            await setup();
+        })();
+        return () => {
+            mounted.current = false;
+        };
     }, []);
 
     useLayoutEffect(() => {
@@ -382,6 +396,7 @@ const TestRenderer = ({
                 setSubmitResult(submitResult);
 
                 testRunStateRef.current = newState;
+                recentTestRunStateRef.current = newState;
                 testRunResultRef.current =
                     submitResult &&
                     submitResult.resultsJSON &&
@@ -394,16 +409,21 @@ const TestRenderer = ({
         }
 
         testRunStateRef.current = testRendererState;
-
+        recentTestRunStateRef.current = testRendererState;
         setIsRendererReady(true);
     }, [testRunExport]);
 
     useEffect(() => {
         if (!submitCalled && completedAt && pageContent) {
             testRunStateRef.current = testRendererState;
+            recentTestRunStateRef.current = testRendererState;
             pageContent.submit.click();
             setSubmitCalled(true);
         }
+        return () => {
+            setSubmitCalled(false);
+            testRunStateRef.current = null;
+        };
     }, [pageContent]);
 
     const parseRichContent = (instruction = []) => {
@@ -1119,6 +1139,7 @@ const TestRenderer = ({
                         hidden
                         onClick={() => {
                             testRunStateRef.current = testRendererState;
+                            recentTestRunStateRef.current = testRendererState;
                             pageContent.submit.click();
                         }}
                     >
@@ -1140,6 +1161,7 @@ TestRenderer.propTypes = {
     support: PropTypes.object,
     testPageUrl: PropTypes.string,
     testRunStateRef: PropTypes.any,
+    recentTestRunStateRef: PropTypes.any,
     testRunResultRef: PropTypes.any,
     submitButtonRef: PropTypes.any,
     isSubmitted: PropTypes.bool,

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -232,6 +232,7 @@ const TestRenderer = ({
     testRunResultRef,
     submitButtonRef,
     isSubmitted = false,
+    isEdit = false,
     setIsRendererReady = false
 }) => {
     const { scenarioResults, test = {}, completedAt } = testResult;
@@ -627,7 +628,8 @@ const TestRenderer = ({
 
     return (
         <Container>
-            {submitResult &&
+            {!isEdit &&
+            submitResult &&
             submitResult.resultsJSON &&
             submitResult.results ? (
                 <SubmitResultsContent />
@@ -1165,6 +1167,7 @@ TestRenderer.propTypes = {
     testRunResultRef: PropTypes.any,
     submitButtonRef: PropTypes.any,
     isSubmitted: PropTypes.bool,
+    isEdit: PropTypes.bool,
     setIsRendererReady: PropTypes.func
 };
 

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -100,6 +100,7 @@ const TestRun = () => {
 
     const [isRendererReady, setIsRendererReady] = useState(false);
     const [isTestSubmitClicked, setIsTestSubmitClicked] = useState(false);
+    const [isTestEditClicked, setIsTestEditClicked] = useState(false);
     const [showTestNavigator, setShowTestNavigator] = useState(true);
     const [currentTestIndex, setCurrentTestIndex] = useState(0);
     const [showStartOverModal, setShowStartOverModal] = useState(false);
@@ -369,6 +370,9 @@ const TestRun = () => {
             forceSave = false,
             forceEdit = false
         ) => {
+            if (forceEdit) setIsTestEditClicked(true);
+            else setIsTestEditClicked(false);
+
             if (!isSignedIn) return true;
             if (!forceEdit && currentTest.testResult.completedAt) return true;
 
@@ -644,6 +648,7 @@ const TestRun = () => {
                                             testRendererSubmitButtonRef
                                         }
                                         isSubmitted={isTestSubmitClicked}
+                                        isEdit={isTestEditClicked}
                                         setIsRendererReady={setIsRendererReady}
                                     />
                                 </Row>


### PR DESCRIPTION
An edge case was found for the TestRenderer component when submitting the form information on Safari. It appears that there is an inconsistent timing with how React's `useLayoutEffect` hook works on Safari.

How this should work is that after populating the testing tasks' fields on the Test Run page and submitting the form, the request would be sent off to the server to be submitted to the database and through a re-render of the TestRenderer component, the summary table of the submission is presented. This works as expected on Chrome and Firefox.
When submitted on Safari, the form data is cleared and errors are displayed for all the fields (although the data was successfully submitted to the database)

This PR addresses this by doing necessary hook method cleanups and with an additional temporary fix to address another issue around using the edit form functionality introduced by the cleanup of the hook methods.

Known Issues:

- [x] Brief flicker when using `Edit Results` functionality