### PR TITLE
Improve AT version and browser version queries 

### DIFF
--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -416,7 +416,7 @@ main.home-page.container h1 {
     display: block;
     font-style: normal;
     font-size: 0.875rem;
-    color: #654e29;
+    color: #654E29;
     line-height: 1.3;
 }
 .w3c-authorization-message strong {
@@ -424,7 +424,7 @@ main.home-page.container h1 {
 }
 .w3c-authorization-message a {
     font-weight: bold;
-    color: #654e29;
+    color: #654E29;
 }
 .w3c-authorization-message a:hover {
     text-decoration: underline;

--- a/client/components/App/App.css
+++ b/client/components/App/App.css
@@ -416,7 +416,7 @@ main.home-page.container h1 {
     display: block;
     font-style: normal;
     font-size: 0.875rem;
-    color: #654E29;
+    color: #654e29;
     line-height: 1.3;
 }
 .w3c-authorization-message strong {
@@ -424,7 +424,7 @@ main.home-page.container h1 {
 }
 .w3c-authorization-message a {
     font-weight: bold;
-    color: #654E29;
+    color: #654e29;
 }
 .w3c-authorization-message a:hover {
     text-decoration: underline;

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -52,6 +52,7 @@ To deploy this project to  server:
 1. Obtain an authorized key and add it to your keychain. This is needed for deploys to Staging and Production. 
   - The shared key is named `aria-at-bocoup`.
   - Place it in the ~/.ssh directory.
+  - For security, set permissions on the key file, which is required by the OS: `chmod 600 ~/.ssh/aria-at-bocoup`.
   - Add it to your keychain with the following command: `ssh-add ~/.ssh/aria-at-bocoup`.
   - Run `ssh root@aria-at-staging.w3.org` and `ssh root@aria-at.w3.org` to verify that you can connect to the servers.
 2. Bocoup maintains its own instance of the app on its internal infrastructure for quick and easy testing. Note that you must be a Bocouper to deploy to this environment. Follow the steps below to verify you are able to connect.
@@ -93,12 +94,12 @@ ansible-vault edit files/config-sandbox.env
 ## Manual DB Backup
 From the `deploy` folder:
 
-1. Retrieve the database user (aka PGUSER) and database password (aka PGPASSWORD).
+1. Retrieve the database user (aka PGUSER) and database password (aka PGPASSWORD), the environment is `production` or `staging`.
    `ansible-vault view --vault-password-file ansible-vault-password.txt files/config-<environment>.env`
-2. Ssh into the machine. The domain is aria-at.w3.org for production and aria-at-staging.w3.org for staging.
+2. Ssh into the machine. The deploy key will be at `~/.ssh/aria-at-bocoup`, if you followed the deploy setup instructions. The domain is `aria-at.w3.org` for production and `aria-at-staging.w3.org` for staging.
   `ssh -i <deploy key> root@<domain>`
-3. Create the backup and save it to a file.
-  `pg_dump -U <value for PGUSER> -h localhost -d aria_at_report > <environment>_dump_<timestamp>.sql`. It will ask for the PGPASSWORD.
+3. Create the backup and save it to a file. After running the command, the terminal prompt will ask for the PGPASSWORD. Use the current date for the timestamp, e.g. `20230406`. Run
+  `pg_dump -U <value for PGUSER> -h localhost -d aria_at_report > <environment>_dump_<timestamp>.sql`. 
 4. From another terminal window that's not connected to the server, copy the backup to your machine.
   `scp -i <deploy key> root@<domain>:<environment>_dump_<timestamp>.sql .`
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -95,12 +95,12 @@ From the `deploy` folder:
 
 1. Retrieve the database user (aka PGUSER) and database password (aka PGPASSWORD).
    `ansible-vault view --vault-password-file ansible-vault-password.txt files/config-<environment>.env`
-2. Ssh into the machine.
-  `ssh -i <deploy key> root@aria-at-staging.w3.org`
+2. Ssh into the machine. The domain is aria-at.w3.org for production and aria-at-staging.w3.org for staging.
+  `ssh -i <deploy key> root@<domain>`
 3. Create the backup and save it to a file.
-  `pg_dump -U <value for PGUSER> -h localhost -d aria_at_report > <environment>_dump_<timestamp>.sql`
-4. Copy the backup to your machine
-  `scp root@aria-at-staging.w3.org:<environment>_dump_<timestamp>.sql .`
+  `pg_dump -U <value for PGUSER> -h localhost -d aria_at_report > <environment>_dump_<timestamp>.sql`. It will ask for the PGPASSWORD.
+4. From another terminal window that's not connected to the server, copy the backup to your machine.
+  `scp -i <deploy key> root@<domain>:<environment>_dump_<timestamp>.sql .`
 
 ## Database Restore
 1. Ssh into the machine.

--- a/docs/database.md
+++ b/docs/database.md
@@ -29,12 +29,6 @@ The database migrations are managed by [Sequelize](https://sequelize.org/). To r
     yarn db-import-tests:dev
     ```
 
-The sample data which is used in test environments can also be populated on development environments.
-
-```
-yarn workspace server db-populate-sample-data:dev;
-```
-
 All at once:
 
 ```
@@ -50,7 +44,33 @@ yarn sequelize db:seed:all;
 yarn db-import-tests:dev;
 ```
 
-### Test Database
+The sample data which is used in test environments can also be populated on development environments.
+
+```
+yarn workspace server db-populate-sample-data:dev;
+```
+
+### Cloning the Production Database
+
+The prerequisite for the following steps is SSH access to the production server.
+
+1. Follow the [manual backup instructions](../deploy/README.md#manual-db-backup) which will produce a local database dump of the production database.
+2. Drop your **local** aria_at_report database using your preferred tool.
+3. Initialize the database in an empty state:
+    ```
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        createdb # run this if the PostgreSQL installation is freshly installed
+        yarn db-init:dev;
+    else
+        sudo -u postgres yarn db-init:dev;
+    fi;
+    ```
+4. Execute the database dump file:
+    ```
+    psql -d aria_at_report -f <environment>_dump_<timestamp>.sql
+    ```
+
+## Test Database
 
 The instructions are similar for the test database, with one extra step:
 

--- a/server/graphql-context.js
+++ b/server/graphql-context.js
@@ -1,8 +1,14 @@
+const AtLoader = require('./models/loaders/AtLoader');
+const BrowserLoader = require('./models/loaders/BrowserLoader');
+
 const getGraphQLContext = ({ req }) => {
     const user =
         req && req.session && req.session.user ? req.session.user : null;
 
-    return { user };
+    const atLoader = AtLoader();
+    const browserLoader = BrowserLoader();
+
+    return { user, atLoader, browserLoader };
 };
 
 module.exports = getGraphQLContext;

--- a/server/models/TestPlanReport.js
+++ b/server/models/TestPlanReport.js
@@ -1,5 +1,4 @@
 const MODEL_NAME = 'TestPlanReport';
-
 const STATUS = {
     DRAFT: 'DRAFT',
     CANDIDATE: 'CANDIDATE',

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -17,7 +17,8 @@ sequelize = new Sequelize(
             ssl: true,
             native: true
         },
-        logging: false // console.log // eslint-disable-line
+        logging: console.log // eslint-disable-line
+        // logging: false
     }
 );
 

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -17,8 +17,7 @@ sequelize = new Sequelize(
             ssl: true,
             native: true
         },
-        logging: console.log // eslint-disable-line
-        // logging: false
+        logging: false
     }
 );
 

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -17,7 +17,7 @@ sequelize = new Sequelize(
             ssl: true,
             native: true
         },
-        logging: false
+       logging: false // console.log // eslint-disable-line
     }
 );
 

--- a/server/models/loaders/AtLoader.js
+++ b/server/models/loaders/AtLoader.js
@@ -1,0 +1,25 @@
+const { getAts } = require('../services/AtService');
+
+const AtLoader = () => {
+    let ats;
+    let activePromise;
+
+    return {
+        getAll: async () => {
+            if (ats) {
+                return ats;
+            }
+
+            if (activePromise) {
+                return activePromise;
+            }
+            activePromise = getAts();
+
+            ats = await activePromise;
+
+            return ats;
+        }
+    };
+};
+
+module.exports = AtLoader;

--- a/server/models/loaders/BrowserLoader.js
+++ b/server/models/loaders/BrowserLoader.js
@@ -1,0 +1,26 @@
+const { getBrowsers } = require('../services/BrowserService');
+
+const BrowserLoader = () => {
+    let browsers;
+    let activePromise;
+
+    return {
+        getAll: async () => {
+            if (browsers) {
+                return browsers;
+            }
+
+            if (activePromise) {
+                return activePromise;
+            }
+
+            activePromise = getBrowsers();
+
+            browsers = await activePromise;
+
+            return browsers;
+        }
+    };
+};
+
+module.exports = BrowserLoader;

--- a/server/models/services/AtService.js
+++ b/server/models/services/AtService.js
@@ -1,4 +1,5 @@
 const ModelService = require('./ModelService');
+
 const {
     AT_ATTRIBUTES,
     AT_VERSION_ATTRIBUTES,

--- a/server/models/services/TestPlanReportService.js
+++ b/server/models/services/TestPlanReportService.js
@@ -78,11 +78,11 @@ const testPlanVersionAssociation = testPlanVersionAttributes => ({
  */
 const atAssociation = (atAttributes, atVersionAttributes) => ({
     association: 'at',
-    attributes: atAttributes,
-    include: [
-        // eslint-disable-next-line no-use-before-define
-        atVersionAssociation(atVersionAttributes)
-    ]
+    attributes: atAttributes
+    // include: [
+    //     // eslint-disable-next-line no-use-before-define
+    //     atVersionAssociation(atVersionAttributes)
+    // ]
 });
 
 /**
@@ -101,11 +101,11 @@ const atVersionAssociation = atVersionAttributes => ({
  */
 const browserAssociation = (browserAttributes, browserVersionAttributes) => ({
     association: 'browser',
-    attributes: browserAttributes,
-    include: [
-        // eslint-disable-next-line no-use-before-define
-        browserVersionAssociation(browserVersionAttributes)
-    ]
+    attributes: browserAttributes
+    // include: [
+    //     // eslint-disable-next-line no-use-before-define
+    //     browserVersionAssociation(browserVersionAttributes)
+    // ]
 });
 
 /**
@@ -194,13 +194,16 @@ const getTestPlanReports = async (
     testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
     testPlanVersionAttributes = TEST_PLAN_VERSION_ATTRIBUTES,
     atAttributes = AT_ATTRIBUTES,
-    atVersionAttributes = AT_VERSION_ATTRIBUTES,
+    // atVersionAttributes = AT_VERSION_ATTRIBUTES,
+    atVersionAttributes = null,
     browserAttributes = BROWSER_ATTRIBUTES,
-    browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
+    // browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
+    browserVersionAttributes = null,
     userAttributes = USER_ATTRIBUTES,
     pagination = {},
     options = {}
 ) => {
+    console.log('getTestPlanReports');
     // search and filtering options
     let where = { ...filter };
 

--- a/server/models/services/TestPlanReportService.js
+++ b/server/models/services/TestPlanReportService.js
@@ -76,7 +76,7 @@ const testPlanVersionAssociation = testPlanVersionAttributes => ({
  * @param {string[]} atVersionAttributes - AT version attributes
  * @returns {{association: string, attributes: string[]}}
  */
-const atAssociation = (atAttributes, atVersionAttributes) => ({
+const atAssociation = atAttributes => ({
     association: 'at',
     attributes: atAttributes
     // include: [
@@ -86,35 +86,17 @@ const atAssociation = (atAttributes, atVersionAttributes) => ({
 });
 
 /**
- * @param {string[]} atVersionAttributes - AT version attributes
- * @returns {{association: string, attributes: string[]}}
- */
-const atVersionAssociation = atVersionAttributes => ({
-    association: 'atVersions',
-    attributes: atVersionAttributes
-});
-
-/**
  * @param {string[]} browserAttributes - Browser attributes
  * @param {string[]} browserVersionAttributes - Browser version attributes
  * @returns {{association: string, attributes: string[]}}
  */
-const browserAssociation = (browserAttributes, browserVersionAttributes) => ({
+const browserAssociation = browserAttributes => ({
     association: 'browser',
     attributes: browserAttributes
     // include: [
     //     // eslint-disable-next-line no-use-before-define
     //     browserVersionAssociation(browserVersionAttributes)
     // ]
-});
-
-/**
- * @param {string[]} browserVersionAttributes - Browser version attributes
- * @returns {{association: string, attributes: string[]}}
- */
-const browserVersionAssociation = browserVersionAttributes => ({
-    association: 'browserVersions',
-    attributes: browserVersionAttributes
 });
 
 /**
@@ -203,7 +185,6 @@ const getTestPlanReports = async (
     pagination = {},
     options = {}
 ) => {
-    console.log('getTestPlanReports');
     // search and filtering options
     let where = { ...filter };
 

--- a/server/models/services/TestPlanReportService.js
+++ b/server/models/services/TestPlanReportService.js
@@ -79,10 +79,6 @@ const testPlanVersionAssociation = testPlanVersionAttributes => ({
 const atAssociation = atAttributes => ({
     association: 'at',
     attributes: atAttributes
-    // include: [
-    //     // eslint-disable-next-line no-use-before-define
-    //     atVersionAssociation(atVersionAttributes)
-    // ]
 });
 
 /**
@@ -93,10 +89,6 @@ const atAssociation = atAttributes => ({
 const browserAssociation = browserAttributes => ({
     association: 'browser',
     attributes: browserAttributes
-    // include: [
-    //     // eslint-disable-next-line no-use-before-define
-    //     browserVersionAssociation(browserVersionAttributes)
-    // ]
 });
 
 /**
@@ -176,10 +168,8 @@ const getTestPlanReports = async (
     testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
     testPlanVersionAttributes = TEST_PLAN_VERSION_ATTRIBUTES,
     atAttributes = AT_ATTRIBUTES,
-    // atVersionAttributes = AT_VERSION_ATTRIBUTES,
     atVersionAttributes = null,
     browserAttributes = BROWSER_ATTRIBUTES,
-    // browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
     browserVersionAttributes = null,
     userAttributes = USER_ATTRIBUTES,
     pagination = {},

--- a/server/models/services/TestPlanRunService.js
+++ b/server/models/services/TestPlanRunService.js
@@ -78,10 +78,6 @@ const testPlanVersionAssociation = testPlanVersionAttributes => ({
 const atAssociation = atAttributes => ({
     association: 'at',
     attributes: atAttributes
-    // include: [
-    //     // eslint-disable-next-line no-use-before-define
-    //     atVersionAssociation(atVersionAttributes)
-    // ]
 });
 
 /**
@@ -92,10 +88,6 @@ const atAssociation = atAttributes => ({
 const browserAssociation = browserAttributes => ({
     association: 'browser',
     attributes: browserAttributes
-    // include: [
-    //     // eslint-disable-next-line no-use-before-define
-    //     browserVersionAssociation(browserVersionAttributes)
-    // ]
 });
 
 /**

--- a/server/models/services/TestPlanRunService.js
+++ b/server/models/services/TestPlanRunService.js
@@ -75,22 +75,13 @@ const testPlanVersionAssociation = testPlanVersionAttributes => ({
  * @param {string[]} atVersionAttributes - AT version attributes
  * @returns {{association: string, attributes: string[]}}
  */
-const atAssociation = (atAttributes, atVersionAttributes) => ({
+const atAssociation = atAttributes => ({
     association: 'at',
-    attributes: atAttributes,
-    include: [
-        // eslint-disable-next-line no-use-before-define
-        atVersionAssociation(atVersionAttributes)
-    ]
-});
-
-/**
- * @param {string[]} atVersionAttributes - AT version attributes
- * @returns {{association: string, attributes: string[]}}
- */
-const atVersionAssociation = atVersionAttributes => ({
-    association: 'atVersions',
-    attributes: atVersionAttributes
+    attributes: atAttributes
+    // include: [
+    //     // eslint-disable-next-line no-use-before-define
+    //     atVersionAssociation(atVersionAttributes)
+    // ]
 });
 
 /**
@@ -98,22 +89,13 @@ const atVersionAssociation = atVersionAttributes => ({
  * @param {string[]} browserVersionAttributes - Browser version attributes
  * @returns {{association: string, attributes: string[]}}
  */
-const browserAssociation = (browserAttributes, browserVersionAttributes) => ({
+const browserAssociation = browserAttributes => ({
     association: 'browser',
-    attributes: browserAttributes,
-    include: [
-        // eslint-disable-next-line no-use-before-define
-        browserVersionAssociation(browserVersionAttributes)
-    ]
-});
-
-/**
- * @param {string[]} browserVersionAttributes - Browser version attributes
- * @returns {{association: string, attributes: string[]}}
- */
-const browserVersionAssociation = browserVersionAttributes => ({
-    association: 'browserVersions',
-    attributes: browserVersionAttributes
+    attributes: browserAttributes
+    // include: [
+    //     // eslint-disable-next-line no-use-before-define
+    //     browserVersionAssociation(browserVersionAttributes)
+    // ]
 });
 
 /**

--- a/server/models/services/TestPlanVersionService.js
+++ b/server/models/services/TestPlanVersionService.js
@@ -66,11 +66,11 @@ const testPlanRunAssociation = (testPlanRunAttributes, userAttributes) => ({
  */
 const atAssociation = (atAttributes, atVersionAttributes) => ({
     association: 'at',
-    attributes: atAttributes,
-    include: [
-        // eslint-disable-next-line no-use-before-define
-        atVersionAssociation(atVersionAttributes)
-    ]
+    attributes: atAttributes
+    // include: [
+    //     // eslint-disable-next-line no-use-before-define
+    //     atVersionAssociation(atVersionAttributes)
+    // ]
 });
 
 /**
@@ -89,11 +89,11 @@ const atVersionAssociation = atVersionAttributes => ({
  */
 const browserAssociation = (browserAttributes, browserVersionAttributes) => ({
     association: 'browser',
-    attributes: browserAttributes,
-    include: [
-        // eslint-disable-next-line no-use-before-define
-        browserVersionAssociation(browserVersionAttributes)
-    ]
+    attributes: browserAttributes
+    // include: [
+    //     // eslint-disable-next-line no-use-before-define
+    //     browserVersionAssociation(browserVersionAttributes)
+    // ]
 });
 
 /**

--- a/server/models/services/TestPlanVersionService.js
+++ b/server/models/services/TestPlanVersionService.js
@@ -64,22 +64,9 @@ const testPlanRunAssociation = (testPlanRunAttributes, userAttributes) => ({
  * @param {string[]} atVersionAttributes - AT version attributes
  * @returns {{association: string, attributes: string[]}}
  */
-const atAssociation = (atAttributes, atVersionAttributes) => ({
+const atAssociation = atAttributes => ({
     association: 'at',
     attributes: atAttributes
-    // include: [
-    //     // eslint-disable-next-line no-use-before-define
-    //     atVersionAssociation(atVersionAttributes)
-    // ]
-});
-
-/**
- * @param {string[]} atVersionAttributes - AT version attributes
- * @returns {{association: string, attributes: string[]}}
- */
-const atVersionAssociation = atVersionAttributes => ({
-    association: 'atVersions',
-    attributes: atVersionAttributes
 });
 
 /**
@@ -87,22 +74,9 @@ const atVersionAssociation = atVersionAttributes => ({
  * @param {string[]} browserVersionAttributes - Browser version attributes
  * @returns {{association: string, attributes: string[]}}
  */
-const browserAssociation = (browserAttributes, browserVersionAttributes) => ({
+const browserAssociation = browserAttributes => ({
     association: 'browser',
     attributes: browserAttributes
-    // include: [
-    //     // eslint-disable-next-line no-use-before-define
-    //     browserVersionAssociation(browserVersionAttributes)
-    // ]
-});
-
-/**
- * @param {string[]} browserVersionAttributes - Browser version attributes
- * @returns {{association: string, attributes: string[]}}
- */
-const browserVersionAssociation = browserVersionAttributes => ({
-    association: 'browserVersions',
-    attributes: browserVersionAttributes
 });
 
 /**

--- a/server/resolvers/AtVersionOperations/deleteAtVersionResolver.js
+++ b/server/resolvers/AtVersionOperations/deleteAtVersionResolver.js
@@ -10,8 +10,9 @@ const populateData = require('../../services/PopulatedData/populateData');
 const deleteAtVersionResolver = async (
     { parentContext: { id: atVersionId } },
     _,
-    { user }
+    context
 ) => {
+    const { user } = context;
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
         throw new AuthenticationError();
     }
@@ -23,7 +24,7 @@ const deleteAtVersionResolver = async (
         return { isDeleted: true };
     }
 
-    const populatedTestResults = populateTestResults(resultIds);
+    const populatedTestResults = populateTestResults(resultIds, context);
 
     return {
         isDeleted: false,
@@ -31,7 +32,7 @@ const deleteAtVersionResolver = async (
     };
 };
 
-const populateTestResults = async resultIds => {
+const populateTestResults = async (resultIds, context) => {
     // Limits the number of queries that will be made for this endpoint
     const queryLimit = 10;
 
@@ -52,7 +53,7 @@ const populateTestResults = async resultIds => {
             const testPlanRun = preloadedTestPlanRunsById[testPlanRunId];
             return populateData(
                 { testResultId },
-                { preloaded: { testPlanRun } }
+                { preloaded: { testPlanRun }, context }
             );
         })
     );

--- a/server/resolvers/TestPlanReport/atResolver.js
+++ b/server/resolvers/TestPlanReport/atResolver.js
@@ -1,0 +1,7 @@
+const atResolver = async (testPlanReport, _, context) => {
+    const ats = await context.atLoader.getAll();
+
+    return ats.find(at => at.id === testPlanReport.at.id);
+};
+
+module.exports = atResolver;

--- a/server/resolvers/TestPlanReport/browserResolver.js
+++ b/server/resolvers/TestPlanReport/browserResolver.js
@@ -1,0 +1,7 @@
+const browserResolver = async (testPlanReport, _, context) => {
+    const browsers = await context.browserLoader.getAll();
+
+    return browsers.find(browser => browser.id === testPlanReport.browser.id);
+};
+
+module.exports = browserResolver;

--- a/server/resolvers/TestPlanReport/conflictsLengthResolver.js
+++ b/server/resolvers/TestPlanReport/conflictsLengthResolver.js
@@ -1,10 +1,14 @@
 const conflictsResolver = require('./conflictsResolver');
 
-const conflictsLengthResolver = async testPlanReport => {
+const conflictsLengthResolver = async (testPlanReport, _, context) => {
     if (testPlanReport?.metrics?.conflictsCount !== undefined)
         return testPlanReport.metrics.conflictsCount;
     else {
-        const conflicts = await conflictsResolver(testPlanReport);
+        const conflicts = await conflictsResolver(
+            testPlanReport,
+            null,
+            context
+        );
         return conflicts.length;
     }
 };

--- a/server/resolvers/TestPlanReport/conflictsResolver.js
+++ b/server/resolvers/TestPlanReport/conflictsResolver.js
@@ -3,25 +3,32 @@ const testResultsResolver = require('../TestPlanRun/testResultsResolver');
 const populateData = require('../../services/PopulatedData/populateData');
 const allEqual = require('../../util/allEqual');
 
-const conflictsResolver = async testPlanReport => {
+const conflictsResolver = async (testPlanReport, _, context) => {
     let testPlanReportData = {};
 
     // Used in cases where the testPlanRuns to evaluate the conflicts doesn't
     // exist for `testPlanReport`, such as this function being called from
     // `conflictsLengthResolver.js`
     if (testPlanReport.testPlanRuns.some(t => !t.testResults)) {
-        const { testPlanReport: _testPlanReport } = await populateData({
-            testPlanReportId: testPlanReport.id
-        });
+        const { testPlanReport: _testPlanReport } = await populateData(
+            {
+                testPlanReportId: testPlanReport.id
+            },
+            { context }
+        );
         testPlanReportData = _testPlanReport;
     } else testPlanReportData = testPlanReport;
 
     const conflicts = [];
 
     const testResultsByTestId = {};
-    testPlanReportData.testPlanRuns.forEach(testPlanRun => {
+    for (const testPlanRun of testPlanReportData.testPlanRuns) {
         testPlanRun.testPlanReport = testPlanReportData; // TODO: remove hacky fix
-        const testResults = testResultsResolver(testPlanRun);
+        const testResults = await testResultsResolver(
+            testPlanRun,
+            null,
+            context
+        );
         testResults
             .filter(testResult => testResult.completedAt)
             .forEach(testResult => {
@@ -30,7 +37,7 @@ const conflictsResolver = async testPlanReport => {
                 }
                 testResultsByTestId[testResult.testId].push(testResult);
             });
-    });
+    }
 
     Object.values(testResultsByTestId).forEach(testResults => {
         // See GraphQL TestPlanResultConflict for more info about how the
@@ -93,10 +100,10 @@ const conflictsResolver = async testPlanReport => {
 
     return Promise.all(
         conflicts.map(async ({ source, conflictingResults }) => ({
-            source: await populateData(source, { preloaded }),
+            source: await populateData(source, { preloaded, context }),
             conflictingResults: await Promise.all(
                 conflictingResults.map(conflictingResult =>
-                    populateData(conflictingResult, { preloaded })
+                    populateData(conflictingResult, { preloaded, context })
                 )
             )
         }))

--- a/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
+++ b/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
@@ -5,7 +5,7 @@ const deepCustomMerge = require('../../util/deepCustomMerge');
  * Completed test results sourced from all the report's runs. The runs must be
  * merged because each run might have skipped different tests.
  */
-const finalizedTestResultsResolver = testPlanReport => {
+const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
     if (
         // CANDIDATE & RECOMMENDED status should be evaluated
         testPlanReport.status === 'DRAFT' ||
@@ -29,7 +29,11 @@ const finalizedTestResultsResolver = testPlanReport => {
         );
     }
 
-    return testResultsResolver({ testPlanReport, testResults: merged });
+    return testResultsResolver(
+        { testPlanReport, testResults: merged },
+        null,
+        context
+    );
 };
 
 module.exports = finalizedTestResultsResolver;

--- a/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
+++ b/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
@@ -11,7 +11,7 @@ const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
         testPlanReport.status === 'DRAFT' ||
         !testPlanReport.testPlanRuns.length
     ) {
-        // console.log('THIS FILE RAN NOW!!');
+
         return null;
     }
 
@@ -29,7 +29,6 @@ const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
             }
         );
     }
-    // console.log('THIS RETURNED SOMETHING BEFOR THE RETURN!!');
     return testResultsResolver(
         { testPlanReport, testResults: merged },
         null,

--- a/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
+++ b/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
@@ -11,7 +11,7 @@ const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
         testPlanReport.status === 'DRAFT' ||
         !testPlanReport.testPlanRuns.length
     ) {
-        console.log('THIS FILE RAN NOW!!');
+        // console.log('THIS FILE RAN NOW!!');
         return null;
     }
 
@@ -29,7 +29,7 @@ const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
             }
         );
     }
-    console.log('THIS RETURNED SOMETHING BEFOR THE RETURN!!');
+    // console.log('THIS RETURNED SOMETHING BEFOR THE RETURN!!');
     return testResultsResolver(
         { testPlanReport, testResults: merged },
         null,

--- a/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
+++ b/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
@@ -11,6 +11,7 @@ const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
         testPlanReport.status === 'DRAFT' ||
         !testPlanReport.testPlanRuns.length
     ) {
+        console.log('THIS FILE RAN NOW!!');
         return null;
     }
 
@@ -28,7 +29,7 @@ const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
             }
         );
     }
-
+    console.log('THIS RETURNED SOMETHING BEFOR THE RETURN!!');
     return testResultsResolver(
         { testPlanReport, testResults: merged },
         null,

--- a/server/resolvers/TestPlanReport/index.js
+++ b/server/resolvers/TestPlanReport/index.js
@@ -7,6 +7,8 @@ const conflictsLength = require('./conflictsLengthResolver');
 const issues = require('./issuesResolver');
 const recommendedStatusTargetDate = require('./recommendedStatusTargetDateResolver');
 const atVersions = require('./atVersionsResolver');
+const at = require('./atResolver');
+const browser = require('./browserResolver');
 const latestAtVersionReleasedAt = require('./latestAtVersionReleasedAtResolver');
 
 module.exports = {
@@ -19,5 +21,7 @@ module.exports = {
     issues,
     recommendedStatusTargetDate,
     atVersions,
+    at,
+    browser,
     latestAtVersionReleasedAt
 };

--- a/server/resolvers/TestPlanReportOperations/assignTesterResolver.js
+++ b/server/resolvers/TestPlanReportOperations/assignTesterResolver.js
@@ -7,8 +7,9 @@ const populateData = require('../../services/PopulatedData/populateData');
 const assignTesterResolver = async (
     { parentContext: { id: testPlanReportId } },
     { userId: testerUserId },
-    { user }
+    context
 ) => {
+    const { user } = context;
     if (
         !(
             user?.roles.find(role => role.name === 'ADMIN') ||
@@ -24,7 +25,7 @@ const assignTesterResolver = async (
         testerUserId
     });
 
-    return populateData({ testPlanRunId });
+    return populateData({ testPlanRunId }, { context });
 };
 
 module.exports = assignTesterResolver;

--- a/server/resolvers/TestPlanReportOperations/bulkUpdateStatusResolver.js
+++ b/server/resolvers/TestPlanReportOperations/bulkUpdateStatusResolver.js
@@ -8,8 +8,9 @@ const {
 const bulkUpdateStatusResolver = async (
     { parentContext: { ids } },
     { status },
-    { user }
+    context
 ) => {
+    const { user } = context;
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
         throw new AuthenticationError();
     }
@@ -19,7 +20,11 @@ const bulkUpdateStatusResolver = async (
         const id = ids[i];
 
         const testPlanReport = await getTestPlanReportById(id);
-        const conflicts = await conflictsResolver(testPlanReport);
+        const conflicts = await conflictsResolver(
+            testPlanReport,
+            null,
+            context
+        );
         if (conflicts.length > 0) {
             throw new Error(
                 `Cannot update test plan report due to conflicts with the ${testPlanReport.at.name} report.`
@@ -29,7 +34,7 @@ const bulkUpdateStatusResolver = async (
         const result = await updateStatusResolver(
             { parentContext: { id } },
             { status },
-            { user }
+            context
         );
         populateDataResultArray.push(result);
     }

--- a/server/resolvers/TestPlanReportOperations/deleteTestPlanRunResolver.js
+++ b/server/resolvers/TestPlanReportOperations/deleteTestPlanRunResolver.js
@@ -11,8 +11,9 @@ const {
 const deleteTestPlanRunResolver = async (
     { parentContext: { id: testPlanReportId } },
     { userId: testerUserId },
-    { user }
+    context
 ) => {
+    const { user } = context;
     if (
         !(
             user?.roles.find(role => role.name === 'ADMIN') ||
@@ -28,10 +29,13 @@ const deleteTestPlanRunResolver = async (
         testerUserId
     });
 
-    const { testPlanReport } = await populateData({
-        testPlanReportId
-    });
-    const conflicts = await conflictsResolver(testPlanReport);
+    const { testPlanReport } = await populateData(
+        {
+            testPlanReportId
+        },
+        context
+    );
+    const conflicts = await conflictsResolver(testPlanReport, null, context);
     await updateTestPlanReport(testPlanReport.id, {
         metrics: {
             ...testPlanReport.metrics,
@@ -39,7 +43,7 @@ const deleteTestPlanRunResolver = async (
         }
     });
 
-    return populateData({ testPlanReportId });
+    return populateData({ testPlanReportId }, { context });
 };
 
 module.exports = deleteTestPlanRunResolver;

--- a/server/resolvers/TestPlanReportOperations/promoteVendorReviewStatusResolver.js
+++ b/server/resolvers/TestPlanReportOperations/promoteVendorReviewStatusResolver.js
@@ -5,7 +5,8 @@ const populateData = require('../../services/PopulatedData/populateData');
 
 const promoteVendorReviewStatusResolver = async (
     { parentContext: { id: testPlanReportId } },
-    { vendorReviewStatus }
+    { vendorReviewStatus },
+    context
 ) => {
     let updateParams = { vendorReviewStatus };
 
@@ -23,7 +24,7 @@ const promoteVendorReviewStatusResolver = async (
         await updateTestPlanReport(testPlanReportId, updateParams);
     }
 
-    return populateData({ testPlanReportId });
+    return populateData({ testPlanReportId }, { context });
 };
 
 module.exports = promoteVendorReviewStatusResolver;

--- a/server/resolvers/TestPlanReportOperations/updateRecommendedStatusTargetDateResolver.js
+++ b/server/resolvers/TestPlanReportOperations/updateRecommendedStatusTargetDateResolver.js
@@ -7,8 +7,9 @@ const populateData = require('../../services/PopulatedData/populateData');
 const updateRecommendedStatusTargetDateResolver = async (
     { parentContext: { id: testPlanReportId } },
     { recommendedStatusTargetDate },
-    { user }
+    context
 ) => {
+    const { user } = context;
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
         throw new AuthenticationError();
     }
@@ -17,7 +18,7 @@ const updateRecommendedStatusTargetDateResolver = async (
         recommendedStatusTargetDate
     });
 
-    return populateData({ testPlanReportId });
+    return populateData({ testPlanReportId }, { context });
 };
 
 module.exports = updateRecommendedStatusTargetDateResolver;

--- a/server/resolvers/TestPlanRun/testResultsResolver.js
+++ b/server/resolvers/TestPlanRun/testResultsResolver.js
@@ -1,9 +1,11 @@
 const testsResolver = require('../TestPlanVersion/testsResolver');
 const unexpectedBehaviorsJson = require('../../resources/unexpectedBehaviors.json');
 
-const testResultsResolver = testPlanRun => {
+const testResultsResolver = async (testPlanRun, _, context) => {
     const { testPlanReport } = testPlanRun;
     const tests = testsResolver(testPlanReport);
+    const ats = await context.atLoader.getAll();
+    const browsers = await context.browserLoader.getAll();
 
     // Populate nested test, atVersion, browserVersion, scenario, assertion and
     // unexpectedBehavior fields
@@ -12,12 +14,14 @@ const testResultsResolver = testPlanRun => {
         return {
             ...testResult,
             test,
-            atVersion: testPlanReport.at.atVersions.find(
-                each => each.id == testResult.atVersionId
-            ),
-            browserVersion: testPlanReport.browser.browserVersions.find(
-                each => each.id == testResult.browserVersionId
-            ),
+            atVersion: ats
+                .find(at => at.id === testPlanReport.at.id)
+                .atVersions.find(each => each.id == testResult.atVersionId),
+            browserVersion: browsers
+                .find(browser => browser.id === testPlanReport.browser.id)
+                .browserVersions.find(
+                    each => each.id == testResult.browserVersionId
+                ),
             scenarioResults: testResult.scenarioResults.map(scenarioResult => ({
                 ...scenarioResult,
                 scenario: test.scenarios.find(

--- a/server/resolvers/TestPlanRunOperations/deleteTestResultsResolver.js
+++ b/server/resolvers/TestPlanRunOperations/deleteTestResultsResolver.js
@@ -8,9 +8,10 @@ const persistConflictsCount = require('../helpers/persistConflictsCount');
 const deleteTestResultsResolver = async (
     { parentContext: { id: testPlanRunId } },
     _,
-    { user }
+    context
 ) => {
-    const { testPlanRun } = await populateData({ testPlanRunId });
+    const { user } = context;
+    const { testPlanRun } = await populateData({ testPlanRunId }, { context });
 
     if (
         !(
@@ -26,8 +27,8 @@ const deleteTestResultsResolver = async (
 
     // TODO: Avoid blocking loads in test runs with a larger amount of tests
     //       and/or test results
-    await persistConflictsCount(testPlanRun);
-    return populateData({ testPlanRunId });
+    await persistConflictsCount(testPlanRun, context);
+    return populateData({ testPlanRunId }, { context });
 };
 
 module.exports = deleteTestResultsResolver;

--- a/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
+++ b/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
@@ -20,13 +20,21 @@ const findOrCreateTestResultResolver = async (
     const { user } = context;
 
     const fixTestPlanReportMetrics = async testPlanReportStale => {
-        const { testPlanReport } = await populateData({
-            testPlanReportId: testPlanReportStale.id
-        }, {context});
+        const { testPlanReport } = await populateData(
+            {
+                testPlanReportId: testPlanReportStale.id
+            },
+            { context }
+        );
         const runnableTests = runnableTestsResolver(testPlanReport);
-        const finalizedTestResults = finalizedTestResultsResolver({
-            ...testPlanReport
-        }, null, context);
+        const finalizedTestResults = finalizedTestResultsResolver(
+            {
+                ...testPlanReport
+            },
+            null,
+            context
+        );
+        console.log(finalizedTestResults);
         const metrics = getMetrics({
             testPlanReport: {
                 ...testPlanReport,

--- a/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
+++ b/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
@@ -9,16 +9,23 @@ const createTestResultSkeleton = require('./createTestResultSkeleton');
 const findOrCreateTestResultResolver = async (
     { parentContext: { id: testPlanRunId } },
     { testId, atVersionId, browserVersionId },
-    { user }
+    context
 ) => {
+    const { user } = context;
     const {
         testPlanRun,
         testPlanReport,
         testPlanVersion: testPlanRunTestPlanVersion
-    } = await populateData({
-        testPlanRunId
-    });
-    const { test, testPlanVersion } = await populateData({ testId });
+    } = await populateData(
+        {
+            testPlanRunId
+        },
+        { context }
+    );
+    const { test, testPlanVersion } = await populateData(
+        { testId },
+        { context }
+    );
 
     if (
         !(
@@ -81,7 +88,7 @@ const findOrCreateTestResultResolver = async (
         });
     }
 
-    return populateData({ testResultId: newTestResult.id });
+    return populateData({ testResultId: newTestResult.id }, { context });
 };
 
 module.exports = findOrCreateTestResultResolver;

--- a/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
+++ b/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
@@ -34,7 +34,6 @@ const findOrCreateTestResultResolver = async (
             null,
             context
         );
-        // console.log(finalizedTestResults);
         const metrics = getMetrics({
             testPlanReport: {
                 ...testPlanReport,

--- a/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
+++ b/server/resolvers/TestPlanRunOperations/findOrCreateTestResultResolver.js
@@ -27,14 +27,14 @@ const findOrCreateTestResultResolver = async (
             { context }
         );
         const runnableTests = runnableTestsResolver(testPlanReport);
-        const finalizedTestResults = finalizedTestResultsResolver(
+        const finalizedTestResults = await finalizedTestResultsResolver(
             {
                 ...testPlanReport
             },
             null,
             context
         );
-        console.log(finalizedTestResults);
+        // console.log(finalizedTestResults);
         const metrics = getMetrics({
             testPlanReport: {
                 ...testPlanReport,

--- a/server/resolvers/TestResultOperations/deleteTestResultResolver.js
+++ b/server/resolvers/TestResultOperations/deleteTestResultResolver.js
@@ -7,9 +7,10 @@ const populateData = require('../../services/PopulatedData/populateData');
 const deleteTestResultResolver = async (
     { parentContext: { id: testResultId } },
     _,
-    { user }
+    context
 ) => {
-    const { testPlanRun } = await populateData({ testResultId });
+    const { user } = context;
+    const { testPlanRun } = await populateData({ testResultId }, { context });
 
     if (
         !(
@@ -31,7 +32,7 @@ const deleteTestResultResolver = async (
 
     await updateTestPlanRun(testPlanRun.id, { testResults: newTestResults });
 
-    return populateData({ testPlanRunId: testPlanRun.id });
+    return populateData({ testPlanRunId: testPlanRun.id }, { context });
 };
 
 module.exports = deleteTestResultResolver;

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -13,14 +13,15 @@ const saveTestResultCommon = async ({
     testResultId,
     input,
     user,
-    isSubmit
+    isSubmit,
+    context
 }) => {
     const {
         testPlanRun,
         testPlanReport,
         test,
         testResult: testResultPopulated
-    } = await populateData({ testResultId });
+    } = await populateData({ testResultId }, { context });
 
     if (
         !(
@@ -79,8 +80,8 @@ const saveTestResultCommon = async ({
 
     // TODO: Avoid blocking loads in test runs with a larger amount of tests
     //       and/or test results
-    await persistConflictsCount(testPlanRun);
-    return populateData({ testResultId });
+    await persistConflictsCount(testPlanRun, context);
+    return populateData({ testResultId }, { context });
 };
 
 const assertTestResultIsValid = newTestResult => {

--- a/server/resolvers/TestResultOperations/saveTestResultResolver.js
+++ b/server/resolvers/TestResultOperations/saveTestResultResolver.js
@@ -3,13 +3,15 @@ const saveTestResultCommon = require('./saveTestResultCommon');
 const saveTestResultResolver = (
     { parentContext: { id: testResultId } },
     { input },
-    { user }
+    context
 ) => {
+    const { user } = context;
     return saveTestResultCommon({
         testResultId,
         input,
         user,
-        isSubmit: false
+        isSubmit: false,
+        context
     });
 };
 

--- a/server/resolvers/TestResultOperations/submitTestResultResolver.js
+++ b/server/resolvers/TestResultOperations/submitTestResultResolver.js
@@ -3,13 +3,15 @@ const saveTestResultCommon = require('./saveTestResultCommon');
 const submitTestResultResolver = (
     { parentContext: { id: testResultId } },
     { input },
-    { user }
+    context
 ) => {
+    const { user } = context;
     return saveTestResultCommon({
         testResultId,
         input,
         user,
-        isSubmit: true
+        isSubmit: true,
+        context
     });
 };
 

--- a/server/resolvers/findOrCreateTestPlanReportResolver.js
+++ b/server/resolvers/findOrCreateTestPlanReportResolver.js
@@ -4,7 +4,8 @@ const {
 } = require('../models/services/TestPlanReportService');
 const populateData = require('../services/PopulatedData/populateData');
 
-const findOrCreateTestPlanReportResolver = async (_, { input }, { user }) => {
+const findOrCreateTestPlanReportResolver = async (_, { input }, context) => {
+    const { user } = context;
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
         throw new AuthenticationError();
     }
@@ -16,10 +17,13 @@ const findOrCreateTestPlanReportResolver = async (_, { input }, { user }) => {
     const preloaded = { testPlanReport };
 
     return {
-        populatedData: await populateData(locationOfData, { preloaded }),
+        populatedData: await populateData(locationOfData, {
+            preloaded,
+            context
+        }),
         created: await Promise.all(
             createdLocationsOfData.map(createdLocationOfData =>
-                populateData(createdLocationOfData, { preloaded })
+                populateData(createdLocationOfData, { preloaded, context })
             )
         )
     };

--- a/server/resolvers/helpers/persistConflictsCount.js
+++ b/server/resolvers/helpers/persistConflictsCount.js
@@ -4,11 +4,18 @@ const {
     updateTestPlanReport
 } = require('../../models/services/TestPlanReportService');
 
-const persistConflictsCount = async testPlanRun => {
-    const { testPlanReport: updatedTestPlanReport } = await populateData({
-        testPlanRunId: testPlanRun.id
-    });
-    const conflicts = await conflictsResolver(updatedTestPlanReport);
+const persistConflictsCount = async (testPlanRun, context) => {
+    const { testPlanReport: updatedTestPlanReport } = await populateData(
+        {
+            testPlanRunId: testPlanRun.id
+        },
+        { context }
+    );
+    const conflicts = await conflictsResolver(
+        updatedTestPlanReport,
+        null,
+        context
+    );
     await updateTestPlanReport(updatedTestPlanReport.id, {
         metrics: {
             ...updatedTestPlanReport.metrics,

--- a/server/resolvers/populateDataResolver.js
+++ b/server/resolvers/populateDataResolver.js
@@ -1,7 +1,7 @@
 const populateData = require('../services/PopulatedData/populateData');
 
-const populateDataResolver = async (_, { locationOfData }) => {
-    return populateData(locationOfData);
+const populateDataResolver = async (_, { locationOfData }, context) => {
+    return populateData(locationOfData, { context });
 };
 
 module.exports = populateDataResolver;

--- a/server/services/PopulatedData/populateData.js
+++ b/server/services/PopulatedData/populateData.js
@@ -10,7 +10,7 @@ const {
 } = require('../../models/services/TestPlanRunService');
 const { decodeLocationOfDataId } = require('./locationOfDataId');
 const testsResolver = require('../../resolvers/TestPlanVersion/testsResolver');
-const testsResultsResolver = require('../../resolvers/TestPlanRun/testResultsResolver');
+const testResultsResolver = require('../../resolvers/TestPlanRun/testResultsResolver');
 const testPlanVersionTestPlanResolver = require('../../resolvers/TestPlanVersion/testPlanVersionTestPlanResolver');
 
 /**
@@ -22,7 +22,7 @@ const testPlanVersionTestPlanResolver = require('../../resolvers/TestPlanVersion
  * and no database queries will be run by this function.
  * @returns
  */
-const populateData = async (locationOfData, { preloaded } = {}) => {
+const populateData = async (locationOfData, { preloaded, context }) => {
     let {
         testPlanId,
         testPlanVersionId,
@@ -130,7 +130,11 @@ const populateData = async (locationOfData, { preloaded } = {}) => {
     let browserVersion;
 
     if (testResultId) {
-        const testResults = testsResultsResolver(testPlanRun);
+        const testResults = await testResultsResolver(
+            testPlanRun,
+            null,
+            context
+        );
         testResult = testResults.find(each => each.id === testResultId);
         if (!testResult) {
             throw new Error(

--- a/server/tests/util/api-server.js
+++ b/server/tests/util/api-server.js
@@ -38,7 +38,7 @@ const startSupertestServer = async ({ graphql = false, pathToRoutes = [] }) => {
 
     // Error handling must be the last middleware
     expressApp.use((error, req, res, next) => {
-        // console.error(error);
+        console.error(error);
         next(error);
     });
 

--- a/server/tests/util/api-server.js
+++ b/server/tests/util/api-server.js
@@ -38,7 +38,7 @@ const startSupertestServer = async ({ graphql = false, pathToRoutes = [] }) => {
 
     // Error handling must be the last middleware
     expressApp.use((error, req, res, next) => {
-        console.error(error);
+        // console.error(error);
         next(error);
     });
 


### PR DESCRIPTION
This PR improves the test queue query speed by 69X and improves the querying speeds for all the rest of pages as well.

- Before this PR, the test queue was querying the cartesian product of all tests, ATs, AT versions, browsers, and browser versions. 
- We removed the `includes` query from the `atAssociation` and `browserAssociation` functions in the  `TestPlanVersionService` and `TestPlanReportService` files. The `includes` query is what was causing the cartesian product problem.
- We then created an `AtLoader` and `BrowserLoader` that fetches all of the AT versions and browser versions, respectively.
- To test the speed improvement, use the production database. Follow the instructions in the database README to see how to use the production database.