### PR TITLE
Limit open dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     directory: "/"
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "npm"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     directory: "/client"
     schedule:
       interval: "monthly"
@@ -15,7 +15,7 @@ updates:
       prefix: "client"
 
   - package-ecosystem: "npm"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 5
     directory: "/server"
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Reduce the # of open dependabot PRs for the `yarn` workspaces to 5 each.

This is meant to limit the high number of notifications coming in for ~90+ dependencies across the `/client` and `/server` directories which may contribute to PR "noise".