### PR TITLE
Add a migration to update invalid test plan titles 

### DIFF
--- a/server/migrations/20230425215656-updateTestPlanVersionTitles.js
+++ b/server/migrations/20230425215656-updateTestPlanVersionTitles.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface) {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion" set title = 'Checkbox Example (Mixed-State)' where title = 'Checkbox Example (Tri State)'`,
+                {
+                    transaction
+                }
+            );
+
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion" set title = 'Alert Example' where title is null and directory = 'alert'`,
+                {
+                    transaction
+                }
+            );
+
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion" set title = 'Modal Dialog Example' where title is null and directory = 'modal-dialog'`,
+                {
+                    transaction
+                }
+            );
+        });
+    }
+};


### PR DESCRIPTION
Addressing a part of #581 by preventing the **known** invalid test plans being shown.

Add migrations to update `TestPlanVersion` rows where:
* the title is `Checkbox Example (Tri State)`, update the title to `Checkbox Example (Mixed-State)`. This is based on [w3c/aria-at/checkbox-tri-state/references.csv](https://github.com/w3c/aria-at/blob/master/tests/checkbox-tri-state/data/references.csv).
* the title is `null` and the directory is `"alert"`, update the title to `Alert Example`. This is based on [w3c/aria-at/alert/references.csv](https://github.com/w3c/aria-at/blob/master/tests/alert/data/references.csv).
* the title is `null` and the directory is `"modal-dialog"`, update the title to `Modal Dialog Example`. This is based on [w3c/aria-at/modal-dialog/references.csv](https://github.com/w3c/aria-at/blob/master/tests/modal-dialog/data/references.csv).

Another PR will follow which will prevent this issue from being visibly shown through the application, in the future should a similar case come up.