### PR TITLE
Disallowing Test Plans with Incomplete Tests

### DIFF
--- a/client/components/CandidateTests/CandidateTestPlanRun/CandidateTestPlanRun.css
+++ b/client/components/CandidateTests/CandidateTestPlanRun/CandidateTestPlanRun.css
@@ -157,3 +157,7 @@
     position: relative;
     top: -5px;
 }
+
+.incomplete-test-plan-information-text {
+    margin-top: 5%;
+}

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -513,10 +513,17 @@ const CandidateTestPlanRun = () => {
                             );
                         } else {
                             return (
-                            <h2 className="test-results-header">
-                                Test Result: INCOMPLETE
-                            </h2>
-                            )
+                                <>
+                                    <h2 className="test-results-header">
+                                        Test Result: INCOMPLETE
+                                    </h2>
+                                    <p className="incomplete-test-plan-information-text">
+                                        Test plans with incomplete tests cannot
+                                        be finished. These tests should have
+                                        their candidate status removed.
+                                    </p>
+                                </>
+                            );
                         }
                     })
                 ]}
@@ -538,6 +545,11 @@ const CandidateTestPlanRun = () => {
         fileBugUrl =
             'https://github.com/FreedomScientific/VFO-standards-support/issues';
     }
+
+    const runnableTestsLength = testPlanReport.runnableTests.length;
+    const incompleteTestRuns = testPlanReport.draftTestPlanRuns.filter(
+        draft => draft.testResultsLength != runnableTestsLength
+    );
 
     return (
         <Container className="test-run-container">
@@ -612,7 +624,11 @@ const CandidateTestPlanRun = () => {
                                                             true
                                                         );
                                                     }}
-                                                    disabled={!isLastTest}
+                                                    disabled={
+                                                        !isLastTest ||
+                                                        incompleteTestRuns.length >
+                                                            0
+                                                    }
                                                 >
                                                     Finish
                                                 </Button>

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -492,21 +492,30 @@ const CandidateTestPlanRun = () => {
                             testPlanReport.finalizedTestResults[
                                 currentTestIndex
                             ];
-                        const { testsPassedCount } = getMetrics({ testResult });
-                        return (
-                            <>
-                                <h2 className="test-results-header">
-                                    Test Result:{' '}
-                                    {testsPassedCount ? 'PASS' : 'FAIL'}
-                                </h2>
-                                <TestPlanResultsTable
-                                    tableClassName="test-results-table"
-                                    key={`${testPlanReport.id} + ${testResult.id}`}
-                                    test={currentTest}
-                                    testResult={testResult}
-                                />
-                            </>
-                        );
+
+                        if (testResult) {
+                            const { testsPassedCount } = getMetrics({
+                                testResult
+                            });
+                            return (
+                                <>
+                                    <h2 className="test-results-header">
+                                        Test Result:{' '}
+                                        {testsPassedCount ? 'PASS' : 'FAIL'}
+                                    </h2>
+                                    <TestPlanResultsTable
+                                        tableClassName="test-results-table"
+                                        key={`${testPlanReport.id} + ${testResult.id}`}
+                                        test={currentTest}
+                                        testResult={testResult}
+                                    />
+                                </>
+                            );
+                        } else {
+                            <h2 className="test-results-header">
+                                Test Result: INCOMPLETE
+                            </h2>;
+                        }
                     })
                 ]}
                 stacked

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -165,6 +165,21 @@ const CandidateTestPlanRun = () => {
         setThankYouModalShowing(true);
     };
 
+    const handleIncompleteTestPlans = () => {
+        const runnableTests = testPlanReport.runnableTests;
+        const finalizedTests = testPlanReport.finalizedTestResults;
+        const finalizedTestIds = finalizedTests.map(x => x.test.id);
+
+        const hasIncompleteTests =
+            runnableTests.length != finalizedTests.length;
+
+        const viewedCompleteTests = viewedTests.filter(viewedTest =>
+            finalizedTestIds.includes(viewedTest)
+        );
+
+        return { hasIncompleteTests, viewedCompleteTests };
+    };
+
     useEffect(() => {
         if (data) {
             if (
@@ -344,6 +359,9 @@ const CandidateTestPlanRun = () => {
             return githubUrl;
         }
     };
+
+    const { hasIncompleteTests, viewedCompleteTests } =
+        handleIncompleteTestPlans();
 
     const heading = (
         <div className="test-info-heading">
@@ -546,11 +564,6 @@ const CandidateTestPlanRun = () => {
             'https://github.com/FreedomScientific/VFO-standards-support/issues';
     }
 
-    const runnableTestsLength = testPlanReport.runnableTests.length;
-    const incompleteTestRuns = testPlanReport.draftTestPlanRuns.filter(
-        draft => draft.testResultsLength != runnableTestsLength
-    );
-
     return (
         <Container className="test-run-container">
             <Helmet>
@@ -565,7 +578,7 @@ const CandidateTestPlanRun = () => {
                     currentTestIndex={currentTestIndex}
                     toggleShowClick={toggleTestNavigator}
                     handleTestClick={handleTestClick}
-                    viewedTests={viewedTests}
+                    viewedTests={viewedCompleteTests}
                 />
                 <Col
                     className="candidate-test-area"
@@ -626,8 +639,7 @@ const CandidateTestPlanRun = () => {
                                                     }}
                                                     disabled={
                                                         !isLastTest ||
-                                                        incompleteTestRuns.length >
-                                                            0
+                                                        hasIncompleteTests
                                                     }
                                                 >
                                                     Finish

--- a/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateTests/CandidateTestPlanRun/index.jsx
@@ -512,9 +512,11 @@ const CandidateTestPlanRun = () => {
                                 </>
                             );
                         } else {
+                            return (
                             <h2 className="test-results-header">
                                 Test Result: INCOMPLETE
-                            </h2>;
+                            </h2>
+                            )
                         }
                     })
                 ]}

--- a/client/components/TestQueueRow/TestQueueRow.css
+++ b/client/components/TestQueueRow/TestQueueRow.css
@@ -107,6 +107,14 @@ button.more-actions:active {
     width: initial;
 }
 
+.next-report-status-information-text {
+    font-size: small;
+    text-align: center;
+    display: block;
+    margin: 5%;
+    color:gray;
+}
+
 /* tr.test-queue-run-row td:first-child {
     padding: 0.75rem;
 } */

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -565,7 +565,6 @@ const TestQueueRow = ({
                                                 nextReportStatus
                                             );
                                         }}
-                                        disabled = {!nextReportStatusCanContinue}
                                     >
                                         Mark as{' '}
                                         {capitalizeEachWord(nextReportStatus, {

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -427,17 +427,11 @@ const TestQueueRow = ({
     };
 
     const evaluateNewReportStatus = () => {
-        const {
-            status,
-            conflictsLength,
-            draftTestPlanRuns,
-            runnableTestsLength
-        } = testPlanReport;
+        const { status, conflictsLength, runnableTestsLength, finalizedTests } =
+            testPlanReport;
         const conflictsCount = conflictsLength;
 
-        const incompleteTestRuns = draftTestPlanRuns.filter(
-            draft => draft.testResultsLength != runnableTestsLength
-        );
+        const hasIncompleteTests = runnableTestsLength != finalizedTests.length;
 
         // If there are no conflicts OR the test has been marked as "final",
         // and admin can mark a test run as "draft"
@@ -463,7 +457,7 @@ const TestQueueRow = ({
             newStatus = 'CANDIDATE';
         }
 
-        if (newStatus === 'CANDIDATE' && incompleteTestRuns.length > 0) {
+        if (newStatus === 'CANDIDATE' && hasIncompleteTests) {
             newStatusCanContinue = false;
             newStatusInformationText =
                 'Incomplete test plans cannot transition to the candidate report status.';

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -434,8 +434,10 @@ const TestQueueRow = ({
             runnableTestsLength
         } = testPlanReport;
         const conflictsCount = conflictsLength;
-        
-        const incompleteTestRuns = draftTestPlanRuns.filter(draft => draft.testResultsLength != runnableTestsLength)
+
+        const incompleteTestRuns = draftTestPlanRuns.filter(
+            draft => draft.testResultsLength != runnableTestsLength
+        );
 
         // If there are no conflicts OR the test has been marked as "final",
         // and admin can mark a test run as "draft"
@@ -456,25 +458,28 @@ const TestQueueRow = ({
         else if (
             status === 'IN_REVIEW' &&
             conflictsCount === 0 &&
-            testPlanRunsWithResults.length > 0 
+            testPlanRunsWithResults.length > 0
         ) {
             newStatus = 'CANDIDATE';
         }
 
-        if (newStatus === 'CANDIDATE' &&
-        incompleteTestRuns.length > 0) {
+        if (newStatus === 'CANDIDATE' && incompleteTestRuns.length > 0) {
             newStatusCanContinue = false;
-            newStatusInformationText = "Incomplete test plans cannot transition to the candidate report status."
-        }
-        else {
+            newStatusInformationText =
+                'Incomplete test plans cannot transition to the candidate report status.';
+        } else {
             newStatusCanContinue = true;
         }
 
-        return {newStatus, newStatusCanContinue, newStatusInformationText};
+        return { newStatus, newStatusCanContinue, newStatusInformationText };
     };
 
     const { status, results } = evaluateStatusAndResults();
-    const {newStatus:nextReportStatus, newStatusCanContinue:nextReportStatusCanContinue, newStatusInformationText:nextReportStatusInformationText} = evaluateNewReportStatus();
+    const {
+        newStatus: nextReportStatus,
+        newStatusCanContinue: nextReportStatusCanContinue,
+        newStatusInformationText: nextReportStatusInformationText
+    } = evaluateNewReportStatus();
 
     const getRowId = tester =>
         [
@@ -553,29 +558,37 @@ const TestQueueRow = ({
                     <div className="status-wrapper">{status}</div>
                     {isSignedIn && isTester && (
                         <div className="secondary-actions">
-                            {isAdmin && !isLoading && nextReportStatus && nextReportStatusCanContinue && (
-                                <>
-                                    <Button
-                                        ref={updateTestPlanStatusButtonRef}
-                                        variant="secondary"
-                                        onClick={async () => {
-                                            focusButtonRef.current =
-                                                updateTestPlanStatusButtonRef.current;
-                                            await updateReportStatus(
-                                                nextReportStatus
-                                            );
-                                        }}
-                                    >
-                                        Mark as{' '}
-                                        {capitalizeEachWord(nextReportStatus, {
-                                            splitChar: '_'
-                                        })}
-                                    </Button>
-                                </>
-                            )}
+                            {isAdmin &&
+                                !isLoading &&
+                                nextReportStatus &&
+                                nextReportStatusCanContinue && (
+                                    <>
+                                        <Button
+                                            ref={updateTestPlanStatusButtonRef}
+                                            variant="secondary"
+                                            onClick={async () => {
+                                                focusButtonRef.current =
+                                                    updateTestPlanStatusButtonRef.current;
+                                                await updateReportStatus(
+                                                    nextReportStatus
+                                                );
+                                            }}
+                                        >
+                                            Mark as{' '}
+                                            {capitalizeEachWord(
+                                                nextReportStatus,
+                                                {
+                                                    splitChar: '_'
+                                                }
+                                            )}
+                                        </Button>
+                                    </>
+                                )}
 
                             {nextReportStatusInformationText && (
-                                <span className='next-report-status-information-text'>{nextReportStatusInformationText}</span>
+                                <span className="next-report-status-information-text">
+                                    {nextReportStatusInformationText}
+                                </span>
                             )}
                             {results}
                         </div>


### PR DESCRIPTION
Reference Issue: https://github.com/w3c/aria-at-app/issues/493

Per the working group, incomplete test plans cannot transition to the candidacy status. This PR is a fix for this issue.


I have ran all these test cases, but have also listed them here for people to double check and/or list if i missed anything. 

Test Cases:

- Verify the test cases from the original issue no longer encounter the error
- Verify the behavior for an incomplete candidate test already existing

1. From another branch, transition an incomplete test plan to the candidate status
2. Migrate back to this branch, verify that the test navigator shows the correct icons for incomplete tests, the incomplete test also shows incomplete, and that a user cannot 'finish' this test. 

- Verify the behavior for an incomplete test plan in review on the test queue page

1. Create an incomplete test plan
2. Set it's status to 'In Review'
3. Validate that you cannot transition it to 'candidate' and that it tells you why you cannot as well.

- Verify the styling in general
- Verify that nothing else is broken

1. General Test Queue Behavior
2. General Candidate Test Behavior