### PR TITLE
Temporarily revise the valid combinations of ATs and Browsers for `embed.js`

### DIFF
--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -221,8 +221,7 @@ const getAllAtBrowserCombinations = reports => {
     const loggedAtIds = [];
 
     const report = reports[0];
-    for (let i = 0; i < report.testPlanVersion.tests.length; i++) {
-        const test = report.testPlanVersion.tests[i];
+    report.testPlanVersion.tests.forEach(test => {
         const atIds = test.ats.map(at => at.id);
 
         if (!loggedAtIds.includes(1) && atIds.includes('1')) {
@@ -242,7 +241,7 @@ const getAllAtBrowserCombinations = reports => {
                 Object.values(validAtBrowserCombinations)[2];
             loggedAtIds.push(3);
         }
-    }
+    });
 
     return combinations;
 };


### PR DESCRIPTION
Based on #583.

I've revised the `getAllAtBrowserCombinations` function after noticing that there's a case where the function may cause the `/embed` url to incorrectly display a AT/Browser pairing as 'Not Applicable` when it should say `Data Not Yet Available` instead.

I've noted this as a temporary patch as it only applies for this file and having a useable solution to be used elsewhere in the application would be best. It most recently aligns with requirements described in /648.

This is currently being tracked in #625