### PR TITLE
Fix bug in database initialization script

### DIFF
--- a/db/scripts/db_init.sh
+++ b/db/scripts/db_init.sh
@@ -16,7 +16,7 @@ fi
 
 result="$(psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='${PGUSER}'")"
 
-if [ $result = '1' ]; then
+if [[ $result = '1' ]]; then
   echo "User ${PGUSER} already exists."
 else
   echo "Creating ${PGUSER} user..."


### PR DESCRIPTION
When the query executed with the `psql` binary returns zero results, it will print nothing to standard output, and the variable designed to capture that output will contain an empty string.

If the `test` binary is invoked with a variable containing the empty string, it will not recognize the value as a distinct argument and will fail to apply comparison operators:

    $ bash -c 'x=""; [ $x == '1' ]'
    bash: line 0: [: ==: unary operator expected

Replace with the `[[` shell built-in to handle this condition appropriately and to align with a similar pattern earlier in the same script.

    $ bash -c 'x=""; [[ $x == '1' ]]'
    $