### PR TITLE
Add w3c message to home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ARIA and Assistive Technologies App (ARIA-AT App)
 ## ARIA-AT APP
-ARIA-AT aims to improve interoperability between different Assistive Technologies (ATs) in how they render ARIA patterns. This is achieved through running manual tests and presenting test results to AT vendors. The tests are based on examples from [WAI-ARIA Authoring Practices](https://w3c.github.io/aria-practices/), and are vetted with stakeholders following the [Working Mode](https://github.com/w3c/aria-at/wiki/Working-Mode) process.
+ARIA-AT aims to improve interoperability between different Assistive Technologies (ATs) in how they render ARIA patterns. This is achieved through running manual tests and presenting test results to AT vendors. The tests are based on examples from [WAI-ARIA Authoring Practices](https://w3c.github.io/aria-practices/), and are vetted with stakeholders following the [Working Mode](https://github.com/w3c/aria-at/wiki/Working-Mode) process. This project is managed by the [ARIA-AT Community Group](https://www.w3.org/groups/cg/aria-at) in coordination with the [Authoring Practices Task Force](https://www.w3.org/WAI/ARIA/task-forces/practices/) of the [ARIA Working Group](http://www.w3.org/WAI/ARIA/). The W3C staff contact is Daniel Montalvo.
 
 This app includes a reports page that shows the public results of manual testing across various browser / AT combinations. The app is also used by manual testers
 

--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -365,6 +365,7 @@ main.home-page.container {
 
 main.home-page.container h1 {
     border: none;
+    padding-bottom: 0;
 }
 
 .hero-section {
@@ -399,6 +400,34 @@ main.home-page.container h1 {
 .hero-link:active,
 .hero-link:focus {
     color: #0058b6;
+}
+
+.w3c-authorization-message {
+    background-color: #fff9ea;
+    display: flex;
+    padding: 1em;
+}
+.w3c-authorization-message i {
+    padding-right: 0.5em;
+    font-size: 25px;
+    font-style: normal;
+}
+.w3c-authorization-message em {
+    display: block;
+    font-style: normal;
+    font-size: 14px;
+    color: #85693D;
+    line-height: 1.3;
+}
+.w3c-authorization-message strong {
+    font-style: italic;
+}
+.w3c-authorization-message a {
+    font-weight: bold;
+    color: #85693D;
+}
+.w3c-authorization-message a:hover {
+    text-decoration: underline;
 }
 
 .right {

--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -416,7 +416,7 @@ main.home-page.container h1 {
     display: block;
     font-style: normal;
     font-size: 14px;
-    color: #85693D;
+    color: #654E29;
     line-height: 1.3;
 }
 .w3c-authorization-message strong {
@@ -424,7 +424,7 @@ main.home-page.container h1 {
 }
 .w3c-authorization-message a {
     font-weight: bold;
-    color: #85693D;
+    color: #654E29;
 }
 .w3c-authorization-message a:hover {
     text-decoration: underline;

--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -415,7 +415,7 @@ main.home-page.container h1 {
 .w3c-authorization-message em {
     display: block;
     font-style: normal;
-    font-size: 14px;
+    font-size: 0.875rem;
     color: #654E29;
     line-height: 1.3;
 }

--- a/client/components/Home/Home.jsx
+++ b/client/components/Home/Home.jsx
@@ -24,8 +24,15 @@ const Home = () => {
                         <p className="w3c-authorization-message">
                             <i aria-hidden="true">✨</i>
                             <em>
-                                <strong>Note:</strong> This project is managed
-                                by the{' '}
+                                <strong>Note:</strong> The{' '}
+                                <a
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    href="https://github.com/w3c/aria-at"
+                                >
+                                    ARIA-AT Project
+                                </a>{' '}
+                                is managed by the{' '}
                                 <a
                                     target="_blank"
                                     rel="noreferrer"

--- a/client/components/Home/Home.jsx
+++ b/client/components/Home/Home.jsx
@@ -86,7 +86,7 @@ const Home = () => {
                         <iframe
                             src="https://player.vimeo.com/video/651279608?h=45aefd646f&byline=false&dnt=true&portrait=false"
                             width="640"
-                            height="360"
+                            height="340"
                             frameBorder="0"
                             allow="autoplay; fullscreen; picture-in-picture"
                             allowFullScreen

--- a/client/components/Home/Home.jsx
+++ b/client/components/Home/Home.jsx
@@ -21,6 +21,37 @@ const Home = () => {
                 </h1>
                 <div className="hero-copy-and-video">
                     <div className="hero-copy">
+                        <p className="w3c-authorization-message">
+                            <i aria-hidden="true">✨</i>
+                            <em>
+                                <strong>Note:</strong> This project is managed
+                                by the{' '}
+                                <a
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    href="https://www.w3.org/community/aria-at/"
+                                >
+                                    ARIA-AT Community Group
+                                </a>{' '}
+                                in coordination with the{' '}
+                                <a
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    href="https://www.w3.org/WAI/ARIA/task-forces/practices/"
+                                >
+                                    Authoring Practices Task Force
+                                </a>{' '}
+                                of the{' '}
+                                <a
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    href="https://www.w3.org/WAI/ARIA/"
+                                >
+                                    ARIA Working Group
+                                </a>
+                                . The W3C staff contact is Daniel Montalvo.
+                            </em>
+                        </p>
                         <p>
                             Today, different screen readers often yield
                             conflicting experiences when presenting a web page,

--- a/client/components/Home/Home.jsx
+++ b/client/components/Home/Home.jsx
@@ -49,7 +49,11 @@ const Home = () => {
                                 >
                                     ARIA Working Group
                                 </a>
-                                . The W3C staff contact is Daniel Montalvo.
+                                . The W3C staff contact is{' '}
+                                <a href="mailto:dmontalvo@w3.org">
+                                    Daniel Montalvo
+                                </a>
+                                .
                             </em>
                         </p>
                         <p>


### PR DESCRIPTION
Adds a required message to the top of the home page which lists some information about the groups which are involved in the project.

As of today April 13 there is a preview of the change up on the sandbox's home page: https://aria-at-app-sandbox.bocoup.com/

@lolaodelola I was hoping you could review the sandbox and let me know if you see the need for any changes. Thanks!