### PR TITLE
Improve performance by changing Postgres JSONB column type

### DIFF
--- a/server/migrations/20220712044433-changeJsonbArraysToJsonb.js
+++ b/server/migrations/20220712044433-changeJsonbArraysToJsonb.js
@@ -1,0 +1,86 @@
+'use strict';
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(async (transaction) => {
+            // https://stackoverflow.com/a/45231776
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanVersion" ALTER COLUMN "tests" DROP DEFAULT;`,
+                { transaction }
+            );
+            await queryInterface.changeColumn(
+                'TestPlanVersion',
+                'tests',
+                {
+                    type: 'JSONB USING to_jsonb(tests)',
+                },
+                { transaction }
+            );
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanVersion" ALTER COLUMN "tests" SET DEFAULT '[]';`,
+                { transaction }
+            );
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanRun" ALTER COLUMN "testResults" DROP DEFAULT;`,
+                { transaction }
+            );
+            await queryInterface.changeColumn(
+                'TestPlanRun',
+                'testResults',
+                {
+                    type: 'JSONB USING to_jsonb("testResults")',
+                },
+                { transaction }
+            );
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanRun" ALTER COLUMN "testResults" SET DEFAULT '[]';`,
+                { transaction }
+            );
+        });
+    },
+
+    down: (queryInterface, Sequelize) => {
+        return queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.sequelize.query(
+                `CREATE OR REPLACE FUNCTION jsonb_to_jsonb_array(jsonb)
+                returns jsonb[] language sql as $$
+                    select array_agg(elem)
+                    from jsonb_array_elements($1) as elem
+                $$;`,
+                { transaction }
+            );
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanVersion" ALTER COLUMN "tests" DROP DEFAULT;`,
+                { transaction }
+            );
+            await queryInterface.changeColumn(
+                'TestPlanVersion',
+                'tests',
+                {
+                    type: 'JSONB[] USING jsonb_to_jsonb_array(tests)',
+                },
+                { transaction }
+            );
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanVersion" ALTER COLUMN "tests" SET DEFAULT '{}';`,
+                { transaction }
+            );
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanRun" ALTER COLUMN "testResults" DROP DEFAULT;`,
+                { transaction }
+            );
+            await queryInterface.changeColumn(
+                'TestPlanRun',
+                'testResults',
+                {
+                    type: 'JSONB[] USING jsonb_to_jsonb_array("testResults")',
+                },
+                { transaction }
+            );
+            await queryInterface.sequelize.query(
+                `ALTER TABLE "TestPlanRun" ALTER COLUMN "testResults" SET DEFAULT '{}';`,
+                { transaction }
+            );
+        });
+    },
+};

--- a/server/models/TestPlanRun.js
+++ b/server/models/TestPlanRun.js
@@ -12,7 +12,7 @@ module.exports = function(sequelize, DataTypes) {
             },
             testerUserId: { type: DataTypes.INTEGER, allowNull: true },
             testPlanReportId: { type: DataTypes.INTEGER },
-            testResults: { type: DataTypes.ARRAY(DataTypes.JSONB) }
+            testResults: { type: DataTypes.JSONB }
         },
         {
             timestamps: false,

--- a/server/models/TestPlanVersion.js
+++ b/server/models/TestPlanVersion.js
@@ -25,7 +25,7 @@ module.exports = function(sequelize, DataTypes) {
                 type: DataTypes.DATE,
                 defaultValue: DataTypes.NOW
             },
-            tests: { type: DataTypes.ARRAY(DataTypes.JSONB) },
+            tests: { type: DataTypes.JSONB },
             metadata: { type: DataTypes.JSONB }
         },
         {


### PR DESCRIPTION
This PR converts database columns that were of type `JSONB[]` to `JSONB`. On my local machine, with a dump of the production database, this improves page load speed from ~10s to 1.5s.

---

(These charts were produced with `yarn dev-debug` and the Chrome Node.js DevTools CPU Profiler set to "Chart" view.)

## Before
<img width="1226" alt="Screen Shot 2022-07-12 at 2 06 15 AM" src="https://user-images.githubusercontent.com/970121/178424081-3e8ff274-4401-415b-b88c-2f953a9b5002.png">

## After
<img width="1223" alt="Screen Shot 2022-07-12 at 2 06 24 AM" src="https://user-images.githubusercontent.com/970121/178423731-ad950da0-5718-4371-8aac-98d44c3bf2fb.png">

## Problem
<img width="440" alt="Screen Shot 2022-07-12 at 2 06 58 AM" src="https://user-images.githubusercontent.com/970121/178424212-36924381-9fed-487d-af75-6c099603e64e.png">

I noticed that 8.5s of total load time was spent inside a single function, `parse()` from the `postgres-array` module.

The problem is that Postgres returns a string for every column. Our JSONB[] columns, looked like this `{"{\"id\": \"1\"}","{\"id\": \"2\"}"}`. Then, the node `pg` client had to parse the string into a JavaScript array with `parse()` from `postgres-array` (e.g. `"{1,2,3}"` to `[1,2,3]`). Unfortunately, the only way to do this was to scan the entire string character by character. This was pathologically slow for our JSONB[] columns which contained all the tests for a test plan in a single row.

The fix is to convert `TestPlanVersion.tests` and `TestPlanRun.testResults` from JSONB[] columns to `JSONB`. Since arrays are valid JSONB, our `tests` column can just look like `"[{id: 1}, {id: 2}]"` and the `pg` client can just use the native `JSON.parse` directly to turn the string into a JavaScript array. Fortunately, this means that the fix also doesn't touch any additional logic in the app, beyond the model definitions.