### PR TITLE
Remove duplicate TestPlan.title from `graphql-schema`

### DIFF
--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -212,7 +212,6 @@ const graphqlSchema = gql`
         as a directory, and this allows you to do both.
         """
         id: ID!
-        title: String!
         """
         The formal name of the test plan
         """


### PR DESCRIPTION
Remove duplicate TestPlan.title from `graphql-schema.js`, that happened during merge of #620.