### PR TITLE
Accessibility feedback from #466

### DIFF
--- a/client/components/App/App.jsx
+++ b/client/components/App/App.jsx
@@ -39,7 +39,7 @@ const App = () => {
                 <Navbar
                     bg="light"
                     expand="lg"
-                    aria-label="Main Menu"
+                    aria-label="Menu"
                     expanded={isNavbarExpanded}
                     onToggle={() => setIsNavbarExpanded(previous => !previous)}
                 >

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
 import TestNavigator from '../../TestRun/TestNavigator';
 import InstructionsRenderer from './InstructionsRenderer';
@@ -54,6 +54,9 @@ const CandidateTestPlanRun = () => {
         PROMOTE_VENDOR_REVIEW_STATUS_REPORT_MUTATION
     );
 
+    const nextButtonRef = useRef();
+    const finishButtonRef = useRef();
+
     const [reviewStatus, setReviewStatus] = useState('');
     const [firstTimeViewing, setFirstTimeViewing] = useState(false);
     const [viewedTests, setViewedTests] = useState([]);
@@ -67,9 +70,9 @@ const CandidateTestPlanRun = () => {
     const [showBrowserBools, setShowBrowserBools] = useState([]);
     const [showBrowserClicks, setShowBrowserClicks] = useState([]);
 
-    const [issuesHeading, setissuesHeading] = React.useState();
+    const [issuesHeading, setIssuesHeading] = React.useState();
     const issuesHeadingSize = useSize(issuesHeading);
-    const [issuesList, setissuesList] = React.useState();
+    const [issuesList, setIssuesList] = React.useState();
     const issuesListSize = useSize(issuesList);
     const isLaptopOrLarger = useMediaQuery({
         query: '(min-width: 792px)'
@@ -101,7 +104,7 @@ const CandidateTestPlanRun = () => {
         );
     };
     const handlePreviousTestClick = async () => {
-        navigateTests(
+        const { isFirstTest } = navigateTests(
             true,
             currentTest,
             tests,
@@ -109,6 +112,7 @@ const CandidateTestPlanRun = () => {
             setIsFirstTest,
             setIsLastTest
         );
+        if (isFirstTest) nextButtonRef.current.focus();
     };
 
     const addViewerToTest = async testId => {
@@ -212,6 +216,10 @@ const CandidateTestPlanRun = () => {
             setIsLastTest(tests?.length === 1);
         }
     }, [data, tests]);
+
+    useEffect(() => {
+        if (isLastTest) finishButtonRef.current.focus();
+    }, [isLastTest]);
 
     if (error)
         return (
@@ -543,11 +551,11 @@ const CandidateTestPlanRun = () => {
                         {heading}
                         {testInfo}
                         <Col className="results-container-col">
-                            <Row xs={1} s={1} md={2} ref={setissuesHeading}>
+                            <Row xs={1} s={1} md={2} ref={setIssuesHeading}>
                                 <Col
                                     className="results-container"
                                     md={isLaptopOrLarger ? 9 : 12}
-                                    ref={setissuesList}
+                                    ref={setIssuesList}
                                 >
                                     <Row>{feedback}</Row>
                                     <Row className="results-container-row">
@@ -564,38 +572,33 @@ const CandidateTestPlanRun = () => {
                                                     onClick={
                                                         handlePreviousTestClick
                                                     }
-                                                    aria-disabled={isFirstTest}
+                                                    disabled={isFirstTest}
                                                 >
                                                     Previous Test
                                                 </Button>
                                             </li>
                                             <li>
                                                 <Button
+                                                    ref={nextButtonRef}
                                                     variant="primary"
                                                     onClick={
                                                         handleNextTestClick
                                                     }
-                                                    aria-disabled={isLastTest}
+                                                    disabled={isLastTest}
                                                 >
                                                     Next Test
                                                 </Button>
                                             </li>
                                             <li>
                                                 <Button
+                                                    ref={finishButtonRef}
                                                     variant="primary"
-                                                    onClick={event => {
-                                                        if (
-                                                            event.target.getAttribute(
-                                                                'aria-disabled'
-                                                            ) === 'true'
-                                                        ) {
-                                                            return;
-                                                        }
+                                                    onClick={() => {
                                                         setFeedbackModalShowing(
                                                             true
                                                         );
                                                     }}
-                                                    aria-disabled={!isLastTest}
+                                                    disabled={!isLastTest}
                                                 >
                                                     Finish
                                                 </Button>

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -339,7 +339,7 @@ const CandidateTestPlanRun = () => {
     const heading = (
         <div className="test-info-heading">
             <div className="sr-only" aria-live="polite" aria-atomic="true">
-                Reviewing Test {currentTest.title}, Test {currentTest.seq} of{' '}
+                Viewing Test {currentTest.title}, Test {currentTest.seq} of{' '}
                 {tests.length}
                 {currentTest.seq === tests.length
                     ? 'You are on the last test.'
@@ -564,7 +564,7 @@ const CandidateTestPlanRun = () => {
                                                     onClick={
                                                         handlePreviousTestClick
                                                     }
-                                                    disabled={isFirstTest}
+                                                    aria-disabled={isFirstTest}
                                                 >
                                                     Previous Test
                                                 </Button>
@@ -575,7 +575,7 @@ const CandidateTestPlanRun = () => {
                                                     onClick={
                                                         handleNextTestClick
                                                     }
-                                                    disabled={isLastTest}
+                                                    aria-disabled={isLastTest}
                                                 >
                                                     Next Test
                                                 </Button>
@@ -583,12 +583,19 @@ const CandidateTestPlanRun = () => {
                                             <li>
                                                 <Button
                                                     variant="primary"
-                                                    onClick={() =>
+                                                    onClick={event => {
+                                                        if (
+                                                            event.target.getAttribute(
+                                                                'aria-disabled'
+                                                            ) === 'true'
+                                                        ) {
+                                                            return;
+                                                        }
                                                         setFeedbackModalShowing(
                                                             true
-                                                        )
-                                                    }
-                                                    disabled={!isLastTest}
+                                                        );
+                                                    }}
+                                                    aria-disabled={!isLastTest}
                                                 >
                                                     Finish
                                                 </Button>

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -63,7 +63,7 @@ const CandidateTestPlanRun = () => {
     const [isLastTest, setIsLastTest] = useState(false);
     const [feedbackModalShowing, setFeedbackModalShowing] = useState(false);
     const [thankYouModalShowing, setThankYouModalShowing] = useState(false);
-    const [showInstructions, setShowInstructions] = useState(true);
+    const [showInstructions, setShowInstructions] = useState(false);
     const [showBrowserBools, setShowBrowserBools] = useState([]);
     const [showBrowserClicks, setShowBrowserClicks] = useState([]);
 
@@ -180,7 +180,7 @@ const CandidateTestPlanRun = () => {
             setViewedTests(viewedTests);
             setReviewStatus(vendorReviewStatus);
 
-            const bools = testPlanReports.map(() => true);
+            const bools = testPlanReports.map(() => false);
             setShowBrowserBools(bools);
 
             const browserClicks = testPlanReports.map((report, index) => () => {
@@ -339,8 +339,11 @@ const CandidateTestPlanRun = () => {
     const heading = (
         <div className="test-info-heading">
             <div className="sr-only" aria-live="polite" aria-atomic="true">
-                Viewing Test: {currentTest.title}, Test {currentTest.seq} of{' '}
+                Reviewing Test {currentTest.title}, Test {currentTest.seq} of{' '}
                 {tests.length}
+                {currentTest.seq === tests.length
+                    ? 'You are on the last test.'
+                    : ''}
             </div>
             <span className="task-label">
                 Reviewing Test {currentTest.seq} of {tests.length}:
@@ -567,27 +570,28 @@ const CandidateTestPlanRun = () => {
                                                 </Button>
                                             </li>
                                             <li>
-                                                {!isLastTest ? (
-                                                    <Button
-                                                        variant="primary"
-                                                        onClick={
-                                                            handleNextTestClick
-                                                        }
-                                                    >
-                                                        Next Test
-                                                    </Button>
-                                                ) : (
-                                                    <Button
-                                                        variant="primary"
-                                                        onClick={() =>
-                                                            setFeedbackModalShowing(
-                                                                true
-                                                            )
-                                                        }
-                                                    >
-                                                        Finish
-                                                    </Button>
-                                                )}
+                                                <Button
+                                                    variant="primary"
+                                                    onClick={
+                                                        handleNextTestClick
+                                                    }
+                                                    disabled={isLastTest}
+                                                >
+                                                    Next Test
+                                                </Button>
+                                            </li>
+                                            <li>
+                                                <Button
+                                                    variant="primary"
+                                                    onClick={() =>
+                                                        setFeedbackModalShowing(
+                                                            true
+                                                        )
+                                                    }
+                                                    disabled={!isLastTest}
+                                                >
+                                                    Finish
+                                                </Button>
                                             </li>
                                         </ul>
                                     </Row>

--- a/client/utils/navigateTests.js
+++ b/client/utils/navigateTests.js
@@ -20,8 +20,13 @@ export const navigateTests = (
             newTestIndex = newTestIndexToEval;
     }
 
-    setCurrentTestIndex &&
-        setCurrentTestIndex(tests.find(t => t.seq === newTestIndex).index);
-    setIsFirstTest && setIsFirstTest(newTestIndex - 1 === 0);
-    setIsLastTest && setIsLastTest(newTestIndex === tests.length);
+    const currentIndex = tests.find(t => t.seq === newTestIndex).index;
+    const isFirstTest = newTestIndex - 1 === 0;
+    const isLastTest = newTestIndex === tests.length;
+
+    setCurrentTestIndex && setCurrentTestIndex(currentIndex);
+    setIsFirstTest && setIsFirstTest(isFirstTest);
+    setIsLastTest && setIsLastTest(isLastTest);
+
+    return { currentIndex, isFirstTest, isLastTest };
 };


### PR DESCRIPTION
This PR implements the following accessibility changes from @louis4533:

- [x] Maybe consider having them all (disclosures) closed so a user may jump to the test Instructions or browser results for their needs.
- [x] Also, instead of the “Next” button changing to “Finish”, make the “Next” button disabled and add an extra “Finish” button
- [x] Should consider announcing that the user is on the last test

I could use some help with the following:

- [x] “main” menu navigation and “main” landmark being announced separately might be confusing
    - I'm not sure how to implement this
- [x] Number of items in navigation menu list not being announced
    - This seems to be announced in VoiceOver. Is there a better way to make this more explicit?