### PR TITLE
Encode reports URL when multiple versions are being checked

### DIFF
--- a/client/components/Reports/SummarizeTestPlanReports.jsx
+++ b/client/components/Reports/SummarizeTestPlanReports.jsx
@@ -222,7 +222,9 @@ const SummarizeTestPlanReports = ({ testPlanReports }) => {
                                 <tr key={testPlanVersionId}>
                                     <td>
                                         <Link
-                                            to={`/report/${testPlanVersionId}`}
+                                            to={`/report/${encodeURIComponent(
+                                                testPlanVersionId
+                                            )}`}
                                             aria-label={`${getTestPlanVersionTitle(
                                                 testPlanVersion
                                             )}, ${status} report`}


### PR DESCRIPTION
On the reports page (`/reports`), there is a chance that multiple versions can to determine which version has the most relevant data. Currently the url is displayed as `/report/1090,1890,2215`, where each number represents a different version of the same test plan.

This change would encode the url to `/report/1090%2C1890%2C2215` instead, to avoid unpredictable situations when navigating to the address.