### PR TITLE
Timeout nginx config

### DIFF
--- a/deploy/roles/proxy/templates/nginx.conf.j2
+++ b/deploy/roles/proxy/templates/nginx.conf.j2
@@ -21,6 +21,10 @@ server {
     proxy_set_header Host $host;
     proxy_cache_bypass $http_upgrade;
   }
+
+  proxy_read_timeout 300;
+  proxy_connect_timeout 300;
+  proxy_send_timeout 300;
 }
 
 {% if cert_file.stat.exists %}


### PR DESCRIPTION
Currently, production takes more than a minute to load. This was causing nginx to return a 504 error. As a quick fix, this PR increases the timeout time until performance issues are resolved.