### PR TITLE
Report build failures during test import

### DIFF
--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -64,6 +64,12 @@ const importTestPlanVersions = async () => {
     });
     console.log('`npm run build` output', buildOutput.stdout.toString());
 
+    if (buildOutput.status !== 0) {
+      throw new Error(
+        'When executed within the ARIA-AT project, the command `npm run build` failed.'
+      );
+    }
+
     const ats = await At.findAll();
     await updateAtsJson(ats);
 


### PR DESCRIPTION
Prior to this commit, the test-importing script would ignore errors in the ARIA-AT project's build process. The script's subsequent behavior was dependent on the particular failure, and if the problem was reported at all, it would be in terms that were only indirectly related to the root cause. For instance:

    Error found: Error: ENOENT: no such file or directory, scandir '/home/mike/aria-at-app/server/scripts/import-tests/tmp/build/tests'    [104/1957]
        at Object.readdirSync (fs.js:1021:3)
        at importTestPlanVersions (/home/mike/aria-at-app/server/scripts/import-tests/index.js:73:33)
    error Command failed with exit code 1.

Immediately exit the test-importing script if the ARIA-AT project's build process fails for any reason.

---

I ran into this because [the ARIA-AT build process is failing on my system](https://github.com/w3c/aria-at/issues/890), but as noted in the commit message, any kind of failure will produce undefined results.