### PR TITLE
Improve TestRun loading and address miscellaneous issues (#623 add-on)

### DIFF
--- a/client/components/App/App.jsx
+++ b/client/components/App/App.jsx
@@ -89,7 +89,13 @@ const App = () => {
                                     as={Link}
                                     to="/test-queue"
                                     aria-current={
-                                        location.pathname === '/test-queue'
+                                        location.pathname.includes(
+                                            '/test-queue'
+                                        ) ||
+                                        location.pathname.includes('/run') ||
+                                        location.pathname.includes(
+                                            '/test-plan-report'
+                                        )
                                     }
                                 >
                                     Test Queue

--- a/client/components/ManageTestQueue/index.jsx
+++ b/client/components/ManageTestQueue/index.jsx
@@ -106,7 +106,7 @@ const ManageTestQueue = ({
 
     const [showManageATs, setShowManageATs] = useState(false);
     const [showAddTestPlans, setShowAddTestPlans] = useState(false);
-    const [selectedManageAtId, setSelectedManageAtId] = useState('');
+    const [selectedManageAtId, setSelectedManageAtId] = useState('1');
     const [selectedManageAtVersions, setSelectedManageAtVersions] = useState(
         []
     );

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -17,7 +17,7 @@ import DisclaimerInfo from '../DisclaimerInfo';
 import TestPlanResultsTable from './TestPlanResultsTable';
 import DisclosureComponent from '../common/DisclosureComponent';
 import { Navigate } from 'react-router';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 const getTestersRunHistory = (
     testPlanReport,
@@ -77,6 +77,7 @@ const getTestersRunHistory = (
 };
 
 const SummarizeTestPlanReport = ({ testPlanReports }) => {
+    const location = useLocation();
     const { testPlanReportId } = useParams();
 
     const testPlanReport = testPlanReports.find(
@@ -145,8 +146,13 @@ const SummarizeTestPlanReport = ({ testPlanReports }) => {
             {testPlanReport.finalizedTestResults.map(testResult => {
                 const test = testResult.test;
 
+                const fromReportPageLink = `https://aria-at.w3.org${location.pathname}#result-${testResult.id}`;
                 const gitHubIssueLinkWithTitleAndBody =
-                    createGitHubIssueWithTitleAndBody({ test, testPlanReport });
+                    createGitHubIssueWithTitleAndBody({
+                        test,
+                        testPlanReport,
+                        fromReportPageLink
+                    });
 
                 // TODO: fix renderedUrl
                 let modifiedRenderedUrl = test.renderedUrl.replace(

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -636,7 +636,7 @@ const TestQueueRow = ({
                                                 {tester.username}
                                             </a>
                                             <div id={getRowId(tester)}>
-                                                {`${testResultsLength} of ${runnableTestsLength} tests complete)`}
+                                                {`${testResultsLength} of ${runnableTestsLength} tests complete`}
                                             </div>
                                         </li>
                                     )

--- a/client/components/TestRun/StatusBar/index.jsx
+++ b/client/components/TestRun/StatusBar/index.jsx
@@ -17,7 +17,7 @@ const StatusBar = ({
             const variant = 'warning';
             const action = (
                 <Button
-                    className="ml-auto"
+                    className="ms-auto"
                     variant={variant}
                     onClick={handleReviewConflictsButtonClick}
                 >
@@ -46,7 +46,7 @@ const StatusBar = ({
                         variant={variant}
                         className="status-bar"
                     >
-                        <Octicon icon={Octicons[icon]} className="mr-2" />{' '}
+                        <Octicon icon={Octicons[icon]} className="me-2" />{' '}
                         {message}
                         {action}
                     </Alert>

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -279,7 +279,7 @@ main.container-fluid .test-iframe-container > .row {
 
 .at-browser {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: flex-start;
 
     background: #f5f8fa;
@@ -291,8 +291,8 @@ main.container-fluid .test-iframe-container > .row {
 .at-browser-row {
     width: 100%;
     display: flex;
-    flex-direction: row;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
     justify-content: space-between;
 }
 

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -44,7 +44,8 @@ const createGitHubIssueWithTitleAndBody = ({
     testPlanReport = {},
     atVersion,
     browserVersion,
-    conflictMarkdown = null
+    conflictMarkdown = null,
+    fromReportPageLink = null
 }) => {
     // TODO: fix renderedUrl
     let modifiedRenderedUrl = test?.renderedUrl?.replace(
@@ -70,6 +71,20 @@ const createGitHubIssueWithTitleAndBody = ({
         `${at.name} (version ${atVersion})\n` +
         `- Browser: ` +
         `${browser.name} (version ${browserVersion})\n`;
+
+    if (fromReportPageLink)
+        body =
+            `## Description of Behavior\n\n` +
+            `<!-- write your description here -->\n\n` +
+            `## Test Setup\n\n` +
+            `- Test File: ` +
+            `[${shortenedUrl}](${modifiedRenderedUrl})\n` +
+            `- Report Page: ` +
+            `[Link](${fromReportPageLink})\n` +
+            `- AT: ` +
+            `${at.name}\n` +
+            `- Browser: ` +
+            `${browser.name}\n`;
 
     if (conflictMarkdown) {
         body += `\n${conflictMarkdown}`;

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -1077,25 +1077,25 @@ const TestRun = () => {
                                 isSignedIn ? ` ${currentAtVersion?.name}` : ''
                             }`}
                         </div>
-                        {isSignedIn && (
-                            <Button
-                                ref={editAtBrowserDetailsButtonRef}
-                                id="edit-fa-button"
-                                aria-label="Edit version details for AT and Browser"
-                                onClick={handleEditAtBrowserDetailsClick}
-                            >
-                                <FontAwesomeIcon icon={faEdit} />
-                            </Button>
-                        )}
+                        <div className="info-label">
+                            <b>Browser:</b>{' '}
+                            {`${testPlanReport.browser?.name}${
+                                isSignedIn
+                                    ? ` ${currentBrowserVersion?.name || ''}`
+                                    : ''
+                            }`}
+                        </div>
                     </div>
-                    <div className="info-label">
-                        <b>Browser:</b>{' '}
-                        {`${testPlanReport.browser?.name}${
-                            isSignedIn
-                                ? ` ${currentBrowserVersion?.name || ''}`
-                                : ''
-                        }`}
-                    </div>
+                    {isSignedIn && (
+                        <Button
+                            ref={editAtBrowserDetailsButtonRef}
+                            id="edit-fa-button"
+                            aria-label="Edit version details for AT and Browser"
+                            onClick={handleEditAtBrowserDetailsClick}
+                        >
+                            <FontAwesomeIcon icon={faEdit} />
+                        </Button>
+                    )}
                 </div>
                 <div className="test-info-entity tests-completed">
                     <div className="info-label">

--- a/client/components/TestRun/queries.js
+++ b/client/components/TestRun/queries.js
@@ -260,6 +260,133 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                 browserVersionId: $browserVersionId
             ) {
                 locationOfData
+                testPlanRun {
+                    testResults {
+                        id
+                        test {
+                            id
+                            renderableContent
+                        }
+                        atVersion {
+                            id
+                            name
+                        }
+                        browserVersion {
+                            id
+                            name
+                        }
+                        startedAt
+                        completedAt
+                        scenarioResults {
+                            id
+                            output
+                            assertionResults {
+                                id
+                                passed
+                                failedReason
+                            }
+                            unexpectedBehaviors {
+                                id
+                                text
+                                otherUnexpectedBehaviorText
+                            }
+                        }
+                    }
+                }
+                testPlanReport {
+                    id
+                    status
+                    conflicts {
+                        source {
+                            test {
+                                id
+                                title
+                                rowNumber
+                            }
+                            scenario {
+                                id
+                                commands {
+                                    text
+                                }
+                            }
+                            assertion {
+                                id
+                                text
+                            }
+                        }
+                        conflictingResults {
+                            testPlanRun {
+                                id
+                                tester {
+                                    username
+                                }
+                            }
+                            scenarioResult {
+                                output
+                                unexpectedBehaviors {
+                                    text
+                                    otherUnexpectedBehaviorText
+                                }
+                            }
+                            assertionResult {
+                                passed
+                                failedReason
+                            }
+                        }
+                    }
+                    at {
+                        id
+                        name
+                        atVersions {
+                            id
+                            name
+                        }
+                    }
+                    browser {
+                        id
+                        name
+                        browserVersions {
+                            id
+                            name
+                        }
+                    }
+                    testPlanVersion {
+                        id
+                        title
+                        gitSha
+                        testPageUrl
+                        testPlan {
+                            directory
+                        }
+                    }
+                    runnableTests {
+                        id
+                        rowNumber
+                        title
+                        ats {
+                            id
+                            name
+                        }
+                        atMode
+                        renderedUrl
+                        scenarios {
+                            id
+                            at {
+                                id
+                                name
+                            }
+                            commands {
+                                id
+                                text
+                            }
+                        }
+                        assertions {
+                            id
+                            priority
+                            text
+                        }
+                    }
+                }
             }
         }
     }
@@ -282,6 +409,133 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                 }
             ) {
                 locationOfData
+                testPlanRun {
+                    testResults {
+                        id
+                        test {
+                            id
+                            renderableContent
+                        }
+                        atVersion {
+                            id
+                            name
+                        }
+                        browserVersion {
+                            id
+                            name
+                        }
+                        startedAt
+                        completedAt
+                        scenarioResults {
+                            id
+                            output
+                            assertionResults {
+                                id
+                                passed
+                                failedReason
+                            }
+                            unexpectedBehaviors {
+                                id
+                                text
+                                otherUnexpectedBehaviorText
+                            }
+                        }
+                    }
+                }
+                testPlanReport {
+                    id
+                    status
+                    conflicts {
+                        source {
+                            test {
+                                id
+                                title
+                                rowNumber
+                            }
+                            scenario {
+                                id
+                                commands {
+                                    text
+                                }
+                            }
+                            assertion {
+                                id
+                                text
+                            }
+                        }
+                        conflictingResults {
+                            testPlanRun {
+                                id
+                                tester {
+                                    username
+                                }
+                            }
+                            scenarioResult {
+                                output
+                                unexpectedBehaviors {
+                                    text
+                                    otherUnexpectedBehaviorText
+                                }
+                            }
+                            assertionResult {
+                                passed
+                                failedReason
+                            }
+                        }
+                    }
+                    at {
+                        id
+                        name
+                        atVersions {
+                            id
+                            name
+                        }
+                    }
+                    browser {
+                        id
+                        name
+                        browserVersions {
+                            id
+                            name
+                        }
+                    }
+                    testPlanVersion {
+                        id
+                        title
+                        gitSha
+                        testPageUrl
+                        testPlan {
+                            directory
+                        }
+                    }
+                    runnableTests {
+                        id
+                        rowNumber
+                        title
+                        ats {
+                            id
+                            name
+                        }
+                        atMode
+                        renderedUrl
+                        scenarios {
+                            id
+                            at {
+                                id
+                                name
+                            }
+                            commands {
+                                id
+                                text
+                            }
+                        }
+                        assertions {
+                            id
+                            priority
+                            text
+                        }
+                    }
+                }
             }
         }
     }
@@ -304,6 +558,133 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                 }
             ) {
                 locationOfData
+                testPlanRun {
+                    testResults {
+                        id
+                        test {
+                            id
+                            renderableContent
+                        }
+                        atVersion {
+                            id
+                            name
+                        }
+                        browserVersion {
+                            id
+                            name
+                        }
+                        startedAt
+                        completedAt
+                        scenarioResults {
+                            id
+                            output
+                            assertionResults {
+                                id
+                                passed
+                                failedReason
+                            }
+                            unexpectedBehaviors {
+                                id
+                                text
+                                otherUnexpectedBehaviorText
+                            }
+                        }
+                    }
+                }
+                testPlanReport {
+                    id
+                    status
+                    conflicts {
+                        source {
+                            test {
+                                id
+                                title
+                                rowNumber
+                            }
+                            scenario {
+                                id
+                                commands {
+                                    text
+                                }
+                            }
+                            assertion {
+                                id
+                                text
+                            }
+                        }
+                        conflictingResults {
+                            testPlanRun {
+                                id
+                                tester {
+                                    username
+                                }
+                            }
+                            scenarioResult {
+                                output
+                                unexpectedBehaviors {
+                                    text
+                                    otherUnexpectedBehaviorText
+                                }
+                            }
+                            assertionResult {
+                                passed
+                                failedReason
+                            }
+                        }
+                    }
+                    at {
+                        id
+                        name
+                        atVersions {
+                            id
+                            name
+                        }
+                    }
+                    browser {
+                        id
+                        name
+                        browserVersions {
+                            id
+                            name
+                        }
+                    }
+                    testPlanVersion {
+                        id
+                        title
+                        gitSha
+                        testPageUrl
+                        testPlan {
+                            directory
+                        }
+                    }
+                    runnableTests {
+                        id
+                        rowNumber
+                        title
+                        ats {
+                            id
+                            name
+                        }
+                        atMode
+                        renderedUrl
+                        scenarios {
+                            id
+                            at {
+                                id
+                                name
+                            }
+                            commands {
+                                id
+                                text
+                            }
+                        }
+                        assertions {
+                            id
+                            priority
+                            text
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This work is based on #623.

Noticed an issue where a Test on the `TestRun` page can fail to be rendered when navigating to it for the first time (during the `create` of the `findOrCreateTestResult` GraphQL mutation). This happened pretty often but there's no correlation to #623, but rather an underlying issue which was hidden when the queries were slower. So I've opted to create a separate PR. This should help to optimze the loading strategy of the `TestRun` component.

I took the chance to address other concerns as well (and under separate commits):
* Fix chance for `atVersions` to be empty on first load of the `ManageTestQueue` component
* Remove unnecessary closing bracket in the `TestQueueRow` component when displaying the amount of tests completed
  * This was noted during the May 11, 2023 CG meeting
* Fix margins between the elements of the Review Conflicts Status Bar on the `TestRun` page
  * Bootstrap classnames had to be updated
* Fix for the Test Queue link in the main nav not being highlighted when on the `TestRun` page
* Fix the document ordering of the AT details, browser details and the edit button on the Test Run page (changing from `AT > Edit Button > Browser` to `AT > Browser > Edit Button`)
* Fix undefined AT and Browser versions being populated in the GitHub issue, when creating an issue from a report's ‘Raise an issue’ button. Also updated the format to include the direct link to the report
