### PR TITLE
Accessibility fixes for combobox and disclosures

### DIFF
--- a/client/components/ManageTestQueue/index.jsx
+++ b/client/components/ManageTestQueue/index.jsx
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import BasicModal from '../common/BasicModal';
 import UpdateVersionModal from '../common/UpdateVersionModal';
 import BasicThemedModal from '../common/BasicThemedModal';
+import SelectCombobox from '../common/SelectCombobox';
 import {
     ADD_AT_VERSION_MUTATION,
     EDIT_AT_VERSION_MUTATION,
@@ -139,6 +140,10 @@ const DisclosureContainer = styled.div`
         grid-auto-flow: column;
         grid-template-columns: 1fr 1fr 1fr 1fr;
         grid-gap: 1rem;
+    }
+
+    .form-group {
+        min-width: 100%;
     }
 
     .disclosure-form-label {
@@ -268,20 +273,16 @@ const ManageTestQueue = ({
         setSelectedTestPlanVersionId(matchingTestPlanVersions[0].id);
     };
 
-    const onManageAtChange = e => {
-        const { value } = e.target;
-        if (selectedManageAtId !== value) {
-            setSelectedManageAtId(value);
-            const at = ats.find(item => item.id === value);
+    const onManageAtChange = id => {
+        if (selectedManageAtId !== id) {
+            setSelectedManageAtId(id);
+            const at = ats.find(item => item.id === id);
             setSelectedManageAtVersions(at.atVersions);
             setSelectedManageAtVersionId(at.atVersions[0].id);
         }
     };
 
-    const onManageAtVersionChange = e => {
-        const { value } = e.target;
-        setSelectedManageAtVersionId(value);
-    };
+    const onManageAtVersionChange = id => setSelectedManageAtVersionId(id);
 
     const onOpenAtVersionModalClick = (type = 'add') => {
         if (type === 'add') {
@@ -357,20 +358,11 @@ const ManageTestQueue = ({
         return selectedManageAtVersions.find(item => id === item.id);
     };
 
-    const onAtChange = e => {
-        const { value } = e.target;
-        setSelectedAtId(value);
-    };
+    const onAtChange = id => setSelectedAtId(id);
 
-    const onBrowserChange = e => {
-        const { value } = e.target;
-        setSelectedBrowserId(value);
-    };
+    const onBrowserChange = id => setSelectedBrowserId(id);
 
-    const onTestPlanVersionChange = e => {
-        const { value } = e.target;
-        setSelectedTestPlanVersionId(value);
-    };
+    const onTestPlanVersionChange = id => setSelectedTestPlanVersionId(id);
 
     const onUpdateAtVersionAction = async (
         actionType,
@@ -562,40 +554,32 @@ const ManageTestQueue = ({
                         <Form.Label className="disclosure-form-label">
                             Assistive Technology
                         </Form.Label>
-                        <Form.Control
-                            as="select"
-                            value={selectedManageAtId}
-                            onChange={onManageAtChange}
-                        >
-                            {ats.map(item => (
-                                <option
-                                    key={`manage-${item.name}-${item.id}`}
-                                    value={item.id}
-                                >
-                                    {item.name}
-                                </option>
-                            ))}
-                        </Form.Control>
+                        <SelectCombobox
+                            id="manageAt"
+                            options={ats.map(item => {
+                                return {
+                                    value: item.id,
+                                    displayValue: item.name
+                                };
+                            })}
+                            onOptionSelect={onManageAtChange}
+                        />
                     </Form.Group>
                     <div className="at-versions-container">
                         <Form.Group>
                             <Form.Label className="disclosure-form-label">
                                 Available Versions
                             </Form.Label>
-                            <Form.Control
-                                as="select"
-                                value={selectedManageAtVersionId}
-                                onChange={onManageAtVersionChange}
-                            >
-                                {selectedManageAtVersions.map(item => (
-                                    <option
-                                        key={`${selectedManageAtId}-${item.id}-${item.name}`}
-                                        value={item.id}
-                                    >
-                                        {item.name}
-                                    </option>
-                                ))}
-                            </Form.Control>
+                            <SelectCombobox
+                                id="manageAtVersion"
+                                options={selectedManageAtVersions.map(item => {
+                                    return {
+                                        value: item.id,
+                                        displayValue: item.name
+                                    };
+                                })}
+                                onOptionSelect={onManageAtVersionChange}
+                            />
                         </Form.Group>
                         <div className="disclosure-buttons-row">
                             <button
@@ -645,92 +629,86 @@ const ManageTestQueue = ({
                         <Form.Label className="disclosure-form-label">
                             Test Plan
                         </Form.Label>
-                        <Form.Control
-                            as="select"
-                            onChange={e => {
-                                const { value } = e.target;
+                        <SelectCombobox
+                            id="filteredTestPlanVersions"
+                            options={filteredTestPlanVersions.map(item => {
+                                return {
+                                    value: item.id,
+                                    displayValue: `${item.title ||
+                                        item.testPlan.directory}`
+                                };
+                            })}
+                            onOptionSelect={value => {
                                 updateMatchingTestPlanVersions(
                                     value,
                                     allTestPlanVersions
                                 );
                             }}
-                        >
-                            {filteredTestPlanVersions.map(item => (
-                                <option
-                                    key={`${item.title ||
-                                        item.testPlan.directory}-${item.id}`}
-                                    value={item.id}
-                                >
-                                    {item.title ||
-                                        `"${item.testPlan.directory}"`}
-                                </option>
-                            ))}
-                        </Form.Control>
+                        />
                     </Form.Group>
                     <Form.Group>
                         <Form.Label className="disclosure-form-label">
                             Test Plan Version
                         </Form.Label>
-                        <Form.Control
-                            as="select"
-                            value={selectedTestPlanVersionId}
-                            onChange={onTestPlanVersionChange}
-                        >
-                            {matchingTestPlanVersions.map(item => (
-                                <option
-                                    key={`${item.gitSha}-${item.id}`}
-                                    value={item.id}
-                                >
-                                    {gitUpdatedDateToString(item.updatedAt)}{' '}
-                                    {item.gitMessage} (
-                                    {item.gitSha.substring(0, 7)})
-                                </option>
-                            ))}
-                        </Form.Control>
+                        <SelectCombobox
+                            id="matchingTestPlanVersions"
+                            options={matchingTestPlanVersions.map(item => {
+                                return {
+                                    value: item.id,
+                                    displayValue: `${gitUpdatedDateToString(
+                                        item.updatedAt
+                                    )} ${
+                                        item.gitMessage
+                                    } (${item.gitSha.substring(0, 7)})`
+                                };
+                            })}
+                            onOptionSelect={onTestPlanVersionChange}
+                        />
                     </Form.Group>
                     <Form.Group>
                         <Form.Label className="disclosure-form-label">
                             Assistive Technology
                         </Form.Label>
-                        <Form.Control
-                            as="select"
-                            value={selectedAtId}
-                            onChange={onAtChange}
-                        >
-                            <option value={''} disabled>
-                                --
-                            </option>
-                            {ats.map(item => (
-                                <option
-                                    key={`${item.name}-${item.id}`}
-                                    value={item.id}
-                                >
-                                    {item.name}
-                                </option>
-                            ))}
-                        </Form.Control>
+                        <SelectCombobox
+                            id="at"
+                            options={[
+                                {
+                                    value: -1,
+                                    displayValue:
+                                        'Select an Assistive Technology',
+                                    disabled: true
+                                },
+                                ...ats.map(item => {
+                                    return {
+                                        value: item.id,
+                                        displayValue: item.name
+                                    };
+                                })
+                            ]}
+                            onOptionSelect={onAtChange}
+                        />
                     </Form.Group>
                     <Form.Group>
                         <Form.Label className="disclosure-form-label">
                             Browser
                         </Form.Label>
-                        <Form.Control
-                            as="select"
-                            value={selectedBrowserId}
-                            onChange={onBrowserChange}
-                        >
-                            <option value={''} disabled>
-                                --
-                            </option>
-                            {browsers.map(item => (
-                                <option
-                                    key={`${item.name}-${item.id}`}
-                                    value={item.id}
-                                >
-                                    {item.name}
-                                </option>
-                            ))}
-                        </Form.Control>
+                        <SelectCombobox
+                            id="browser"
+                            options={[
+                                {
+                                    value: -1,
+                                    displayValue: 'Select a Browser',
+                                    disabled: true
+                                },
+                                ...browsers.map(item => {
+                                    return {
+                                        value: item.id,
+                                        displayValue: item.name
+                                    };
+                                })
+                            ]}
+                            onOptionSelect={onBrowserChange}
+                        />
                     </Form.Group>
                 </div>
                 <Button

--- a/client/components/ManageTestQueue/index.jsx
+++ b/client/components/ManageTestQueue/index.jsx
@@ -26,6 +26,11 @@ import { convertStringToDate } from '../../utils/formatter';
 const Container = styled.div`
     border: 1px solid #d3d5da;
     border-radius: 3px;
+
+    h3 {
+        margin: 0;
+        padding: 0;
+    }
 `;
 
 const DisclosureButton = styled.button`
@@ -40,24 +45,21 @@ const DisclosureButton = styled.button`
     border-radius: 3px;
     background-color: transparent;
 
+    &.top-border {
+        border-top: 1px solid #d3d5da;
+    }
+
     &:nth-of-type(1) {
         border-radius: 3px 3px 0 0;
     }
 
     &:nth-last-of-type(1) {
-        border-top: 1px solid #d3d5da;
         border-radius: 0 0 3px 3px;
-
-        &:hover,
-        &:focus {
-            border-top: 1px solid #d3d5da;
-        }
     }
 
     &:hover,
     &:focus {
         padding: 1.25rem;
-        border: 0 solid #005a9c;
         background-color: #def;
         cursor: pointer;
     }
@@ -533,18 +535,26 @@ const ManageTestQueue = ({
 
     return (
         <Container>
-            <DisclosureButton
-                type="button"
-                aria-expanded={showManageATs}
-                aria-controls="id_manage_ats"
-                onClick={onManageAtsClick}
+            <h3>
+                <DisclosureButton
+                    id="id_manage_ats_button"
+                    type="button"
+                    aria-expanded={showManageATs}
+                    aria-controls="id_manage_ats"
+                    onClick={onManageAtsClick}
+                >
+                    Manage Assistive Technology Versions
+                    <FontAwesomeIcon
+                        icon={showManageATs ? faChevronUp : faChevronDown}
+                    />
+                </DisclosureButton>
+            </h3>
+            <DisclosureContainer
+                role="region"
+                id="id_manage_ats"
+                aria-labelledby="id_manage_ats_button"
+                show={showManageATs}
             >
-                Manage Assistive Technology Versions
-                <FontAwesomeIcon
-                    icon={showManageATs ? faChevronUp : faChevronDown}
-                />
-            </DisclosureButton>
-            <DisclosureContainer id="id_manage_ats" show={showManageATs}>
                 <span>
                     Select an Assistive Technology and manage its versions in
                     the ARIA-AT App
@@ -608,18 +618,27 @@ const ManageTestQueue = ({
                     </div>
                 </div>
             </DisclosureContainer>
-            <DisclosureButton
-                type="button"
-                aria-expanded={showAddTestPlans}
-                aria-controls="id_test_plans"
-                onClick={onAddTestPlansClick}
+            <h3>
+                <DisclosureButton
+                    id="id_test_plans_button"
+                    type="button"
+                    aria-expanded={showAddTestPlans}
+                    aria-controls="id_test_plans"
+                    onClick={onAddTestPlansClick}
+                    className="top-border"
+                >
+                    Add Test Plans to the Test Queue
+                    <FontAwesomeIcon
+                        icon={showAddTestPlans ? faChevronUp : faChevronDown}
+                    />
+                </DisclosureButton>
+            </h3>
+            <DisclosureContainer
+                role="region"
+                id="id_test_plans"
+                aria-labelledby="id_test_plans_button"
+                show={showAddTestPlans}
             >
-                Add Test Plans to the Test Queue
-                <FontAwesomeIcon
-                    icon={showAddTestPlans ? faChevronUp : faChevronDown}
-                />
-            </DisclosureButton>
-            <DisclosureContainer id="id_test_plans" show={showAddTestPlans}>
                 <span>
                     Select a Test Plan and version and an Assistive Technology
                     and Browser to add it to the Test Queue

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -22,6 +22,11 @@ import DisclaimerInfo from '../DisclaimerInfo';
 const DisclosureParent = styled.div`
     border: 1px solid #d3d5da;
     border-radius: 3px;
+
+    h3 {
+        margin: 0;
+        padding: 0;
+    }
 `;
 
 const DisclosureButton = styled.button`
@@ -366,23 +371,32 @@ const SummarizeTestPlanReport = ({ testPlanReport }) => {
                         </Table>
 
                         <DisclosureParent>
-                            <DisclosureButton
-                                type="button"
-                                aria-expanded={!!runHistoryItems[testResult.id]}
-                                aria-controls={`run-history-${testResult.id}`}
-                                onClick={() => onClickRunHistory(testResult.id)}
-                            >
-                                Run History
-                                <FontAwesomeIcon
-                                    icon={
-                                        runHistoryItems[testResult.id]
-                                            ? faChevronUp
-                                            : faChevronDown
+                            <h3>
+                                <DisclosureButton
+                                    id={`run-history-${testResult.id}-button`}
+                                    type="button"
+                                    aria-expanded={
+                                        !!runHistoryItems[testResult.id]
                                     }
-                                />
-                            </DisclosureButton>
+                                    aria-controls={`run-history-${testResult.id}`}
+                                    onClick={() =>
+                                        onClickRunHistory(testResult.id)
+                                    }
+                                >
+                                    Run History
+                                    <FontAwesomeIcon
+                                        icon={
+                                            runHistoryItems[testResult.id]
+                                                ? faChevronUp
+                                                : faChevronDown
+                                        }
+                                    />
+                                </DisclosureButton>
+                            </h3>
                             <DisclosureContainer
+                                role="region"
                                 id={`run-history-${testResult.id}`}
+                                aria-labelledby={`run-history-${testResult.id}-button`}
                                 show={!!runHistoryItems[testResult.id]}
                             >
                                 {getTestersRunHistory(

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -7,8 +7,9 @@ import {
     faInfoCircle,
     faExclamationTriangle
 } from '@fortawesome/free-solid-svg-icons';
-import { useDetectUa } from '../../../hooks/useDetectUa';
 import BasicModal from '../BasicModal';
+import SelectCombobox from '../SelectCombobox';
+import { useDetectUa } from '../../../hooks/useDetectUa';
 
 const ModalInnerSectionContainer = styled.div`
     display: flex;
@@ -119,15 +120,12 @@ const AtAndBrowserDetailsModal = ({
         else setBrowserVersionMismatchMessage(!isAdmin && false);
     }, [updatedBrowserVersion, uaMajor, uaMinor, uaPatch]);
 
-    const handleAtVersionChange = e => {
-        const value = e.target.value;
-        setUpdatedAtVersion(value);
+    const handleAtVersionChange = id => {
+        setUpdatedAtVersion(id);
         setIsAtVersionError(false);
     };
 
-    const handleBrowserVersionChange = (e, setFreeTextBrowserVersion) => {
-        const value = e.target.value;
-
+    const handleBrowserVersionChange = (value, setFreeTextBrowserVersion) => {
         if (setFreeTextBrowserVersion) setFreeTextBrowserVersion(value);
         else setUpdatedBrowserVersion(value);
 
@@ -225,27 +223,27 @@ const AtAndBrowserDetailsModal = ({
                             <Form.Label>
                                 Assistive Technology Version
                             </Form.Label>
-                            <Form.Control
+                            <SelectCombobox
                                 ref={updatedAtVersionDropdownRef}
-                                as="select"
-                                value={updatedAtVersion}
-                                onChange={handleAtVersionChange}
+                                id="atVersion"
+                                options={[
+                                    {
+                                        value: -1,
+                                        displayValue: 'Select a Version',
+                                        disabled: true
+                                    },
+                                    ...atVersions.map(item => {
+                                        return {
+                                            value: item,
+                                            displayValue: item,
+                                            isSelected:
+                                                item === updatedAtVersion
+                                        };
+                                    })
+                                ]}
+                                onOptionSelect={handleAtVersionChange}
                                 isInvalid={isAtVersionError}
-                            >
-                                {['Select a Version', ...atVersions].map(
-                                    item => (
-                                        <option
-                                            key={`atVersionKey-${item}`}
-                                            value={item}
-                                            disabled={
-                                                item === 'Select a Version'
-                                            }
-                                        >
-                                            {item}
-                                        </option>
-                                    )
-                                )}
-                            </Form.Control>
+                            />
                             {isAtVersionError && (
                                 <Form.Control.Feedback
                                     style={{ display: 'block' }}
@@ -441,7 +439,11 @@ const AtAndBrowserDetailsModal = ({
                                         ref={adminFreeTextBrowserVersionRef}
                                         type="text"
                                         value={updatedBrowserVersion}
-                                        onChange={handleBrowserVersionChange}
+                                        onChange={e => {
+                                            handleBrowserVersionChange(
+                                                e.target.value
+                                            );
+                                        }}
                                         isInvalid={
                                             isAdminFreeTextBrowserVersionError
                                         }
@@ -457,27 +459,21 @@ const AtAndBrowserDetailsModal = ({
                                     )}
                                 </>
                             ) : (
-                                <Form.Control
-                                    as="select"
-                                    disabled={uaMajor === '0'}
-                                    value={updatedBrowserVersion}
-                                    onChange={handleBrowserVersionChange}
-                                >
-                                    {(uaMajor === '0'
-                                        ? [
-                                              'Not detected',
-                                              ...updatedBrowserVersions
-                                          ]
+                                <SelectCombobox
+                                    id="browserVersion"
+                                    options={(uaMajor === '0'
+                                        ? ['Not detected']
                                         : updatedBrowserVersions
-                                    ).map(item => (
-                                        <option
-                                            key={`browserVersionKey-${item}`}
-                                            value={item}
-                                        >
-                                            {item}
-                                        </option>
-                                    ))}
-                                </Form.Control>
+                                    ).map(item => ({
+                                        value: item,
+                                        displayValue: item,
+                                        isSelected: updatedBrowserVersion.includes(
+                                            item
+                                        )
+                                    }))}
+                                    isDisabled={uaMajor === '0'}
+                                    onOptionSelect={handleBrowserVersionChange}
+                                />
                             )}
                         </Form.Group>
 
@@ -490,7 +486,7 @@ const AtAndBrowserDetailsModal = ({
                                     value={freeTextBrowserVersion}
                                     onChange={e =>
                                         handleBrowserVersionChange(
-                                            e,
+                                            e.target.value,
                                             setFreeTextBrowserVersion
                                         )
                                     }

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -467,9 +467,8 @@ const AtAndBrowserDetailsModal = ({
                                     ).map(item => ({
                                         value: item,
                                         displayValue: item,
-                                        isSelected: updatedBrowserVersion.includes(
-                                            item
-                                        )
+                                        isSelected:
+                                            item === updatedBrowserVersion
                                     }))}
                                     isDisabled={uaMajor === '0'}
                                     onOptionSelect={handleBrowserVersionChange}

--- a/client/components/common/SelectCombobox/index.jsx
+++ b/client/components/common/SelectCombobox/index.jsx
@@ -1,0 +1,471 @@
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+    width: inherit;
+    max-width: inherit;
+
+    ::after {
+        border-bottom: 2px solid rgb(0 0 0 / 75%);
+        border-right: 2px solid rgb(0 0 0 / 75%);
+        content: '';
+        display: block;
+        height: 12px;
+        pointer-events: none;
+        position: absolute;
+        right: 16px;
+        top: 50%;
+        transform: translate(0, -65%) rotate(45deg);
+        width: 12px;
+    }
+`;
+
+const Combobox = styled.div`
+    word-wrap: normal;
+    text-transform: none;
+    margin: 0;
+    font-family: inherit;
+    cursor: default;
+
+    :focus {
+        color: #495057;
+        background-color: #fff;
+        border-color: #80bdff;
+        outline: 0;
+        box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+    }
+`;
+
+const Listbox = styled.div`
+    display: ${({ open }) => (open ? 'block' : 'none')};
+
+    position: absolute;
+    padding: 0;
+    color: #495057;
+
+    max-height: 200px;
+    overflow-y: hidden;
+
+    z-index: 100;
+
+    background-color: #fff;
+    border: 1px solid #ced4da;
+    border-radius: 0.25rem;
+`;
+
+const Option = styled.option`
+    padding: 0.375rem 2rem;
+    background-color: ${({ current }) => (current ? 'rgb(0 0 0 / 10%)' : '')};
+    cursor: default;
+
+    :hover {
+        background-color: rgb(0 0 0 / 10%);
+    }
+
+    &[aria-selected='true'] {
+        position: relative;
+    }
+
+    &[aria-selected='true']::before {
+        position: absolute;
+
+        width: 6px;
+        height: 12px;
+
+        left: 12px;
+        top: 50%;
+
+        border-bottom: 2px solid #495057;
+        border-right: 2px solid #495057;
+        content: '';
+        transform: translate(0, -50%) rotate(45deg);
+    }
+`;
+
+// Save a list of named combobox actions
+const SelectActions = {
+    Close: 0,
+    CloseSelect: 1,
+    First: 2,
+    Last: 3,
+    Next: 4,
+    Open: 5,
+    PageDown: 6,
+    PageUp: 7,
+    Previous: 8,
+    Select: 9,
+    Type: 10
+};
+
+/*
+ * Helper functions
+ */
+
+// filter an array of options against an input string
+// returns an array of options that begin with the filter string, case-independent
+function filterOptions(options = [], filter, exclude = []) {
+    return options.filter(option => {
+        const matches =
+            option.toLowerCase().indexOf(filter.toLowerCase()) === 0;
+        return matches && exclude.indexOf(option) < 0;
+    });
+}
+
+// map a key press to an action
+function getActionFromKey(event, menuOpen) {
+    const { key, altKey, ctrlKey, metaKey } = event;
+    const openKeys = ['ArrowDown', 'ArrowUp', 'Enter', ' ']; // all keys that will do the default open action
+    // handle opening when closed
+    if (!menuOpen && openKeys.includes(key)) {
+        return SelectActions.Open;
+    }
+
+    // home and end move the selected option when open or closed
+    if (key === 'Home') {
+        return SelectActions.First;
+    }
+    if (key === 'End') {
+        return SelectActions.Last;
+    }
+
+    // handle typing characters when open or closed
+    if (
+        key === 'Backspace' ||
+        key === 'Clear' ||
+        (key.length === 1 && key !== ' ' && !altKey && !ctrlKey && !metaKey)
+    ) {
+        return SelectActions.Type;
+    }
+
+    // handle keys when open
+    if (menuOpen) {
+        if (key === 'ArrowUp' && altKey) {
+            return SelectActions.CloseSelect;
+        } else if (key === 'ArrowDown' && !altKey) {
+            return SelectActions.Next;
+        } else if (key === 'ArrowUp') {
+            return SelectActions.Previous;
+        } else if (key === 'PageUp') {
+            return SelectActions.PageUp;
+        } else if (key === 'PageDown') {
+            return SelectActions.PageDown;
+        } else if (key === 'Escape') {
+            return SelectActions.Close;
+        } else if (key === 'Enter' || key === ' ') {
+            return SelectActions.CloseSelect;
+        }
+    }
+}
+
+// return the index of an option from an array of options, based on a search string
+// if the filter is multiple iterations of the same letter (e.g "aaa"), then cycle through first-letter matches
+function getIndexByLetter(options, filter, startIndex = 0) {
+    const orderedOptions = [
+        ...options.slice(startIndex),
+        ...options.slice(0, startIndex)
+    ];
+    const firstMatch = filterOptions(orderedOptions, filter)[0];
+    const allSameLetter = array => array.every(letter => letter === array[0]);
+
+    // first check if there is an exact match for the typed string
+    if (firstMatch) {
+        return options.indexOf(firstMatch);
+    }
+
+    // if the same letter is being repeated, cycle through first-letter matches
+    else if (allSameLetter(filter.split(''))) {
+        const matches = filterOptions(orderedOptions, filter[0]);
+        return options.indexOf(matches[0]);
+    }
+
+    // if no matches, return -1
+    else {
+        return -1;
+    }
+}
+
+// get an updated option index after performing an action
+function getUpdatedIndex(currentIndex, maxIndex, action) {
+    const pageSize = 10; // used for pageup/pagedown
+
+    switch (action) {
+        case SelectActions.First:
+            return 0;
+        case SelectActions.Last:
+            return maxIndex;
+        case SelectActions.Previous:
+            return Math.max(0, currentIndex - 1);
+        case SelectActions.Next:
+            return Math.min(maxIndex, currentIndex + 1);
+        case SelectActions.PageUp:
+            return Math.max(0, currentIndex - pageSize);
+        case SelectActions.PageDown:
+            return Math.min(maxIndex, currentIndex + pageSize);
+        default:
+            return currentIndex;
+    }
+}
+
+// check if element is visible in browser view port
+function isElementInView(element) {
+    var bounding = element.getBoundingClientRect();
+
+    return (
+        bounding.top >= 0 &&
+        bounding.left >= 0 &&
+        bounding.bottom <=
+            (window.innerHeight || document.documentElement.clientHeight) &&
+        bounding.right <=
+            (window.innerWidth || document.documentElement.clientWidth)
+    );
+}
+
+// check if an element is currently scrollable
+function isScrollable(element) {
+    return element && element.clientHeight < element.scrollHeight;
+}
+
+// ensure a given child element is within the parent's visible scroll area
+// if the child is not visible, scroll the parent
+function maintainScrollVisibility(activeElement, scrollParent) {
+    const { offsetHeight, offsetTop } = activeElement;
+    const { offsetHeight: parentOffsetHeight, scrollTop } = scrollParent;
+
+    const isAbove = offsetTop < scrollTop;
+    const isBelow = offsetTop + offsetHeight > scrollTop + parentOffsetHeight;
+
+    if (isAbove) {
+        scrollParent.scrollTo(0, offsetTop);
+    } else if (isBelow) {
+        scrollParent.scrollTo(0, offsetTop - parentOffsetHeight + offsetHeight);
+    }
+}
+
+const SelectCombobox = ({
+    id = 'browser',
+    options = ['--', 'Chrome', 'Firefox', 'Safari']
+}) => {
+    const comboboxRef = useRef();
+    const listboxRef = useRef();
+
+    const activeIndexRef = useRef(0);
+    const ignoreBlurRef = useRef(false);
+    const openRef = useRef(false);
+    const searchStringRef = useRef('');
+    const searchTimeoutRef = useRef(null);
+    const optionElRefs = useRef({});
+
+    const [isOpen, setIsOpen] = useState(false);
+    const [activeId, setActiveId] = useState('');
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    const getSearchString = char => {
+        // reset typing timeout and start new timeout
+        // this allows us to make multiple-letter matches, like a native select
+        if (typeof searchTimeoutRef.current === 'number') {
+            window.clearTimeout(searchTimeoutRef.current);
+        }
+
+        searchTimeoutRef.current = window.setTimeout(() => {
+            searchStringRef.current = '';
+        }, 500);
+
+        // add most recent letter to saved search string
+        searchStringRef.current += char;
+        return searchStringRef.current;
+    };
+
+    const onComboBlur = () => {
+        // do not do blur action if ignoreBlur flag has been set
+        if (ignoreBlurRef.current) {
+            ignoreBlurRef.current = false;
+            return;
+        }
+
+        // select current option and close
+        if (openRef.current) {
+            selectOption(activeIndexRef.current);
+            updateMenuState(false, false);
+        }
+    };
+
+    const onComboClick = () => {
+        updateMenuState(!openRef.current, false);
+    };
+
+    const onComboKeyDown = e => {
+        const { key } = e;
+        const max = options.length - 1;
+
+        const action = getActionFromKey(e, openRef.current);
+
+        switch (action) {
+            case SelectActions.Last:
+            case SelectActions.First:
+                updateMenuState(true);
+            // intentional fallthrough
+            case SelectActions.Next:
+            case SelectActions.Previous:
+            case SelectActions.PageUp:
+            case SelectActions.PageDown:
+                e.preventDefault();
+                return onOptionChange(
+                    getUpdatedIndex(activeIndexRef.current, max, action)
+                );
+            case SelectActions.CloseSelect:
+                e.preventDefault();
+                selectOption(activeIndexRef.current);
+            // intentional fallthrough
+            case SelectActions.Close:
+                e.preventDefault();
+                return updateMenuState(false);
+            case SelectActions.Type:
+                return onComboType(key);
+            case SelectActions.Open:
+                e.preventDefault();
+                return updateMenuState(true);
+        }
+    };
+
+    const onComboType = letter => {
+        // open the listbox if it is closed
+        updateMenuState(true);
+
+        // find the index of the first matching option
+        const searchString = getSearchString(letter);
+        const searchIndex = getIndexByLetter(
+            options,
+            searchString,
+            activeIndexRef.current + 1
+        );
+
+        // if a match was found, go to it
+        if (searchIndex >= 0) {
+            onOptionChange(searchIndex);
+        }
+        // if no matches, clear the timeout and search string
+        else {
+            window.clearTimeout(searchTimeoutRef.current);
+            searchStringRef.current = '';
+        }
+    };
+
+    const onOptionChange = index => {
+        // update state
+        activeIndexRef.current = index;
+
+        // update aria-activedescendant
+        setActiveId(`combobox-${id}-${activeIndexRef.current}`);
+
+        // ensure the new option is in view
+        if (isScrollable(listboxRef.current)) {
+            maintainScrollVisibility(
+                optionElRefs.current[index],
+                listboxRef.current
+            );
+        }
+
+        // ensure the new option is in view
+        if (!isElementInView(optionElRefs.current[index])) {
+            optionElRefs.current[index].scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest'
+            });
+        }
+    };
+
+    const onOptionClick = index => {
+        onOptionChange(index);
+        selectOption(index);
+        updateMenuState(false);
+    };
+
+    const onOptionMouseDown = () => {
+        // Clicking an option will cause a blur event,
+        // but we don't want to perform the default keyboard blur action
+        ignoreBlurRef.current = true;
+    };
+
+    const selectOption = index => {
+        // update state
+        activeIndexRef.current = index;
+
+        // update displayed value
+        setSelectedIndex(index);
+    };
+
+    const updateMenuState = (open, callFocus = true) => {
+        if (openRef.current === open) {
+            return;
+        }
+
+        // update state
+        openRef.current = open;
+
+        // update aria-expanded
+        setIsOpen(open);
+
+        // update activedescendant
+        const activeId = open ? `combobox-${id}-${activeIndexRef.current}` : '';
+        setActiveId(activeId);
+
+        if (activeId === '' && !isElementInView(comboboxRef.current)) {
+            comboboxRef.current.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest'
+            });
+        }
+
+        // move focus back to the combobox, if needed
+        callFocus && comboboxRef.current.focus();
+    };
+
+    return (
+        <Container>
+            <Combobox
+                ref={comboboxRef}
+                role="combobox"
+                className="form-control"
+                tabIndex="0"
+                aria-expanded={isOpen}
+                aria-activedescendant={isOpen && activeId ? activeId : null}
+                onBlur={onComboBlur}
+                onClick={onComboClick}
+                onKeyDown={onComboKeyDown}
+            >
+                {options[selectedIndex]}
+            </Combobox>
+            <Listbox
+                ref={listboxRef}
+                role="listbox"
+                open={isOpen}
+                tabIndex="-1"
+            >
+                {options.map((option, index) => (
+                    <Option
+                        ref={ref => [(optionElRefs.current[index] = ref)]}
+                        id={`combobox-${id}-${index}`}
+                        key={`combobox-${id}-${index}`}
+                        current={activeId === `combobox-${id}-${index}`}
+                        aria-selected={selectedIndex === index}
+                        onClick={e => {
+                            e.stopPropagation();
+                            onOptionClick(index);
+                        }}
+                        onMouseDown={onOptionMouseDown}
+                    >
+                        {option}
+                    </Option>
+                ))}
+            </Listbox>
+        </Container>
+    );
+};
+
+SelectCombobox.propTypes = {
+    id: PropTypes.string,
+    options: PropTypes.array
+};
+
+export default SelectCombobox;


### PR DESCRIPTION
Addresses #429.

This PR moves away from using bootstrap's `<Form.Control as="select" />` which used the native HTML `select` widget for a user to select possible values from a list. In it's place, a [combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) has been implemented which is based on the [Combobox APG Select Only Example](https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html).

Additionally, the robustness of the disclosure components used with the `ManageTestQueue` component and `Run History` on relevant reporting pages has been improved.