### PR TITLE
Updater performance

### DIFF
--- a/client/components/TestPlanUpdater/TestPlanUpdaterModal.css
+++ b/client/components/TestPlanUpdater/TestPlanUpdaterModal.css
@@ -20,6 +20,11 @@
     height: 250px;
 }
 
+.results-spinner-container {
+    display: flex;
+    justify-content: center;
+}
+
 @media (min-width: 768px) {
     .modal-50w {
         min-width: 50%;

--- a/client/components/TestPlanUpdater/TestPlanUpdaterModal.jsx
+++ b/client/components/TestPlanUpdater/TestPlanUpdaterModal.jsx
@@ -28,7 +28,7 @@ const TestPlanUpdaterModal = ({
     show,
     handleClose,
     testPlanReportId,
-    triggerPageUpdate
+    triggerTestPlanReportUpdate
 }) => {
     const loadInitialData = async ({ client, testPlanReportId }) => {
         const { data: currentReportData } = await client.query({
@@ -101,7 +101,7 @@ const TestPlanUpdaterModal = ({
         visible: false
     });
     const [backupChecked, setBackupChecked] = useState(false);
-    const [newReport, setNewReport] = useState(false);
+    const [newReport, setNewReport] = useState();
     const [closeButton, setCloseButton] = useState(false);
 
     useEffect(() => {
@@ -221,7 +221,7 @@ const TestPlanUpdaterModal = ({
             return;
         }
 
-        setNewReport(true);
+        setNewReport(created.find(item => item.testPlanReport.id));
 
         for (const testPlanRun of runsWithResults) {
             const { data: runData } = await client.mutate({
@@ -324,13 +324,13 @@ const TestPlanUpdaterModal = ({
 
     const closeAndReload = async () => {
         if (newReport) {
-            await triggerPageUpdate();
+            await triggerTestPlanReportUpdate(newReport.testPlanReport.id);
         }
         handleClose();
     };
 
     return (
-        <Modal show={show} onHide={handleClose} dialogClassName="modal-50w">
+        <Modal show={show} onHide={closeAndReload} dialogClassName="modal-50w">
             <Modal.Header closeButton className="test-plan-updater-header">
                 <Modal.Title>Test Plan Updater</Modal.Title>
             </Modal.Header>
@@ -513,7 +513,7 @@ TestPlanUpdaterModal.propTypes = {
     handleClose: PropTypes.func,
     handleAction: PropTypes.func,
     testPlanReportId: PropTypes.string,
-    triggerPageUpdate: PropTypes.func
+    triggerTestPlanReportUpdate: PropTypes.func
 };
 
 export default TestPlanUpdaterModal;

--- a/client/components/TestPlanUpdater/queries.js
+++ b/client/components/TestPlanUpdater/queries.js
@@ -16,21 +16,14 @@ export const TEST_PLAN_ID_QUERY = gql`
                 id
                 testPlan {
                     id
+                    latestTestPlanVersion {
+                        id
+                        gitSha
+                        gitMessage
+                        updatedAt
+                    }
                 }
                 title
-                gitMessage
-                gitSha
-                updatedAt
-            }
-        }
-    }
-`;
-
-export const UPDATER_QUERY = gql`
-    query Updater($testPlanId: ID!) {
-        testPlan(id: $testPlanId) {
-            latestTestPlanVersion {
-                id
                 gitMessage
                 gitSha
                 updatedAt

--- a/client/components/TestPlanUpdater/queries.js
+++ b/client/components/TestPlanUpdater/queries.js
@@ -4,20 +4,6 @@ export const TEST_PLAN_ID_QUERY = gql`
     query TestPlanIdQuery($testPlanReportId: ID!) {
         testPlanReport(id: $testPlanReportId) {
             id
-            testPlanVersion {
-                id
-                testPlan {
-                    id
-                }
-            }
-        }
-    }
-`;
-
-export const UPDATER_QUERY = gql`
-    query Updater($testPlanReportId: ID!, $testPlanId: ID!) {
-        testPlanReport(id: $testPlanReportId) {
-            id
             at {
                 name
                 id
@@ -28,20 +14,22 @@ export const UPDATER_QUERY = gql`
             }
             testPlanVersion {
                 id
+                testPlan {
+                    id
+                }
                 title
                 gitMessage
                 gitSha
                 updatedAt
             }
         }
+    }
+`;
+
+export const UPDATER_QUERY = gql`
+    query Updater($testPlanId: ID!) {
         testPlan(id: $testPlanId) {
             latestTestPlanVersion {
-                id
-                gitMessage
-                gitSha
-                updatedAt
-            }
-            testPlanVersions {
                 id
                 gitMessage
                 gitSha
@@ -71,7 +59,7 @@ export const VERSION_QUERY = gql`
         }
     }
 
-    query VersionQuery(
+    query LatestVersionQuery(
         $testPlanReportId: ID!
         $testPlanVersionId: ID!
         $atId: ID!

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -102,11 +102,11 @@ const TestQueueRow = ({
         return draftTestPlanRuns.find(({ tester }) => tester.id === userId).id;
     };
 
-    const triggerTestPlanReportUpdate = async () => {
+    const triggerTestPlanReportUpdate = async (id = testPlanReport.id) => {
         setIsLoading(true);
         const { data } = await client.query({
             query: TEST_PLAN_REPORT_QUERY,
-            variables: { testPlanReportId: testPlanReport.id },
+            variables: { testPlanReportId: id },
             fetchPolicy: 'network-only'
         });
         setTestPlanReport(data.testPlanReport);
@@ -655,7 +655,7 @@ const TestQueueRow = ({
                     show={showTestPlanUpdaterModal}
                     handleClose={() => setShowTestPlanUpdaterModal(false)}
                     testPlanReportId={testPlanReportId}
-                    triggerPageUpdate={triggerPageUpdate}
+                    triggerTestPlanReportUpdate={triggerTestPlanReportUpdate}
                 />
             )}
             {showThemedModal && (

--- a/server/models/services/TestPlanVersionService.js
+++ b/server/models/services/TestPlanVersionService.js
@@ -460,8 +460,14 @@ const getTestPlans = async ({
     return testPlans;
 };
 
-const getTestPlanById = async id => {
-    const result = await getTestPlans({ id });
+const getTestPlanById = async (id, options = {}) => {
+    let result;
+    try {
+        result = await getTestPlans({ id, ...options });
+    } catch (e) {
+        console.error(e);
+    }
+
     return result[0];
 };
 

--- a/server/resolvers/TestPlanVersion/testPlanVersionTestPlanResolver.js
+++ b/server/resolvers/TestPlanVersion/testPlanVersionTestPlanResolver.js
@@ -1,7 +1,35 @@
-const testPlanVersionTestPlanResolver = testPlanVersion => {
+const {
+    getTestPlanById
+} = require('../../models/services/TestPlanVersionService');
+
+const testPlanVersionTestPlanResolver = async (
+    testPlanVersion,
+    args,
+    cotext,
+    info
+) => {
+    const requestedFields =
+        info?.fieldNodes[0] &&
+        info.fieldNodes[0].selectionSet.selections.map(
+            selection => selection.name.value
+        );
+    const includeLatest = !!requestedFields?.includes('latestTestPlanVersion');
+
+    let latestTestPlanVersion = { latestTestPlanVersion: null };
+
+    if (includeLatest) {
+        latestTestPlanVersion = await getTestPlanById(
+            testPlanVersion.directory,
+            {
+                includeTestPlanVersions: false
+            }
+        );
+    }
+
     return {
         id: testPlanVersion.directory,
-        directory: testPlanVersion.directory
+        directory: testPlanVersion.directory,
+        latestTestPlanVersion: latestTestPlanVersion.latestTestPlanVersion
     };
 };
 


### PR DESCRIPTION
This PR introduces changes to help the TestPlanUpdater performance. The main change is removing the UPDATER_QUERY in favor of returning the `latestTestPlanVersion` from the server.