### PR TITLE
Test Management Page

### DIFF
--- a/client/components/App/App.jsx
+++ b/client/components/App/App.jsx
@@ -70,20 +70,20 @@ const App = () => {
                                     Test Reports
                                 </Nav.Link>
                             </li>
-                            {/*{isSignedIn && isAdmin && (*/}
-                            {/*    <li>*/}
-                            {/*        <Nav.Link*/}
-                            {/*            as={Link}*/}
-                            {/*            to="/test-management"*/}
-                            {/*            aria-current={*/}
-                            {/*                location.pathname ===*/}
-                            {/*                '/test-management'*/}
-                            {/*            }*/}
-                            {/*        >*/}
-                            {/*            Test Management*/}
-                            {/*        </Nav.Link>*/}
-                            {/*    </li>*/}
-                            {/*)}*/}
+                            {isSignedIn && isAdmin && (
+                                <li>
+                                    <Nav.Link
+                                        as={Link}
+                                        to="/test-management"
+                                        aria-current={
+                                            location.pathname ===
+                                            '/test-management'
+                                        }
+                                    >
+                                        Test Management
+                                    </Nav.Link>
+                                </li>
+                            )}
                             <li>
                                 <Nav.Link
                                     as={Link}

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -47,10 +47,16 @@ const CandidateTestPlanRun = () => {
     const { atId, testPlanVersionId } = useParams();
     const navigate = useNavigate();
 
+    let testPlanVersionIds = [];
+    if (testPlanVersionId.includes(','))
+        testPlanVersionIds = testPlanVersionId.split(',');
+
     const { loading, data, error, refetch } = useQuery(
         CANDIDATE_REPORTS_QUERY,
         {
-            variables: { testPlanVersionId, atId }
+            variables: testPlanVersionIds.length
+                ? { testPlanVersionIds, atId }
+                : { testPlanVersionId, atId }
         }
     );
     const [addViewer] = useMutation(ADD_VIEWER_MUTATION);
@@ -179,7 +185,7 @@ const CandidateTestPlanRun = () => {
                 tests[0].id,
                 ...tests
                     .filter(test =>
-                        test.viewers.find(
+                        test.viewers?.find(
                             viewer => viewer.username === data.me.username
                         )
                     )
@@ -253,11 +259,31 @@ const CandidateTestPlanRun = () => {
     };
     const at = atMap[atId];
 
-    const testPlanReports = data.testPlanReports;
-    if (testPlanReports.length === 0) return <Navigate to="/404" replace />;
+    const testPlanReports = [];
+    const _testPlanReports = data.testPlanReports;
+    if (_testPlanReports.length === 0) return <Navigate to="/404" replace />;
+
+    const getLatestReleasedAtVersionReport = arr => {
+        return arr.reduce((o1, o2) => {
+            return new Date(o1.latestAtVersionReleasedAt.releasedAt) >
+                new Date(o2.latestAtVersionReleasedAt.releasedAt)
+                ? o1
+                : o2;
+        });
+    };
+
+    Object.keys(atMap).forEach(k => {
+        const group = _testPlanReports.filter(t => t.browser.id == k);
+        if (group.length) {
+            const latestReport = getLatestReleasedAtVersionReport(group);
+            testPlanReports.push(latestReport);
+        }
+    });
 
     const testPlanReport = testPlanReports.find(
-        each => each.testPlanVersion.id === testPlanVersionId
+        each =>
+            each.testPlanVersion.id === testPlanVersionId ||
+            testPlanVersionIds.includes(each.testPlanVersion.id)
     );
 
     const tests = testPlanReport.runnableTests.map((test, index) => ({

--- a/client/components/CandidateTests/CandidateTestPlanRun/queries.js
+++ b/client/components/CandidateTests/CandidateTestPlanRun/queries.js
@@ -25,16 +25,21 @@ export const PROMOTE_VENDOR_REVIEW_STATUS_REPORT_MUTATION = gql`
 `;
 
 export const CANDIDATE_REPORTS_QUERY = gql`
-    query CandidateReportsQuery($testPlanVersionId: ID!, $atId: ID!) {
+    query CandidateReportsQuery(
+        $atId: ID!
+        $testPlanVersionId: ID
+        $testPlanVersionIds: [ID]
+    ) {
         me {
             id
             roles
             username
         }
         testPlanReports(
+            atId: $atId
             statuses: [CANDIDATE]
             testPlanVersionId: $testPlanVersionId
-            atId: $atId
+            testPlanVersionIds: $testPlanVersionIds
         ) {
             id
             candidateStatusReachedAt
@@ -49,6 +54,11 @@ export const CANDIDATE_REPORTS_QUERY = gql`
             at {
                 id
                 name
+            }
+            latestAtVersionReleasedAt {
+                id
+                name
+                releasedAt
             }
             browser {
                 id

--- a/client/components/CandidateTests/index.jsx
+++ b/client/components/CandidateTests/index.jsx
@@ -34,9 +34,17 @@ const CandidateTests = () => {
 
     if (!data) return null;
 
+    const candidateTestPlanReports = data.testPlanReports.filter(
+        t => t.status === 'CANDIDATE'
+    );
+    const recommendedTestPlanReports = data.testPlanReports.filter(
+        t => t.status === 'RECOMMENDED'
+    );
+
     return (
         <TestPlans
-            testPlanReports={data.testPlanReports}
+            candidateTestPlanReports={candidateTestPlanReports}
+            recommendedTestPlanReports={recommendedTestPlanReports}
             triggerPageUpdate={refetch}
         />
     );

--- a/client/components/CandidateTests/queries.js
+++ b/client/components/CandidateTests/queries.js
@@ -2,12 +2,18 @@ import { gql } from '@apollo/client';
 
 export const CANDIDATE_TESTS_PAGE_QUERY = gql`
     query {
-        testPlanReports(statuses: [CANDIDATE]) {
+        testPlanReports(statuses: [CANDIDATE, RECOMMENDED]) {
             id
+            status
             metrics
             at {
                 id
                 name
+            }
+            latestAtVersionReleasedAt {
+                id
+                name
+                releasedAt
             }
             browser {
                 id

--- a/client/components/Reports/SummarizeTestPlanReports.jsx
+++ b/client/components/Reports/SummarizeTestPlanReports.jsx
@@ -139,58 +139,6 @@ const SummarizeTestPlanReports = ({ testPlanReports }) => {
                     if (latestPrevDate > latestCurrDate)
                         resultTestPlanTargets[testPlanTargetKey] =
                             testPlanTargets[testPlanTargetKey];
-
-                    /*
-                    // TODO: Determine if still required for evaluating by
-                        candidateStatusReachedAt and recommendedStatusReachedAt
-                        dates
-                    // Compare if latest version
-                    const latestPrevDate =
-                        new Date(
-                            testPlanTargets[
-                                testPlanTargetKey
-                            ]?.recommendedStatusReachedAt
-                        ) >
-                        new Date(
-                            testPlanTargets[
-                                testPlanTargetKey
-                            ]?.candidateStatusReachedAt
-                        )
-                            ? new Date(
-                                  testPlanTargets[
-                                      testPlanTargetKey
-                                  ]?.recommendedStatusReachedAt
-                              )
-                            : new Date(
-                                  testPlanTargets[
-                                      testPlanTargetKey
-                                  ]?.candidateStatusReachedAt
-                              );
-                    const latestCurrDate =
-                        new Date(
-                            resultTestPlanTargets[
-                                testPlanTargetKey
-                            ]?.recommendedStatusReachedAt
-                        ) >
-                        new Date(
-                            resultTestPlanTargets[
-                                testPlanTargetKey
-                            ]?.candidateStatusReachedAt
-                        )
-                            ? new Date(
-                                  resultTestPlanTargets[
-                                      testPlanTargetKey
-                                  ]?.recommendedStatusReachedAt
-                              )
-                            : new Date(
-                                  resultTestPlanTargets[
-                                      testPlanTargetKey
-                                  ]?.candidateStatusReachedAt
-                              );
-
-                    if (latestPrevDate > latestCurrDate)
-                        resultTestPlanTargets[testPlanTargetKey] =
-                            testPlanTargets[testPlanTargetKey];*/
                 }
             });
         }

--- a/client/components/TestManagement/StatusSummaryRow/index.jsx
+++ b/client/components/TestManagement/StatusSummaryRow/index.jsx
@@ -51,7 +51,7 @@ const PhaseDot = styled.span`
     }
 `;
 
-const StatusSummaryRow = ({ atItems }) => {
+const StatusSummaryRow = ({ reportResult, testPlanVersion }) => {
     const [bulkUpdateTestPlanReportStatusMutation] = useMutation(
         BULK_UPDATE_TEST_PLAN_REPORT_STATUS_MUTATION
     );
@@ -59,7 +59,9 @@ const StatusSummaryRow = ({ atItems }) => {
     const dropdownUpdateReportStatusButtonRef = useRef();
     const { triggerLoad, loadingMessage } = useTriggerLoad();
 
-    const [testPlanReports, setTestPlanReports] = useState(atItems);
+    const [testPlanReports, setTestPlanReports] = useState(
+        Object.values(reportResult).filter(i => i !== null)
+    );
     const [showThemedModal, setShowThemedModal] = useState(false);
     const [themedModalType, setThemedModalType] = useState('warning');
     const [themedModalTitle, setThemedModalTitle] = useState('');
@@ -111,7 +113,7 @@ const StatusSummaryRow = ({ atItems }) => {
         <LoadingStatus message={loadingMessage}>
             <tr>
                 <th>
-                    {testPlanReports[0].testPlanVersion?.title}
+                    {testPlanVersion.title}
                     <PhaseText className={phase.toLowerCase()}>
                         {phase}
                     </PhaseText>
@@ -122,15 +124,17 @@ const StatusSummaryRow = ({ atItems }) => {
                             id={nextId()}
                             ref={dropdownUpdateReportStatusButtonRef}
                             variant="secondary"
-                            aria-label={`Change test plan phase for ${testPlanReports[0].testPlanVersion.title}`}
+                            aria-label={`Change test plan phase for ${testPlanVersion.title}`}
                         >
                             <PhaseDot className={phase.toLowerCase()} />
                             {phase}
                         </Dropdown.Toggle>
                         <Dropdown.Menu role="menu">
+                            {/* TODO: Don't allow reverting to DRAFT until
+                                    data model restructure */}
                             <Dropdown.Item
                                 role="menuitem"
-                                disabled={phase === 'Draft'}
+                                disabled={true}
                                 onClick={async () => {
                                     await bulkUpdateReportStatus(
                                         testPlanReports.map(i => i.id),
@@ -194,7 +198,8 @@ const StatusSummaryRow = ({ atItems }) => {
 };
 
 StatusSummaryRow.propTypes = {
-    atItems: PropTypes.array
+    reportResult: PropTypes.object,
+    testPlanVersion: PropTypes.object
 };
 
 export default StatusSummaryRow;

--- a/client/components/TestManagement/StatusSummaryRow/index.jsx
+++ b/client/components/TestManagement/StatusSummaryRow/index.jsx
@@ -130,11 +130,9 @@ const StatusSummaryRow = ({ reportResult, testPlanVersion }) => {
                             {phase}
                         </Dropdown.Toggle>
                         <Dropdown.Menu role="menu">
-                            {/* TODO: Don't allow reverting to DRAFT until
-                                    data model restructure */}
                             <Dropdown.Item
                                 role="menuitem"
-                                disabled={true}
+                                disabled={phase === 'Draft'}
                                 onClick={async () => {
                                     await bulkUpdateReportStatus(
                                         testPlanReports.map(i => i.id),

--- a/client/components/TestManagement/index.jsx
+++ b/client/components/TestManagement/index.jsx
@@ -188,7 +188,8 @@ const TestManagement = () => {
             )}
 
             <p data-testid="test-management-instructions">
-                Manage test plans in the Test Queue and test plan phases.
+                Manage test plans in the Test Queue (which are using the latest
+                Assistive Technology versions), and their test plan phases.
             </p>
 
             <ManageTestQueue

--- a/client/components/TestManagement/index.jsx
+++ b/client/components/TestManagement/index.jsx
@@ -244,14 +244,15 @@ const TestManagement = () => {
                                                 resultTestPlanTargets,
                                                 combinedTestPlanVersionIdArray
                                             } = combineObject(tabularReport);
-                                            reportResult = resultTestPlanTargets;
-                                            testPlanVersionId = combinedTestPlanVersionIdArray.join(
-                                                ','
-                                            );
+                                            reportResult =
+                                                resultTestPlanTargets;
+                                            testPlanVersionId =
+                                                combinedTestPlanVersionIdArray.join(
+                                                    ','
+                                                );
                                         } else {
-                                            reportResult = Object.values(
-                                                tabularReport
-                                            )[0];
+                                            reportResult =
+                                                Object.values(tabularReport)[0];
                                             testPlanVersionId =
                                                 reportResult.testPlanVersion.id;
                                         }

--- a/client/components/TestManagement/index.jsx
+++ b/client/components/TestManagement/index.jsx
@@ -7,6 +7,11 @@ import StatusSummaryRow from './StatusSummaryRow';
 import PageStatus from '../common/PageStatus';
 import DisclosureComponent from '../common/DisclosureComponent';
 import ManageTestQueue from '../ManageTestQueue';
+import alphabetizeObjectBy from '@client/utils/alphabetizeObjectBy';
+import {
+    getTestPlanTargetTitle,
+    getTestPlanVersionTitle
+} from '@components/Reports/getTitles';
 import './TestManagement.css';
 
 const TestManagement = () => {
@@ -23,9 +28,6 @@ const TestManagement = () => {
     const [testPlanVersions, setTestPlanVersions] = useState([]);
     const [testPlanReports, setTestPlanReports] = useState([]);
 
-    const [summaryGroupedTestPlanReports, setSummaryGroupedTestPlanReports] =
-        useState({});
-
     useEffect(() => {
         if (data) {
             const {
@@ -41,71 +43,6 @@ const TestManagement = () => {
             setPageReady(true);
         }
     }, [data]);
-
-    useEffect(() => {
-        const jawsGroup = testPlanReports.filter(t => t.at.id == 1);
-        const nvdaGroup = testPlanReports.filter(t => t.at.id == 2);
-        const voGroup = testPlanReports.filter(t => t.at.id == 3);
-
-        const groupedData = atGroup => {
-            let allResultGroup = {};
-            let summaryResultGroup = {};
-
-            atGroup.forEach(t => {
-                const testPlanId = t.testPlanVersion.testPlan.directory;
-                if (!allResultGroup[testPlanId])
-                    allResultGroup[testPlanId] = [t];
-                else allResultGroup[testPlanId].push(t);
-
-                // Ensure the latest version is being used in the grouped data
-                // In the future, it can be assumed that the latest can be
-                // consistently retrieved from
-                // `query { testPlans { latestTestPlanVersion } }`
-                if (!summaryResultGroup[testPlanId])
-                    summaryResultGroup[testPlanId] = t;
-                else if (
-                    new Date(t.testPlanVersion.updatedAt) >
-                    new Date(
-                        summaryResultGroup[testPlanId].testPlanVersion.updatedAt
-                    )
-                ) {
-                    summaryResultGroup[testPlanId] = t;
-                }
-            });
-
-            return { allResultGroup, summaryResultGroup };
-        };
-
-        const {
-            allResultGroup: allJawsGroupedByTestPlan,
-            summaryResultGroup: summaryJawsGroupedByTestPlan
-        } = groupedData(jawsGroup);
-        const {
-            allResultGroup: allNvdaGroupedByTestPlan,
-            summaryResultGroup: summaryNvdaGroupedByTestPlan
-        } = groupedData(nvdaGroup);
-        const {
-            allResultGroup: allVoGroupedByTestPlan,
-            summaryResultGroup: summaryVoGroupedByTestPlan
-        } = groupedData(voGroup);
-
-        // TODO: This dataset can be used in the future to complete the AT
-        //       separated sections
-        // eslint-disable-next-line
-        const allGroupedTestPlanReports = {
-            jaws: allJawsGroupedByTestPlan,
-            nvda: allNvdaGroupedByTestPlan,
-            vo: allVoGroupedByTestPlan
-        };
-
-        const summaryGroupedTestPlanReports = {
-            jaws: summaryJawsGroupedByTestPlan,
-            nvda: summaryNvdaGroupedByTestPlan,
-            vo: summaryVoGroupedByTestPlan
-        };
-
-        setSummaryGroupedTestPlanReports(summaryGroupedTestPlanReports);
-    }, [testPlanReports]);
 
     if (error) {
         return (
@@ -127,25 +64,105 @@ const TestManagement = () => {
         );
     }
 
-    const constructStatusSummaryData = () => {
-        let result = {};
-
-        // Arrange the summary data by example
-        Object.keys(summaryGroupedTestPlanReports).forEach(atKey => {
-            Object.keys(summaryGroupedTestPlanReports[atKey]).forEach(
-                exampleKey => {
-                    if (!result[exampleKey]) result[exampleKey] = {};
-                    result[exampleKey][atKey] =
-                        summaryGroupedTestPlanReports[atKey][exampleKey];
-                }
-            );
-        });
-
-        return result;
-    };
-
     const emptyTestPlans = !testPlanReports.length;
-    const summaryData = constructStatusSummaryData();
+
+    const testPlanReportsById = {};
+    let testPlanTargetsById = {};
+    let testPlanVersionsById = {};
+    testPlanReports.forEach(testPlanReport => {
+        const { testPlanVersion, at, browser } = testPlanReport;
+
+        // Construct testPlanTarget
+        const testPlanTarget = { id: `${at.id}${browser.id}`, at, browser };
+        testPlanReportsById[testPlanReport.id] = testPlanReport;
+        testPlanTargetsById[testPlanTarget.id] = testPlanTarget;
+        testPlanVersionsById[testPlanVersion.id] = testPlanVersion;
+    });
+    testPlanTargetsById = alphabetizeObjectBy(testPlanTargetsById, keyValue =>
+        getTestPlanTargetTitle(keyValue[1])
+    );
+    testPlanVersionsById = alphabetizeObjectBy(testPlanVersionsById, keyValue =>
+        getTestPlanVersionTitle(keyValue[1])
+    );
+
+    const tabularReports = {};
+    const tabularReportsByDirectory = {};
+    Object.keys(testPlanVersionsById).forEach(testPlanVersionId => {
+        const directory =
+            testPlanVersionsById[testPlanVersionId].testPlan.directory;
+
+        tabularReports[testPlanVersionId] = {};
+        if (!tabularReportsByDirectory[directory])
+            tabularReportsByDirectory[directory] = {};
+        tabularReportsByDirectory[directory][testPlanVersionId] = {};
+        Object.keys(testPlanTargetsById).forEach(testPlanTargetId => {
+            tabularReports[testPlanVersionId][testPlanTargetId] = null;
+            tabularReportsByDirectory[directory][testPlanVersionId][
+                testPlanTargetId
+            ] = null;
+        });
+    });
+    testPlanReports.forEach(testPlanReport => {
+        const { testPlanVersion, at, browser } = testPlanReport;
+        const directory = testPlanVersion.testPlan.directory;
+
+        // Construct testPlanTarget
+        const testPlanTarget = { id: `${at.id}${browser.id}`, at, browser };
+        tabularReports[testPlanVersion.id][testPlanTarget.id] = testPlanReport;
+        tabularReportsByDirectory[directory][testPlanVersion.id][
+            testPlanTarget.id
+        ] = testPlanReport;
+        tabularReportsByDirectory[directory][
+            testPlanVersion.id
+        ].testPlanVersion = testPlanVersion;
+    });
+
+    const combineObject = originalObject => {
+        let combinedTestPlanVersionIdArray = [];
+        let resultTestPlanTargets = Object.values(originalObject)[0];
+        combinedTestPlanVersionIdArray.push(
+            resultTestPlanTargets.testPlanVersion.id
+        );
+
+        for (let i = 1; i < Object.values(originalObject).length; i++) {
+            let testPlanTargets = Object.values(originalObject)[i];
+            if (
+                !combinedTestPlanVersionIdArray.includes(
+                    testPlanTargets.testPlanVersion.id
+                )
+            )
+                combinedTestPlanVersionIdArray.push(
+                    testPlanTargets.testPlanVersion.id
+                );
+
+            delete testPlanTargets.testPlanVersion;
+
+            // Check if exists in newObject and add/update newObject based on criteria
+            Object.keys(testPlanTargets).forEach(testPlanTargetKey => {
+                if (!resultTestPlanTargets[testPlanTargetKey])
+                    resultTestPlanTargets[testPlanTargetKey] =
+                        testPlanTargets[testPlanTargetKey];
+                else {
+                    const latestPrevDate = new Date(
+                        testPlanTargets[
+                            testPlanTargetKey
+                        ]?.latestAtVersionReleasedAt?.releasedAt
+                    );
+
+                    const latestCurrDate = new Date(
+                        resultTestPlanTargets[
+                            testPlanTargetKey
+                        ]?.latestAtVersionReleasedAt?.releasedAt
+                    );
+
+                    if (latestPrevDate > latestCurrDate)
+                        resultTestPlanTargets[testPlanTargetKey] =
+                            testPlanTargets[testPlanTargetKey];
+                }
+            });
+        }
+        return { resultTestPlanTargets, combinedTestPlanVersionIdArray };
+    };
 
     return (
         <Container id="main" as="main" tabIndex="-1">
@@ -204,24 +221,52 @@ const TestManagement = () => {
                             </thead>
                             <tbody>
                                 {/* Sort the summary items by title */}
-                                {Object.keys(summaryData)
+                                {Object.values(tabularReportsByDirectory)
                                     .sort((a, b) =>
-                                        Object.values(summaryData[a])[0]
-                                            .testPlanVersion.title <
-                                        Object.values(summaryData[b])[0]
-                                            .testPlanVersion.title
+                                        Object.values(a)[0].testPlanVersion
+                                            .title <
+                                        Object.values(b)[0].testPlanVersion
+                                            .title
                                             ? -1
                                             : 1
                                     )
-                                    .map(k => {
-                                        const summaryItem = summaryData[k];
-                                        const atItems =
-                                            Object.values(summaryItem);
-                                        const key = `summary-table-item-${k}`;
+                                    .map(tabularReport => {
+                                        let reportResult = null;
+                                        let testPlanVersionId = null;
+
+                                        // Evaluate what is prioritised across the
+                                        // collection of testPlanVersions
+                                        if (
+                                            Object.values(tabularReport)
+                                                .length > 1
+                                        ) {
+                                            const {
+                                                resultTestPlanTargets,
+                                                combinedTestPlanVersionIdArray
+                                            } = combineObject(tabularReport);
+                                            reportResult = resultTestPlanTargets;
+                                            testPlanVersionId = combinedTestPlanVersionIdArray.join(
+                                                ','
+                                            );
+                                        } else {
+                                            reportResult = Object.values(
+                                                tabularReport
+                                            )[0];
+                                            testPlanVersionId =
+                                                reportResult.testPlanVersion.id;
+                                        }
+
+                                        const testPlanVersion =
+                                            reportResult.testPlanVersion;
+                                        delete reportResult.testPlanVersion;
+
                                         return (
                                             <StatusSummaryRow
-                                                key={key}
-                                                atItems={atItems}
+                                                key={testPlanVersionId}
+                                                testPlanVersion={
+                                                    testPlanVersion
+                                                }
+                                                reportResult={reportResult}
                                             />
                                         );
                                     })}

--- a/client/components/TestManagement/queries.js
+++ b/client/components/TestManagement/queries.js
@@ -32,6 +32,11 @@ export const TEST_MANAGEMENT_PAGE_QUERY = gql`
                 id
                 name
             }
+            latestAtVersionReleasedAt {
+                id
+                name
+                releasedAt
+            }
             browser {
                 id
                 name

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -126,6 +126,39 @@ export const TEST_PLAN_REPORT_QUERY = gql`
     }
 `;
 
+export const TEST_PLAN_REPORT_CANDIDATE_RECOMMENDED_QUERY = gql`
+    query CandidateTestPlanReportsQuery {
+        testPlanReports(statuses: [CANDIDATE, RECOMMENDED]) {
+            id
+            status
+            latestAtVersionReleasedAt {
+                id
+                name
+                releasedAt
+            }
+            candidateStatusReachedAt
+            recommendedStatusTargetDate
+            at {
+                id
+                name
+            }
+            browser {
+                id
+                name
+            }
+            testPlanVersion {
+                id
+                title
+                gitSha
+                testPlan {
+                    directory
+                }
+                metadata
+            }
+        }
+    }
+`;
+
 export const ADD_AT_VERSION_MUTATION = gql`
     mutation AddAtVersion($atId: ID!, $name: String!, $releasedAt: Timestamp!) {
         at(id: $atId) {
@@ -241,9 +274,15 @@ export const UPDATE_TEST_PLAN_REPORT_STATUS_MUTATION = gql`
     mutation UpdateTestPlanReportStatus(
         $testReportId: ID!
         $status: TestPlanReportStatus!
+        $candidateStatusReachedAt: Timestamp
+        $recommendedStatusTargetDate: Timestamp
     ) {
         testPlanReport(id: $testReportId) {
-            updateStatus(status: $status) {
+            updateStatus(
+                status: $status
+                candidateStatusReachedAt: $candidateStatusReachedAt
+                recommendedStatusTargetDate: $recommendedStatusTargetDate
+            ) {
                 testPlanReport {
                     status
                 }

--- a/client/components/TestQueueRow/CandidatePhaseSelectModal.jsx
+++ b/client/components/TestQueueRow/CandidatePhaseSelectModal.jsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Form } from 'react-bootstrap';
+import styled from '@emotion/styled';
+import BasicModal from '../common/BasicModal';
+import { convertDateToString } from '../../utils/formatter';
+import FormCheck from 'react-bootstrap/FormCheck';
+
+const ModalInnerSectionContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const CandidatePhaseSelectModal = ({
+    show = false,
+    title = null,
+    dates = [],
+    handleAction = () => {},
+    handleClose = () => {}
+}) => {
+    const [selectedDateIndex, setSelectedDateIndex] = useState('0');
+
+    const handleChange = e => {
+        const { value } = e.target;
+        setSelectedDateIndex(value);
+    };
+
+    const onSubmit = () => {
+        if (selectedDateIndex == -1) handleAction(null);
+        const date = dates[selectedDateIndex];
+        handleAction(date);
+    };
+
+    return (
+        <BasicModal
+            show={show}
+            closeButton={false}
+            title={title}
+            content={
+                <ModalInnerSectionContainer>
+                    <Form.Group>
+                        {dates.map((d, index) => {
+                            return (
+                                <FormCheck
+                                    key={`CandidatePhaseSelection_${index}`}
+                                >
+                                    <FormCheck.Input
+                                        id={`${index}`}
+                                        type="radio"
+                                        value={index}
+                                        onChange={handleChange}
+                                        checked={selectedDateIndex == index}
+                                    />
+                                    <FormCheck.Label htmlFor={`${index}`}>
+                                        Candidate Phase Start Date on{' '}
+                                        <b>
+                                            {convertDateToString(
+                                                d.candidateStatusReachedAt,
+                                                'MMMM D, YYYY'
+                                            )}
+                                        </b>{' '}
+                                        and Recommended Phase Target Completion
+                                        Date on{' '}
+                                        <b>
+                                            {convertDateToString(
+                                                d.recommendedStatusTargetDate,
+                                                'MMMM D, YYYY'
+                                            )}
+                                        </b>
+                                    </FormCheck.Label>
+                                </FormCheck>
+                            );
+                        })}
+                        <FormCheck key={'CandidatePhaseSelection_-1'}>
+                            <FormCheck.Input
+                                id="-1"
+                                type="radio"
+                                value={-1}
+                                onChange={handleChange}
+                                checked={selectedDateIndex == -1}
+                            />
+                            <FormCheck.Label htmlFor="-1">
+                                <b>Create new Candidate Phase starting today</b>
+                            </FormCheck.Label>
+                        </FormCheck>
+                    </Form.Group>
+                </ModalInnerSectionContainer>
+            }
+            actionLabel={'Select Candidate Phase'}
+            handleAction={onSubmit}
+            handleClose={handleClose}
+        />
+    );
+};
+
+CandidatePhaseSelectModal.propTypes = {
+    show: PropTypes.bool,
+    title: PropTypes.node.isRequired,
+    dates: PropTypes.array,
+    handleAction: PropTypes.func,
+    handleClose: PropTypes.func
+};
+
+export default CandidatePhaseSelectModal;

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -14,6 +14,7 @@ import ATAlert from '../ATAlert';
 import { capitalizeEachWord } from '../../utils/formatter';
 import {
     TEST_PLAN_REPORT_QUERY,
+    TEST_PLAN_REPORT_CANDIDATE_RECOMMENDED_QUERY,
     ASSIGN_TESTER_MUTATION,
     UPDATE_TEST_PLAN_REPORT_STATUS_MUTATION,
     REMOVE_TEST_PLAN_REPORT_MUTATION,
@@ -25,6 +26,8 @@ import TestPlanUpdaterModal from '../TestPlanUpdater/TestPlanUpdaterModal';
 import BasicThemedModal from '../common/BasicThemedModal';
 import { LoadingStatus, useTriggerLoad } from '../common/LoadingStatus';
 import './TestQueueRow.css';
+import CandidatePhaseSelectModal from '@components/TestQueueRow/CandidatePhaseSelectModal';
+
 const TestQueueRow = ({
     user = {},
     testers = [],
@@ -45,6 +48,8 @@ const TestQueueRow = ({
     const deleteTestPlanButtonRef = useRef();
     const updateTestPlanStatusButtonRef = useRef();
 
+    const [candidatePhaseTestPlanReports, setCandidatePhaseTestPlanReports] =
+        useState([]);
     const [alertMessage, setAlertMessage] = useState('');
 
     const [showThemedModal, setShowThemedModal] = useState(false);
@@ -63,6 +68,8 @@ const TestQueueRow = ({
     const [removeTesterResults] = useMutation(REMOVE_TESTER_RESULTS_MUTATION);
 
     const [showTestPlanUpdaterModal, setShowTestPlanUpdaterModal] =
+        useState(false);
+    const [showCandidatePhaseSelectModal, setShowCandidatePhaseSelectModal] =
         useState(false);
     const [testPlanReport, setTestPlanReport] = useState(testPlanReportData);
     const [isLoading, setIsLoading] = useState(false);
@@ -378,14 +385,107 @@ const TestQueueRow = ({
     const updateReportStatus = async status => {
         try {
             await triggerLoad(async () => {
-                await updateTestPlanReportStatus({
-                    variables: {
-                        testReportId: testPlanReport.id,
-                        status: status
+                if (status === 'CANDIDATE') {
+                    // Get list of testPlanReports which are already in CANDIDATE phase and check to see which
+                    // is also the same pattern as what's being updated here to provide as a date option
+                    const { data } = await client.query({
+                        query: TEST_PLAN_REPORT_CANDIDATE_RECOMMENDED_QUERY,
+                        fetchPolicy: 'network-only'
+                    });
+
+                    // TODO: Check to see if the proposed test plan report to be promoted to CANDIDATE
+                    //  has a test plan version date less than whatever is in CANDIDATE or RECOMMENDED
+                    //  tests already, if any, and note it may never be displayed to the admin
+
+                    // --- SECTION START: OutdatedCandidatePhaseComparison
+                    // Check to see if there are candidate test reports are already being compared
+                    // which can never be shown in the test reports page as it currently is, so do
+                    // not show it as an existing candidate phase option
+                    const ignoredIds = [];
+
+                    const directory = testPlanVersion.testPlan.directory;
+                    const candidateReports = data.testPlanReports.filter(
+                        r =>
+                            r.status === 'CANDIDATE' &&
+                            r.testPlanVersion.testPlan.directory === directory
+                    );
+
+                    const recommendedReports = data.testPlanReports.filter(
+                        r =>
+                            r.status === 'RECOMMENDED' &&
+                            r.testPlanVersion.testPlan.directory === directory
+                    );
+
+                    recommendedReports.forEach(r => {
+                        candidateReports.forEach(t => {
+                            if (
+                                !ignoredIds.includes(t.id) &&
+                                t.at.id == r.at.id &&
+                                t.browser.id == r.browser.id &&
+                                t.testPlanVersion.testPlan.directory ==
+                                    r.testPlanVersion.testPlan.directory &&
+                                new Date(
+                                    t.latestAtVersionReleasedAt.releasedAt
+                                ) <
+                                    new Date(
+                                        r.latestAtVersionReleasedAt.releasedAt
+                                    )
+                            )
+                                ignoredIds.push(t.id);
+                        });
+                    });
+
+                    const filteredCandidateReports = candidateReports.filter(
+                        t => !ignoredIds.includes(t.id)
+                    );
+                    // --- SECTION END: OutdatedCandidatePhaseComparison
+
+                    const dates = filteredCandidateReports
+                        .map(c => {
+                            return {
+                                candidateStatusReachedAt:
+                                    c.candidateStatusReachedAt,
+                                recommendedStatusTargetDate:
+                                    c.recommendedStatusTargetDate
+                            };
+                        })
+                        // Sort in descending order of dates (top is the latest date the existing
+                        // candidate report status was reached at)
+                        .sort((a, b) =>
+                            new Date(a.candidateStatusReachedAt) >
+                            new Date(b.candidateStatusReachedAt)
+                                ? -1
+                                : 1
+                        );
+
+                    const stringifiedDates = dates.map(d => JSON.stringify(d));
+                    const uniq = [...new Set(stringifiedDates)];
+                    const candidatePhaseList = uniq.map(u => JSON.parse(u));
+                    setCandidatePhaseTestPlanReports(candidatePhaseList);
+
+                    if (candidatePhaseList.length > 0) {
+                        // There already exists a Test Plan Report which uses this pattern so
+                        // there is already a candidate phase to select from
+                        setShowCandidatePhaseSelectModal(true);
+                    } else {
+                        await updateTestPlanReportStatus({
+                            variables: {
+                                testReportId: testPlanReport.id,
+                                status: status
+                            }
+                        });
+                        await triggerPageUpdate();
                     }
-                });
-                if (status === 'CANDIDATE') await triggerPageUpdate();
-                else await triggerTestPlanReportUpdate();
+                } else {
+                    // Create a new candidate phase since no others exist
+                    await updateTestPlanReportStatus({
+                        variables: {
+                            testReportId: testPlanReport.id,
+                            status: status
+                        }
+                    });
+                    await triggerTestPlanReportUpdate();
+                }
             }, 'Updating Test Plan Status');
         } catch (e) {
             showThemedMessage(
@@ -466,6 +566,45 @@ const TestQueueRow = ({
             tester.username,
             'completed'
         ].join('-');
+
+    const onHandleCandidatePhaseSelectModalAction = async date => {
+        let variables = {};
+
+        if (date) {
+            const { candidateStatusReachedAt, recommendedStatusTargetDate } =
+                date;
+            variables = {
+                candidateStatusReachedAt,
+                recommendedStatusTargetDate
+            };
+        }
+
+        // Null 'date' if candidate phase is to be created; promote to candidate phase as normal
+        try {
+            await triggerLoad(async () => {
+                setShowCandidatePhaseSelectModal(false);
+                await updateTestPlanReportStatus({
+                    variables: {
+                        testReportId: testPlanReport.id,
+                        status: 'CANDIDATE',
+                        ...variables
+                    }
+                });
+                await triggerPageUpdate();
+            }, 'Updating Test Plan Status');
+        } catch (e) {
+            showThemedMessage(
+                'Error Updating Test Plan Status',
+                <>{e.message}</>,
+                'warning'
+            );
+        }
+    };
+
+    const onCandidatePhaseSelectModalClose = () => {
+        setShowCandidatePhaseSelectModal(false);
+        focusButtonRef.current.focus();
+    };
 
     return (
         <LoadingStatus message={loadingMessage}>
@@ -653,6 +792,15 @@ const TestQueueRow = ({
                     handleClose={() => setShowTestPlanUpdaterModal(false)}
                     testPlanReportId={testPlanReportId}
                     triggerTestPlanReportUpdate={triggerTestPlanReportUpdate}
+                />
+            )}
+            {showCandidatePhaseSelectModal && (
+                <CandidatePhaseSelectModal
+                    show={showCandidatePhaseSelectModal}
+                    title={`Select existing Candidate Phase for the ${testPlanVersion.title}, ${testPlanReport.at?.name} & ${testPlanReport.browser?.name} Test Plan Report`}
+                    dates={candidatePhaseTestPlanReports}
+                    handleAction={onHandleCandidatePhaseSelectModalAction}
+                    handleClose={onCandidatePhaseSelectModalClose}
                 />
             )}
             {showThemedModal && (

--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -11,7 +11,7 @@ import TestQueue from '@components/TestQueue';
 import TestRun from '@components/TestRun';
 import UserSettings from '@components/UserSettings';
 import CandidateTestPlanRun from '@components/CandidateTests/CandidateTestPlanRun';
-// import TestManagement from '@components/TestManagement';
+import TestManagement from '@components/TestManagement';
 
 export default () => (
     <Routes>
@@ -65,15 +65,15 @@ export default () => (
                 </ConfirmAuth>
             }
         />
-        {/*<Route*/}
-        {/*    exact*/}
-        {/*    path="/test-management"*/}
-        {/*    element={*/}
-        {/*        <ConfirmAuth requiredPermission="ADMIN">*/}
-        {/*            <TestManagement />*/}
-        {/*        </ConfirmAuth>*/}
-        {/*    }*/}
-        {/*/>*/}
+        <Route
+            exact
+            path="/test-management"
+            element={
+                <ConfirmAuth requiredPermission="ADMIN">
+                    <TestManagement />
+                </ConfirmAuth>
+            }
+        />
         <Route exact path="/invalid-request" element={<InvalidRequest />} />
         <Route exact path="/404" element={<NotFound />} />
         <Route exact path="*" element={<Navigate to="/404" replace />} />

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -826,7 +826,7 @@ const graphqlSchema = gql`
         """
         The latest AT Version used collecting results for this report.
         """
-        latestAtVersionReleasedAt: AtVersion!
+        latestAtVersionReleasedAt: AtVersion
         """
         The browser used when collecting results.
         """

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1083,7 +1083,11 @@ const graphqlSchema = gql`
         Update the report status. Remember that all conflicts must be resolved
         when setting the status to IN_REVIEW. Only available to admins.
         """
-        updateStatus(status: TestPlanReportStatus!): PopulatedData!
+        updateStatus(
+            status: TestPlanReportStatus!
+            candidateStatusReachedAt: Timestamp
+            recommendedStatusTargetDate: Timestamp
+        ): PopulatedData!
         """
         Update the report status for multiple TestPlanReports. Remember that all
         conflicts must be resolved when setting the status to IN_REVIEW. Only

--- a/server/resolvers/TestPlanReport/latestAtVersionReleasedAtResolver.js
+++ b/server/resolvers/TestPlanReport/latestAtVersionReleasedAtResolver.js
@@ -6,13 +6,18 @@ const latestAtVersionReleasedAtResolver = async testPlanReport => {
     // Return first element because result should already be sorted by descending
     // order of releasedAt date for AtVersion
     const results = await getUniqueAtVersionsForReport(testPlanReport.id);
-    const { atVersionId, name, releasedAt } = results[0];
+    if (results[0]) {
+        const { atVersionId, name, releasedAt } = results[0];
+        return {
+            id: atVersionId,
+            name,
+            releasedAt
+        };
+    }
 
-    return {
-        id: atVersionId,
-        name,
-        releasedAt
-    };
+    // When TestPlanReport is DRAFT and an assigned tester hasn't set a
+    // TestPlanVersion
+    return null;
 };
 
 module.exports = latestAtVersionReleasedAtResolver;

--- a/server/resolvers/TestPlanReportOperations/updateStatusResolver.js
+++ b/server/resolvers/TestPlanReportOperations/updateStatusResolver.js
@@ -12,7 +12,7 @@ const getMetrics = require('../../util/getMetrics');
 
 const updateStatusResolver = async (
     { parentContext: { id: testPlanReportId } },
-    { status },
+    { status, candidateStatusReachedAt, recommendedStatusTargetDate },
     { user }
 ) => {
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
@@ -63,15 +63,20 @@ const updateStatusResolver = async (
                 metrics: { ...testPlanReport.metrics, ...metrics }
             };
         } else if (status === 'CANDIDATE') {
-            const candidateStatusReachedAt = new Date();
+            const candidateStatusReachedAtValue = candidateStatusReachedAt
+                ? candidateStatusReachedAt
+                : new Date();
+            const recommendedStatusTargetDateValue = recommendedStatusTargetDate
+                ? recommendedStatusTargetDate
+                : recommendedStatusTargetDateResolver({
+                      candidateStatusReachedAt
+                  });
+
             updateParams = {
                 ...updateParams,
-                candidateStatusReachedAt,
                 metrics: { ...testPlanReport.metrics, ...metrics },
-                recommendedStatusTargetDate:
-                    recommendedStatusTargetDateResolver({
-                        candidateStatusReachedAt
-                    }),
+                candidateStatusReachedAt: candidateStatusReachedAtValue,
+                recommendedStatusTargetDate: recommendedStatusTargetDateValue,
                 vendorReviewStatus: 'READY'
             };
         } else if (status === 'RECOMMENDED') {


### PR DESCRIPTION
Reintroducing the Test Management page with minimal features. This is located at `<base_url>/test-management`

The page now includes a `Status Summary` section which administrators can use to move the status of test plans between `DRAFT`, `CANDIDATE` and `RECOMMENDED`. The data being represented is also based on the test plan reports which are using the latest version of their respective ATs.