### PR TITLE
Fix report urls

### DIFF
--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -212,6 +212,12 @@ const SummarizeTestPlanReport = ({ testPlanReport }) => {
                     { test, testPlanReport }
                 );
 
+                // TODO: fix renderedUrl
+                let modifiedRenderedUrl = test.renderedUrl.replace(
+                    /.+(?=\/tests)/,
+                    'https://aria-at.netlify.app'
+                );
+
                 return (
                     <Fragment key={testResult.id}>
                         <div className="test-result-heading">
@@ -237,7 +243,7 @@ const SummarizeTestPlanReport = ({ testPlanReport }) => {
                                 <Button
                                     target="_blank"
                                     rel="noreferrer"
-                                    href={test.renderedUrl}
+                                    href={modifiedRenderedUrl}
                                     variant="secondary"
                                 >
                                     <FontAwesomeIcon icon={faExternalLinkAlt} />

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -45,6 +45,7 @@ const createGitHubIssueWithTitleAndBody = ({
     browserVersion,
     conflictMarkdown = null
 }) => {
+    // TODO: fix renderedUrl
     let modifiedRenderedUrl = test.renderedUrl.replace(
         /.+(?=\/tests)/,
         'https://aria-at.netlify.app'


### PR DESCRIPTION
Applies an existing fix from the test queue page to the reports page as well. A more permanent solution which fixes the urls within the database is still needed.