### PR TITLE
Test Run Page Improvements #1

### DIFF
--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -489,7 +489,12 @@ const TestRun = () => {
                     },
                     forceSave ? false : !!testRunResultRef.current
                 );
-                if (withResult && !forceSave) return !!testRunResultRef.current;
+
+                if (withResult && !forceSave) {
+                    setIsSavingForm(false);
+                    return !!testRunResultRef.current;
+                }
+
                 setIsSavingForm(false);
                 return true;
             } catch (e) {

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -141,6 +141,7 @@ const TestRun = () => {
         true
     );
     const [isRendererReady, setIsRendererReady] = useState(false);
+    const [isSavingForm, setIsSavingForm] = useState(false);
     const [isTestSubmitClicked, setIsTestSubmitClicked] = useState(false);
     const [isTestEditClicked, setIsTestEditClicked] = useState(false);
     const [showTestNavigator, setShowTestNavigator] = useState(true);
@@ -189,7 +190,7 @@ const TestRun = () => {
         );
     }
 
-    if (!data || loading || createTestResultLoading) {
+    if (!data || loading || createTestResultLoading || isSavingForm) {
         return (
             <PageStatus
                 title="Loading - Test Results | ARIA-AT"
@@ -465,28 +466,36 @@ const TestRun = () => {
             forceSave = false,
             forceEdit = false
         ) => {
-            if (forceEdit) setIsTestEditClicked(true);
-            else setIsTestEditClicked(false);
+            try {
+                if (forceEdit) setIsTestEditClicked(true);
+                else setIsTestEditClicked(false);
 
-            if (!isSignedIn) return true;
-            if (!forceEdit && currentTest.testResult?.completedAt) return true;
+                if (!isSignedIn) return true;
+                if (!forceEdit && currentTest.testResult?.completedAt)
+                    return true;
 
-            const scenarioResults = remapScenarioResults(
-                testRunStateRef.current || recentTestRunStateRef.current,
-                currentTest.testResult?.scenarioResults,
-                false
-            );
+                setIsSavingForm(true);
+                const scenarioResults = remapScenarioResults(
+                    testRunStateRef.current || recentTestRunStateRef.current,
+                    currentTest.testResult?.scenarioResults,
+                    false
+                );
 
-            await handleSaveOrSubmitTestResultAction(
-                {
-                    atVersionId: currentTestAtVersionId,
-                    browserVersionId: currentTestBrowserVersionId,
-                    scenarioResults
-                },
-                forceSave ? false : !!testRunResultRef.current
-            );
-            if (withResult && !forceSave) return !!testRunResultRef.current;
-            return true;
+                await handleSaveOrSubmitTestResultAction(
+                    {
+                        atVersionId: currentTestAtVersionId,
+                        browserVersionId: currentTestBrowserVersionId,
+                        scenarioResults
+                    },
+                    forceSave ? false : !!testRunResultRef.current
+                );
+                if (withResult && !forceSave) return !!testRunResultRef.current;
+                setIsSavingForm(false);
+                return true;
+            } catch (e) {
+                console.error('save.error', e);
+                setIsSavingForm(false);
+            }
         };
 
         switch (action) {

--- a/server/resolvers/TestPlanRunOperations/deleteTestResultsResolver.js
+++ b/server/resolvers/TestPlanRunOperations/deleteTestResultsResolver.js
@@ -3,6 +3,10 @@ const {
     updateTestPlanRun
 } = require('../../models/services/TestPlanRunService');
 const populateData = require('../../services/PopulatedData/populateData');
+const conflictsResolver = require('../TestPlanReport/conflictsResolver');
+const {
+    updateTestPlanReport
+} = require('../../models/services/TestPlanReportService');
 
 const deleteTestResultsResolver = async (
     { parentContext: { id: testPlanRunId } },
@@ -23,7 +27,22 @@ const deleteTestResultsResolver = async (
 
     await updateTestPlanRun(testPlanRunId, { testResults: [] });
 
+    // Perform in background
+    await persistConflictsCount(testPlanRun);
     return populateData({ testPlanRunId });
+};
+
+const persistConflictsCount = async testPlanRun => {
+    const { testPlanReport: updatedTestPlanReport } = await populateData({
+        testPlanRunId: testPlanRun.id
+    });
+    const conflicts = await conflictsResolver(updatedTestPlanReport);
+    await updateTestPlanReport(updatedTestPlanReport.id, {
+        metrics: {
+            ...updatedTestPlanReport.metrics,
+            conflictsCount: conflicts.length
+        }
+    });
 };
 
 module.exports = deleteTestResultsResolver;

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -80,9 +80,11 @@ const saveTestResultCommon = async ({
 
     await updateTestPlanRun(testPlanRun.id, { testResults: newTestResults });
 
-    // Perform in background
-    persistConflictsCount(testPlanRun);
-
+    // Ignore result to avoid blocking loads in test runs with a larger amount
+    // of tests and/or test results
+    persistConflictsCount(testPlanRun).then(() => {
+        // Do nothing
+    });
     return populateData({ testResultId });
 };
 

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -81,7 +81,7 @@ const saveTestResultCommon = async ({
     await updateTestPlanRun(testPlanRun.id, { testResults: newTestResults });
 
     // Perform in background
-    if (isSubmit) persistConflictsCount(testPlanRun);
+    if (isSubmit) await persistConflictsCount(testPlanRun);
 
     return populateData({ testResultId });
 };

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -80,11 +80,9 @@ const saveTestResultCommon = async ({
 
     await updateTestPlanRun(testPlanRun.id, { testResults: newTestResults });
 
-    // Ignore result to avoid blocking loads in test runs with a larger amount
-    // of tests and/or test results
-    persistConflictsCount(testPlanRun).then(() => {
-        // Do nothing
-    });
+    // TODO: Avoid blocking loads in test runs with a larger amount of tests
+    //       and/or test results
+    await persistConflictsCount(testPlanRun);
     return populateData({ testResultId });
 };
 

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -80,7 +80,13 @@ const saveTestResultCommon = async ({
 
     await updateTestPlanRun(testPlanRun.id, { testResults: newTestResults });
 
-    // Persist conflicts count
+    // Perform in background
+    if (isSubmit) persistConflictsCount(testPlanRun);
+
+    return populateData({ testResultId });
+};
+
+const persistConflictsCount = async testPlanRun => {
     const { testPlanReport: updatedTestPlanReport } = await populateData({
         testPlanRunId: testPlanRun.id
     });
@@ -91,8 +97,6 @@ const saveTestResultCommon = async ({
             conflictsCount: conflicts.length
         }
     });
-
-    return populateData({ testResultId });
 };
 
 const assertTestResultIsValid = newTestResult => {

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -7,10 +7,7 @@ const deepCustomMerge = require('../../util/deepCustomMerge');
 const deepPickEqual = require('../../util/deepPickEqual');
 const convertTestResultToInput = require('../TestPlanRunOperations/convertTestResultToInput');
 const createTestResultSkeleton = require('../TestPlanRunOperations/createTestResultSkeleton');
-const {
-    updateTestPlanReport
-} = require('../../models/services/TestPlanReportService');
-const conflictsResolver = require('../TestPlanReport/conflictsResolver');
+const persistConflictsCount = require('../helpers/persistConflictsCount');
 
 const saveTestResultCommon = async ({
     testResultId,
@@ -84,19 +81,6 @@ const saveTestResultCommon = async ({
     //       and/or test results
     await persistConflictsCount(testPlanRun);
     return populateData({ testResultId });
-};
-
-const persistConflictsCount = async testPlanRun => {
-    const { testPlanReport: updatedTestPlanReport } = await populateData({
-        testPlanRunId: testPlanRun.id
-    });
-    const conflicts = await conflictsResolver(updatedTestPlanReport);
-    await updateTestPlanReport(updatedTestPlanReport.id, {
-        metrics: {
-            ...updatedTestPlanReport.metrics,
-            conflictsCount: conflicts.length
-        }
-    });
 };
 
 const assertTestResultIsValid = newTestResult => {

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -81,7 +81,7 @@ const saveTestResultCommon = async ({
     await updateTestPlanRun(testPlanRun.id, { testResults: newTestResults });
 
     // Perform in background
-    if (isSubmit) await persistConflictsCount(testPlanRun);
+    persistConflictsCount(testPlanRun);
 
     return populateData({ testResultId });
 };

--- a/server/resolvers/helpers/persistConflictsCount.js
+++ b/server/resolvers/helpers/persistConflictsCount.js
@@ -1,0 +1,20 @@
+const populateData = require('../../services/PopulatedData/populateData');
+const conflictsResolver = require('../TestPlanReport/conflictsResolver');
+const {
+    updateTestPlanReport
+} = require('../../models/services/TestPlanReportService');
+
+const persistConflictsCount = async testPlanRun => {
+    const { testPlanReport: updatedTestPlanReport } = await populateData({
+        testPlanRunId: testPlanRun.id
+    });
+    const conflicts = await conflictsResolver(updatedTestPlanReport);
+    await updateTestPlanReport(updatedTestPlanReport.id, {
+        metrics: {
+            ...updatedTestPlanReport.metrics,
+            conflictsCount: conflicts.length
+        }
+    });
+};
+
+module.exports = persistConflictsCount;


### PR DESCRIPTION
* Conditionally persist computed conflicts to database based on whether the results are being "saved" or "saved & submitted"
* Show loading when necessary when navigating between test run pages (avoid frozen pages for up to ~1s when navigating)