### PR TITLE
Fix Test Database Seeder to Support TestPlanReport Metrics

### DIFF
--- a/server/tests/integration/embed.test.js
+++ b/server/tests/integration/embed.test.js
@@ -57,9 +57,7 @@ describe('embed', () => {
         const copyEmbedButtonOnClick = copyEmbedButton.getAttribute('onclick');
         const table = document.querySelector('table');
         const cellWithData = Array.from(table.querySelectorAll('td')).find(td =>
-            // TODO: change check to \d+ instead of \d* as soon as the missing
-            // number issue is fixed
-            td.innerHTML.match(/<b>\s*\d*%\s*<\/b>\s*supported/)
+            td.innerHTML.match(/<b>\s*\d+%\s*<\/b>\s*supported/)
         );
 
         expect(res.text).toEqual(res2.text);


### PR DESCRIPTION
We made one of our tests more lax than it should have been to work around the fact that metrics were missing from our automatically seeded data - this PR fixes that issue and fixes the test.