### PR TITLE
Update JAWS Test Instructions

### DIFF
--- a/client/resources/aria-at-test-io-format.mjs
+++ b/client/resources/aria-at-test-io-format.mjs
@@ -11,6 +11,7 @@ import {
   CommonResultMap,
 } from "./aria-at-test-run.mjs";
 import * as keysModule from "./keys.mjs";
+import * as keys from "@client/resources/keys.mjs";
 
 const UNEXPECTED_BEHAVIORS = [
   "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",
@@ -79,7 +80,7 @@ class KeysInput {
       at: atKey,
       modeInstructions: {
         reading: {
-          jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn on the Virtual Cursor by pressing ${keys.INS_Z}.`,
+          jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing ${keys.ESC}.`,
           nvda: `Insure NVDA is in browse mode by pressing ${keys.ESC}. Note: This command has no effect if NVDA is already in browse mode.`,
           voiceover_macos: `Toggle Quick Nav ON by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`,
         }[atKey],

--- a/client/resources/aria-at-test-io-format.mjs
+++ b/client/resources/aria-at-test-io-format.mjs
@@ -11,7 +11,6 @@ import {
   CommonResultMap,
 } from "./aria-at-test-run.mjs";
 import * as keysModule from "./keys.mjs";
-import * as keys from "@client/resources/keys.mjs";
 
 const UNEXPECTED_BEHAVIORS = [
   "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",

--- a/client/resources/at-commands.mjs
+++ b/client/resources/at-commands.mjs
@@ -34,7 +34,7 @@ constructor(commands, support) {
 
     this.MODE_INSTRUCTIONS = {
       reading: {
-        jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, turn on the Virtual Cursor by pressing ${keys.INS_Z}.`,
+        jaws: `Verify the Virtual Cursor is active by pressing ${keys.ALT_DELETE}. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing ${keys.ESC}.`,
         nvda: `Insure NVDA is in browse mode by pressing ${keys.ESC}. Note: This command has no effect if NVDA is already in browse mode.`,
         voiceover_macos: `Toggle Quick Nav ON by pressing the ${keys.LEFT} and ${keys.RIGHT} keys at the same time.`
       },

--- a/server/migrations/20220801210224-updateJawsTestInstructions.js
+++ b/server/migrations/20220801210224-updateJawsTestInstructions.js
@@ -1,0 +1,83 @@
+'use strict';
+
+module.exports = {
+    up: queryInterface => {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                        set tests = update_data.updated_tests
+                        from (select id,
+                            jsonb_agg(
+                                jsonb_build_object(
+                                    'id', elements -> 'id',
+                                    'atIds', elements -> 'atIds',
+                                    'title', elements -> 'title',
+                                    'atMode', elements -> 'atMode',
+                                    'rowNumber', elements -> 'rowNumber',
+                                    'scenarios', elements -> 'scenarios',
+                                    'assertions', elements -> 'assertions',
+                                    'renderedUrls', elements -> 'renderedUrls',
+                                    'renderableContent', jsonb_strip_nulls(
+                                        jsonb_build_object(
+                                            '1', jsonb_set(
+                                                (elements -> 'renderableContent' -> '1')::jsonb, '{instructions, mode}',
+                                                    case
+                                                        when elements -> 'renderableContent' -> '1' -> 'instructions' ->> 'mode' =
+                                                            'Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, turn on the Virtual Cursor by pressing Insert+Z.'
+                                                            then '"Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing Escape."'::jsonb
+                                                        else (elements -> 'renderableContent' -> '1' -> 'instructions' -> 'mode')::jsonb
+                                                    end),
+                                            '2', (elements -> 'renderableContent' -> '2')::jsonb,
+                                            '3', (elements -> 'renderableContent' -> '3')::jsonb)
+                                        )
+                                )
+                            ) as updated_tests
+                            from "TestPlanVersion",
+                                jsonb_array_elements("TestPlanVersion".tests) as elements
+                            group by id) update_data
+                        where update_data.id = "TestPlanVersion".id;`,
+                { transaction }
+            );
+        });
+    },
+
+    down: queryInterface => {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                        set tests = update_data.updated_tests
+                        from (select id,
+                            jsonb_agg(
+                                jsonb_build_object(
+                                    'id', elements -> 'id',
+                                    'atIds', elements -> 'atIds',
+                                    'title', elements -> 'title',
+                                    'atMode', elements -> 'atMode',
+                                    'rowNumber', elements -> 'rowNumber',
+                                    'scenarios', elements -> 'scenarios',
+                                    'assertions', elements -> 'assertions',
+                                    'renderedUrls', elements -> 'renderedUrls',
+                                    'renderableContent', jsonb_strip_nulls(
+                                        jsonb_build_object(
+                                            '1', jsonb_set(
+                                                (elements -> 'renderableContent' -> '1')::jsonb, '{instructions, mode}',
+                                                    case
+                                                        when elements -> 'renderableContent' -> '1' -> 'instructions' ->> 'mode' =
+                                                            'Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing Escape.'
+                                                            then '"Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, turn on the Virtual Cursor by pressing Insert+Z."'::jsonb
+                                                        else (elements -> 'renderableContent' -> '1' -> 'instructions' -> 'mode')::jsonb
+                                                    end),
+                                            '2', (elements -> 'renderableContent' -> '2')::jsonb,
+                                            '3', (elements -> 'renderableContent' -> '3')::jsonb)
+                                        )
+                                )
+                            ) as updated_tests
+                            from "TestPlanVersion",
+                                jsonb_array_elements("TestPlanVersion".tests) as elements
+                            group by id) update_data
+                        where update_data.id = "TestPlanVersion".id;`,
+                { transaction }
+            );
+        });
+    }
+};


### PR DESCRIPTION
Updated JAWS test instructions regarding exiting Forms Mode based on https://github.com/w3c/aria-at/issues/731#issuecomment-1158078906 and https://github.com/w3c/aria-at/issues/731#issuecomment-1167912369.

When being displayed on the Test Run pages, the instructions will now read as:
> 2. ...
> 3. Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, exit Forms Mode to activate the Virtual Cursor by pressing Escape.
> 4. ...

instead of:
> 2. ...
> 3. Verify the Virtual Cursor is active by pressing Alt+Delete. If it is not, turn on the Virtual Cursor by pressing Insert+Z.
> 4. ...

This is also related to https://github.com/w3c/aria-at/pull/794.