### PR TITLE
Update GitHub Issue Test File link

### DIFF
--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -44,20 +44,25 @@ const createGitHubIssueWithTitleAndBody = ({
     browserVersion,
     conflictMarkdown = null
 }) => {
+    let modifiedRenderedUrl = test.renderedUrl.replace(
+        /.+(?=\/tests)/,
+        'https://aria-at.netlify.app'
+    );
+
     const { testPlanVersion, at, browser } = testPlanReport;
 
     const title =
         `Feedback: "${test.title}" (${testPlanVersion.title}, ` +
         `Test ${test.rowNumber})`;
 
-    const shortenedUrl = test.renderedUrl.match(/[^/]+$/)[0];
+    const shortenedUrl = modifiedRenderedUrl.match(/[^/]+$/)[0];
 
     let body =
         `## Description of Behavior\n\n` +
         `<!-- write your description here -->\n\n` +
         `## Test Setup\n\n` +
-        `- Test File at Exact Commit: ` +
-        `[${shortenedUrl}](https://aria-at.w3.org${test.renderedUrl})\n` +
+        `- Test File: ` +
+        `[${shortenedUrl}](${modifiedRenderedUrl})\n` +
         `- AT: ` +
         `${at.name} (version ${atVersion})\n` +
         `- Browser: ` +


### PR DESCRIPTION
The `/build` has been removed from the aria-at repo, so links which made use of the app's proxy to render the test from that folder are no longer valid.

`https://aria-at.w3.org/aria-at/d0e16b42179de6f6c070da2310e99de837c71215/build/tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction-voiceover_macos.collected.html` is now `https://aria-at.netlify.app/tests/menu-button-actions-active-descendant/test-05-navigate-forwards-to-menu-button-interaction-voiceover_macos.collected.html`