### PR TITLE
Remove row and refresh when report status is marked as `Finalized`

### DIFF
--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -392,7 +392,8 @@ const TestQueueRow = ({
                         status: status
                     }
                 });
-                await triggerTestPlanReportUpdate();
+                if (status === 'FINALIZED') await triggerPageUpdate();
+                else await triggerTestPlanReportUpdate();
             }, 'Updating Test Plan Status');
         } catch (e) {
             showThemedMessage(


### PR DESCRIPTION
Refreshes the Test Queue page instead of individual row when report status updated to `Finalized`.