### PR TITLE
Add vendor role

### DIFF
--- a/client/components/App/App.jsx
+++ b/client/components/App/App.jsx
@@ -20,7 +20,7 @@ const App = () => {
     const [isNavbarExpanded, setIsNavbarExpanded] = useState(false);
 
     const auth = evaluateAuth(data && data.me ? data.me : {});
-    const { username, isSignedIn } = auth;
+    const { username, isSignedIn, isVendor } = auth;
 
     const signOut = async () => {
         await fetch('/api/auth/signout', { method: 'POST' });
@@ -82,18 +82,20 @@ const App = () => {
                             </li>
                             {isSignedIn && (
                                 <>
-                                    <li>
-                                        <Nav.Link
-                                            as={Link}
-                                            to="/account/settings"
-                                            aria-current={
-                                                location.pathname ===
-                                                '/account/settings'
-                                            }
-                                        >
-                                            Settings
-                                        </Nav.Link>
-                                    </li>
+                                    {!isVendor && (
+                                        <li>
+                                            <Nav.Link
+                                                as={Link}
+                                                to="/account/settings"
+                                                aria-current={
+                                                    location.pathname ===
+                                                    '/account/settings'
+                                                }
+                                            >
+                                                Settings
+                                            </Nav.Link>
+                                        </li>
+                                    )}
                                     <li className="signed-in-wrapper">
                                         <div
                                             className="signed-in"

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -48,7 +48,7 @@ const TestQueueRow = ({
         false
     );
 
-    const { id, isAdmin, isVendor, username } = user;
+    const { id, isAdmin, isTester, isVendor, username } = user;
     const {
         id: testPlanReportId,
         testPlanVersion,
@@ -60,7 +60,7 @@ const TestQueueRow = ({
 
     const checkIsTesterAssigned = username => {
         return draftTestPlanRuns.some(
-            testPlanRun => testPlanRun.tester.username === username && !isVendor
+            testPlanRun => testPlanRun.tester.username === username && isTester
         );
     };
 

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -48,7 +48,7 @@ const TestQueueRow = ({
         false
     );
 
-    const { id, isAdmin, username } = user;
+    const { id, isAdmin, isVendor, username } = user;
     const {
         id: testPlanReportId,
         testPlanVersion,
@@ -60,7 +60,7 @@ const TestQueueRow = ({
 
     const checkIsTesterAssigned = username => {
         return draftTestPlanRuns.some(
-            testPlanRun => testPlanRun.tester.username === username
+            testPlanRun => testPlanRun.tester.username === username && !isVendor
         );
     };
 
@@ -157,7 +157,7 @@ const TestQueueRow = ({
                 </>
             );
 
-        if (!isSignedIn)
+        if (!isSignedIn || isVendor)
             return (
                 <>
                     <Link to={`/test-plan-report/${testPlanReport.id}`}>
@@ -395,7 +395,7 @@ const TestQueueRow = ({
             <tr className="test-queue-run-row">
                 <th>{renderAssignedUserToTestPlan()}</th>
                 <td>
-                    {isSignedIn && (
+                    {isSignedIn && !isVendor && (
                         <div className="testers-wrapper">
                             {isAdmin && renderAssignMenu()}
                             <div className="assign-actions">
@@ -456,7 +456,7 @@ const TestQueueRow = ({
                 </td>
                 <td>
                     <div className="status-wrapper">{status}</div>
-                    {isSignedIn && (
+                    {isSignedIn && !isVendor && (
                         <div className="secondary-actions">
                             {isAdmin && nextReportStatus && (
                                 <>
@@ -522,7 +522,7 @@ const TestQueueRow = ({
                             </Button>
                         )}
 
-                        {!isSignedIn && (
+                        {(!isSignedIn || isVendor) && (
                             <Button
                                 variant="primary"
                                 href={`/test-plan-report/${testPlanReport.id}`}
@@ -531,7 +531,7 @@ const TestQueueRow = ({
                             </Button>
                         )}
                     </div>
-                    {isSignedIn && (
+                    {isSignedIn && !isVendor && (
                         <div className="secondary-actions">
                             {isAdmin && renderOpenAsDropdown()}
                             {isAdmin && renderDeleteMenu()}

--- a/client/utils/evaluateAuth.js
+++ b/client/utils/evaluateAuth.js
@@ -16,6 +16,7 @@ export const evaluateAuth = (data = {}) => {
         // calculated booleans
         isAdmin: roles.includes('ADMIN'),
         isTester: roles.includes('TESTER'),
+        isVendor: roles.includes('VENDOR'),
         isSignedIn: !!data.username,
 
         // user object values

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -30,6 +30,11 @@ const graphqlSchema = gql`
         of a special GitHub team, which is different for each app environment.
         """
         ADMIN
+        """
+        Whether the user can perform vendor actions, such as reviewing
+        candidate test plans. Vendors are specified in vendors.txt.
+        """
+        VENDOR
     }
 
     type User {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -26,7 +26,7 @@ module.exports = function(sequelize, DataTypes) {
 
     Model.TESTER = 'TESTER';
     Model.ADMIN = 'ADMIN';
-    Model.VENDER = 'VENDOR';
+    Model.VENDOR = 'VENDOR';
 
     Model.ROLE_ASSOCIATION = { through: 'UserRoles', as: 'roles' };
     Model.ATS_ASSOCIATION = { through: 'UserAts', as: 'ats' };

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -26,6 +26,7 @@ module.exports = function(sequelize, DataTypes) {
 
     Model.TESTER = 'TESTER';
     Model.ADMIN = 'ADMIN';
+    Model.VENDER = 'VENDOR';
 
     Model.ROLE_ASSOCIATION = { through: 'UserRoles', as: 'roles' };
     Model.ATS_ASSOCIATION = { through: 'UserAts', as: 'ats' };

--- a/server/seeders/20220727141440-vendor-role.js
+++ b/server/seeders/20220727141440-vendor-role.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { Role } = require('../models');
+
+module.exports = {
+    up: async queryInterface => {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await Role.create({ name: 'VENDOR' }, { transaction });
+        });
+    },
+
+    down: queryInterface => {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await Role.destroy({ where: { name: 'VENDOR' }, transaction });
+        });
+    }
+};

--- a/server/seeders/20220727141440-vendor-role.js
+++ b/server/seeders/20220727141440-vendor-role.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Role } = require('../models');
+const { Role, User } = require('../models');
 
 module.exports = {
     up: async queryInterface => {

--- a/server/seeders/20220727141440-vendor-role.js
+++ b/server/seeders/20220727141440-vendor-role.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Role, User } = require('../models');
+const { Role } = require('../models');
 
 module.exports = {
     up: async queryInterface => {

--- a/server/tests/models/services/RoleService.test.js
+++ b/server/tests/models/services/RoleService.test.js
@@ -55,15 +55,18 @@ describe('RoleModel Data Checks', () => {
         expect(name).toEqual(_name);
     });
 
-    it('should only have 2 named roles (ADMIN & TESTER)', async () => {
+    it('should only have 3 named roles (ADMIN, TESTER, and VENDOR)', async () => {
         const roles = await RoleService.getRoles('');
 
-        expect(roles.length).toEqual(2);
+        expect(roles.length).toEqual(3);
         expect(roles).toContainEqual(
             expect.objectContaining({ name: 'ADMIN' })
         );
         expect(roles).toContainEqual(
             expect.objectContaining({ name: 'TESTER' })
+        );
+        expect(roles).toContainEqual(
+            expect.objectContaining({ name: 'VENDOR' })
         );
     });
 

--- a/server/util/getUsersFromFile.js
+++ b/server/util/getUsersFromFile.js
@@ -1,14 +1,14 @@
 const path = require('path');
 const fs = require('fs/promises');
 
-const getTesters = async () => {
-    const testersPath = path.join(__dirname, '../../testers.txt');
-    const testersTxt = await fs.readFile(testersPath, { encoding: 'utf8' });
-    const linesRaw = testersTxt.split('\n');
+const getUsersFromFile = async file => {
+    const roleGroupPath = path.join(__dirname, file);
+    const roleGroupTxt = await fs.readFile(roleGroupPath, { encoding: 'utf8' });
+    const linesRaw = roleGroupTxt.split('\n');
     const noComments = linesRaw.filter(line => line.substr(0, 1) !== '#');
     const noEmpties = noComments.filter(line => line.trim().length > 0);
     const testers = noEmpties.map(line => line.trim());
     return testers;
 };
 
-module.exports = getTesters;
+module.exports = getUsersFromFile;

--- a/vendors.txt
+++ b/vendors.txt
@@ -1,3 +1,3 @@
 # Allow users with the following GitHub usernames to sign in as vendors.
 
-evmiguel
+

--- a/vendors.txt
+++ b/vendors.txt
@@ -1,0 +1,3 @@
+# Allow users with the following GitHub usernames to sign in as vendors.
+
+evmiguel


### PR DESCRIPTION
This PR includes:

- Backend support for vendor role
- New vendors.txt for participating vendors
- Fake role support for vendor role

To test:

- Seed the database: `yarn sequelize db:seed:all`
- Sign out of the app 
- Go to localhost:3000/?fakeRole=vendor
- Hit 'Sign in'
- Observe that the Setting Page is no longer available and Test Queue page is read only