### PR TITLE
Simplify and safen CLI instructions

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -12,9 +12,7 @@ The database migrations are managed by [Sequelize](https://sequelize.org/). To r
     ```
     - Linux
     ```
-    su root
-    su postgres
-    yarn db-init:dev
+    sudo -u postgres yarn db-init:dev
     ```
 2. Run database migrations
     ```


### PR DESCRIPTION
Avoid temporarily entering a root shell and restrict privilege escalation to a single command.