### PR TITLE
Optimize loading of embedded reports

### DIFF
--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -55,24 +55,29 @@ const getLatestReportsForPattern = async pattern => {
                         name
                         releasedAt
                     }
-                    # finalizedTestResults {
-                    #     id
-                    #     atVersion {
-                    #         id
-                    #         name
-                    #         releasedAt
-                    #     }
-                    # }
-                    # runnableTests {
-                    #     id
-                    # }
-                    # draftTestPlanRuns {
-                    #     testResults {
-                    #         test {
-                    #             id
-                    #         }
-                    #     }
-                    # }
+                    #                    atVersions {
+                    #                        id
+                    #                        name
+                    #                        releasedAt
+                    #                    }
+                    #                    finalizedTestResults {
+                    #                        id
+                    #                        atVersion {
+                    #                            id
+                    #                            name
+                    #                            releasedAt
+                    #                        }
+                    #                    }
+                    #                    runnableTests {
+                    #                        id
+                    #                    }
+                    #                    draftTestPlanRuns {
+                    #                        testResults {
+                    #                            test {
+                    #                                id
+                    #                            }
+                    #                        }
+                    #                    }
                     testPlanVersion {
                         id
                         title
@@ -112,7 +117,15 @@ const getLatestReportsForPattern = async pattern => {
             status = report.status;
         }
 
-        // console.log('latestAtVersionReleasedAt', report.latestAtVersionReleasedAt);
+        // console.log(`======== ${report.id} START ========`);
+        // console.log(
+        //     `latestAtVersionReleasedAt:${JSON.stringify(
+        //         report.latestAtVersionReleasedAt,
+        //         null,
+        //         2
+        //     )}`
+        // );
+        // console.log(`atVersions:${JSON.stringify(report.atVersions, null, 2)}`);
 
         // Get the latest AT version used for testing per AT
         // report.finalizedTestResults.forEach(result => {
@@ -127,8 +140,25 @@ const getLatestReportsForPattern = async pattern => {
         //     }
         // });
 
-        allAtVersionsByAtDupe[report.at.name] =
-            report.latestAtVersionReleasedAt;
+        // console.log(
+        //     `allAtVersionsByAt:${JSON.stringify(
+        //         allAtVersionsByAt[report.at.name],
+        //         null,
+        //         2
+        //     )}`
+        // );
+        // console.log(`======== ${report.id}  END  ========\n\n`);
+
+        if (!allAtVersionsByAtDupe[report.at.name])
+            allAtVersionsByAtDupe[report.at.name] =
+                report.latestAtVersionReleasedAt;
+        else if (
+            new Date(report.latestAtVersionReleasedAt.releasedAt) >
+            new Date(allAtVersionsByAtDupe[report.at.name].releasedAt)
+        ) {
+            allAtVersionsByAtDupe[report.at.name] =
+                report.latestAtVersionReleasedAt;
+        }
 
         const sameAtAndBrowserReports = testPlanReports.filter(
             r =>
@@ -187,6 +217,7 @@ const getLatestReportsForPattern = async pattern => {
     return {
         title,
         allBrowsers,
+        // allAtVersionsByAt,
         allAtVersionsByAt: allAtVersionsByAtDupe,
         testPlanVersionIds,
         status,

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -55,29 +55,6 @@ const getLatestReportsForPattern = async pattern => {
                         name
                         releasedAt
                     }
-                    #                    atVersions {
-                    #                        id
-                    #                        name
-                    #                        releasedAt
-                    #                    }
-                    #                    finalizedTestResults {
-                    #                        id
-                    #                        atVersion {
-                    #                            id
-                    #                            name
-                    #                            releasedAt
-                    #                        }
-                    #                    }
-                    #                    runnableTests {
-                    #                        id
-                    #                    }
-                    #                    draftTestPlanRuns {
-                    #                        testResults {
-                    #                            test {
-                    #                                id
-                    #                            }
-                    #                        }
-                    #                    }
                     testPlanVersion {
                         id
                         title
@@ -102,8 +79,7 @@ const getLatestReportsForPattern = async pattern => {
 
     let allAts = new Set();
     let allBrowsers = new Set();
-    // let allAtVersionsByAt = {};
-    let allAtVersionsByAtDupe = {};
+    let allAtVersionsByAt = {};
     let status = 'RECOMMENDED';
     let reportsByAt = {};
     let testPlanVersionIds = new Set();
@@ -117,46 +93,14 @@ const getLatestReportsForPattern = async pattern => {
             status = report.status;
         }
 
-        // console.log(`======== ${report.id} START ========`);
-        // console.log(
-        //     `latestAtVersionReleasedAt:${JSON.stringify(
-        //         report.latestAtVersionReleasedAt,
-        //         null,
-        //         2
-        //     )}`
-        // );
-        // console.log(`atVersions:${JSON.stringify(report.atVersions, null, 2)}`);
-
-        // Get the latest AT version used for testing per AT
-        // report.finalizedTestResults.forEach(result => {
-        //     if (report.at.name in allAtVersionsByAt) {
-        //         allAtVersionsByAt[report.at.name] =
-        //             new Date(result.atVersion.releasedAt) >
-        //             new Date(allAtVersionsByAt[report.at.name].releasedAt)
-        //                 ? result.atVersion
-        //                 : allAtVersionsByAt[report.at.name];
-        //     } else {
-        //         allAtVersionsByAt[report.at.name] = result.atVersion;
-        //     }
-        // });
-
-        // console.log(
-        //     `allAtVersionsByAt:${JSON.stringify(
-        //         allAtVersionsByAt[report.at.name],
-        //         null,
-        //         2
-        //     )}`
-        // );
-        // console.log(`======== ${report.id}  END  ========\n\n`);
-
-        if (!allAtVersionsByAtDupe[report.at.name])
-            allAtVersionsByAtDupe[report.at.name] =
+        if (!allAtVersionsByAt[report.at.name])
+            allAtVersionsByAt[report.at.name] =
                 report.latestAtVersionReleasedAt;
         else if (
             new Date(report.latestAtVersionReleasedAt.releasedAt) >
-            new Date(allAtVersionsByAtDupe[report.at.name].releasedAt)
+            new Date(allAtVersionsByAt[report.at.name].releasedAt)
         ) {
-            allAtVersionsByAtDupe[report.at.name] =
+            allAtVersionsByAt[report.at.name] =
                 report.latestAtVersionReleasedAt;
         }
 
@@ -211,14 +155,10 @@ const getLatestReportsForPattern = async pattern => {
             .sort((a, b) => a.browser.name.localeCompare(b.browser.name));
     });
 
-    // console.log('allAtVersionsByAt', allAtVersionsByAt);
-    // console.log('allAtVersionsByAtDupe', allAtVersionsByAtDupe);
-
     return {
         title,
         allBrowsers,
-        // allAtVersionsByAt,
-        allAtVersionsByAt: allAtVersionsByAtDupe,
+        allAtVersionsByAt,
         testPlanVersionIds,
         status,
         reportsByAt

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -50,24 +50,29 @@ const getLatestReportsForPattern = async pattern => {
                         id
                         name
                     }
-                    finalizedTestResults {
+                    latestAtVersionReleasedAt {
                         id
-                        atVersion {
-                            id
-                            name
-                            releasedAt
-                        }
+                        name
+                        releasedAt
                     }
-                    runnableTests {
-                        id
-                    }
-                    draftTestPlanRuns {
-                        testResults {
-                            test {
-                                id
-                            }
-                        }
-                    }
+                    # finalizedTestResults {
+                    #     id
+                    #     atVersion {
+                    #         id
+                    #         name
+                    #         releasedAt
+                    #     }
+                    # }
+                    # runnableTests {
+                    #     id
+                    # }
+                    # draftTestPlanRuns {
+                    #     testResults {
+                    #         test {
+                    #             id
+                    #         }
+                    #     }
+                    # }
                     testPlanVersion {
                         id
                         title
@@ -92,7 +97,8 @@ const getLatestReportsForPattern = async pattern => {
 
     let allAts = new Set();
     let allBrowsers = new Set();
-    let allAtVersionsByAt = {};
+    // let allAtVersionsByAt = {};
+    let allAtVersionsByAtDupe = {};
     let status = 'RECOMMENDED';
     let reportsByAt = {};
     let testPlanVersionIds = new Set();
@@ -106,18 +112,23 @@ const getLatestReportsForPattern = async pattern => {
             status = report.status;
         }
 
+        // console.log('latestAtVersionReleasedAt', report.latestAtVersionReleasedAt);
+
         // Get the latest AT version used for testing per AT
-        report.finalizedTestResults.forEach(result => {
-            if (report.at.name in allAtVersionsByAt) {
-                allAtVersionsByAt[report.at.name] =
-                    new Date(result.atVersion.releasedAt) >
-                    new Date(allAtVersionsByAt[report.at.name].releasedAt)
-                        ? result.atVersion
-                        : allAtVersionsByAt[report.at.name];
-            } else {
-                allAtVersionsByAt[report.at.name] = result.atVersion;
-            }
-        });
+        // report.finalizedTestResults.forEach(result => {
+        //     if (report.at.name in allAtVersionsByAt) {
+        //         allAtVersionsByAt[report.at.name] =
+        //             new Date(result.atVersion.releasedAt) >
+        //             new Date(allAtVersionsByAt[report.at.name].releasedAt)
+        //                 ? result.atVersion
+        //                 : allAtVersionsByAt[report.at.name];
+        //     } else {
+        //         allAtVersionsByAt[report.at.name] = result.atVersion;
+        //     }
+        // });
+
+        allAtVersionsByAtDupe[report.at.name] =
+            report.latestAtVersionReleasedAt;
 
         const sameAtAndBrowserReports = testPlanReports.filter(
             r =>
@@ -170,10 +181,13 @@ const getLatestReportsForPattern = async pattern => {
             .sort((a, b) => a.browser.name.localeCompare(b.browser.name));
     });
 
+    // console.log('allAtVersionsByAt', allAtVersionsByAt);
+    // console.log('allAtVersionsByAtDupe', allAtVersionsByAtDupe);
+
     return {
         title,
         allBrowsers,
-        allAtVersionsByAt,
+        allAtVersionsByAt: allAtVersionsByAtDupe,
         testPlanVersionIds,
         status,
         reportsByAt


### PR DESCRIPTION
This PR replaces the logic for displaying the latest version used with each respective `TestPlanReport` displayed on the embed page with an optimized query served through the `testPlanReports.latestAtVersionReleasedAt` resolver.