### PR TITLE
Add At and Browser Association

### DIFF
--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -83,6 +83,10 @@ const graphqlSchema = gql`
         A fully-qualified version like "99.0.4844.84"
         """
         browserVersions: [BrowserVersion]!
+        """
+        The Ats which can be run with the specific browser, for example, Jaws can be run with Chrome but not Safari, and Safari works with VoiceOver only.
+        """
+        ats: [At]!
     }
 
     """
@@ -145,6 +149,10 @@ const graphqlSchema = gql`
         # """
         # modes: [AtMode]!
         atVersions: [AtVersion]!
+        """
+        The browsers which can run the At, for example, Safari can run VoiceOver but not Jaws because Jaws is Windows only.
+        """
+        browsers: [Browser]!
     }
 
     """

--- a/server/handlebars/helpers/index.js
+++ b/server/handlebars/helpers/index.js
@@ -14,7 +14,7 @@ module.exports = {
         return object.allAtVersionsByAt[key].name;
     },
     combinationExists: function (object, atName, browserName) {
-        if (object.allAtBrowserCombinations[atName].has(browserName)) {
+        if (object.allAtBrowserCombinations[atName].includes(browserName)) {
             return true;
         }
         return false;

--- a/server/models/At.js
+++ b/server/models/At.js
@@ -22,7 +22,7 @@ module.exports = function (sequelize, DataTypes) {
     );
 
     Model.AT_VERSION_ASSOCIATION = { as: 'atVersions' };
-
+    Model.BROWSERS_ASSOCIATION = { through: 'AtBrowsers', as: 'browsers' };
     Model.AT_MODE_ASSOCIATION = { as: 'modes' };
 
     Model.associate = function (models) {
@@ -30,6 +30,12 @@ module.exports = function (sequelize, DataTypes) {
             ...Model.AT_VERSION_ASSOCIATION,
             foreignKey: 'atId',
             sourceKey: 'id'
+        });
+
+        Model.belongsToMany(models.Browser, {
+            ...Model.BROWSERS_ASSOCIATION,
+            foreignKey: 'atId',
+            otherKey: 'browserId'
         });
 
         Model.hasMany(models.AtMode, {

--- a/server/models/AtBrowsers.js
+++ b/server/models/AtBrowsers.js
@@ -1,0 +1,29 @@
+const MODEL_NAME = 'AtBrowsers';
+
+module.exports = function (sequelize, DataTypes) {
+    return sequelize.define(
+        MODEL_NAME,
+        {
+            atId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'At',
+                    key: 'id'
+                }
+            },
+            browserId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'Browser',
+                    key: 'id'
+                }
+            }
+        },
+        {
+            timestamps: false,
+            tableName: MODEL_NAME
+        }
+    );
+};

--- a/server/models/Browser.js
+++ b/server/models/Browser.js
@@ -27,11 +27,22 @@ module.exports = function (sequelize, DataTypes) {
 
     Model.BROWSER_VERSION_ASSOCIATION = { as: 'browserVersions' };
 
+    Model.ATS_ASSOCIATION = {
+        through: 'AtBrowsers',
+        as: 'ats'
+    };
+
     Model.associate = function (models) {
         Model.hasMany(models.BrowserVersion, {
             ...Model.BROWSER_VERSION_ASSOCIATION,
             foreignKey: 'browserId',
             sourceKey: 'id'
+        });
+
+        Model.belongsToMany(models.At, {
+            ...Model.ATS_ASSOCIATION,
+            foreignKey: 'browserId',
+            otherKey: 'atId'
         });
     };
 

--- a/server/models/services/AtService.js
+++ b/server/models/services/AtService.js
@@ -3,7 +3,8 @@ const ModelService = require('./ModelService');
 const {
     AT_ATTRIBUTES,
     AT_VERSION_ATTRIBUTES,
-    AT_MODE_ATTRIBUTES
+    AT_MODE_ATTRIBUTES,
+    BROWSER_ATTRIBUTES
 } = require('./helpers');
 const { Sequelize, At, AtVersion, AtMode } = require('../');
 const { Op } = Sequelize;
@@ -37,6 +38,15 @@ const atModeAssociation = atModeAttributes => ({
     attributes: atModeAttributes
 });
 
+/**
+ * @param browserAttributes - Browser attributes
+ * @returns {{association: string, attributes: string[]}}
+ */
+const browserAssociation = browserAttributes => ({
+    association: 'browsers',
+    attributes: browserAttributes
+});
+
 // At
 
 /**
@@ -45,6 +55,7 @@ const atModeAssociation = atModeAttributes => ({
  * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {string[]} atVersionAttributes  - AtVersion attributes to be returned in the result
  * @param {string[]} atModeAttributes  - AtMode attributes to be returned in the result
+ * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {object} options - Generic options for Sequelize
  * @param {*} options.transaction - Sequelize transaction
  * @returns {Promise<*>}
@@ -54,6 +65,7 @@ const getAtById = async (
     atAttributes = AT_ATTRIBUTES,
     atVersionAttributes = AT_VERSION_ATTRIBUTES,
     atModeAttributes = AT_MODE_ATTRIBUTES,
+    browserAttributes = BROWSER_ATTRIBUTES,
     options = {}
 ) => {
     return ModelService.getById(
@@ -62,7 +74,8 @@ const getAtById = async (
         atAttributes,
         [
             atVersionAssociation(atVersionAttributes),
-            atModeAssociation(atModeAttributes)
+            atModeAssociation(atModeAttributes),
+            browserAssociation(browserAttributes)
         ],
         options
     );
@@ -74,6 +87,7 @@ const getAtById = async (
  * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {string[]} atVersionAttributes  - AtVersion attributes to be returned in the result
  * @param {string[]} atModeAttributes  - AtMode attributes to be returned in the result
+ * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {object} pagination - pagination options for query
  * @param {number} [pagination.page=0] - page to be queried in the pagination result (affected by {@param pagination.enablePagination})
  * @param {number} [pagination.limit=10] - amount of results to be returned per page (affected by {@param pagination.enablePagination})
@@ -89,6 +103,7 @@ const getAts = async (
     atAttributes = AT_ATTRIBUTES,
     atVersionAttributes = AT_VERSION_ATTRIBUTES,
     atModeAttributes = AT_MODE_ATTRIBUTES,
+    browserAttributes = BROWSER_ATTRIBUTES,
     pagination = {},
     options = {}
 ) => {
@@ -103,7 +118,8 @@ const getAts = async (
         atAttributes,
         [
             atVersionAssociation(atVersionAttributes),
-            atModeAssociation(atModeAttributes)
+            atModeAssociation(atModeAttributes),
+            browserAssociation(browserAttributes)
         ],
         pagination,
         options
@@ -115,6 +131,7 @@ const getAts = async (
  * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {string[]} atVersionAttributes  - AtVersion attributes to be returned in the result
  * @param {string[]} atModeAttributes  - AtMode attributes to be returned in the result
+ * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {object} options - Generic options for Sequelize
  * @param {*} options.transaction - Sequelize transaction
  * @returns {Promise<*>}
@@ -124,6 +141,7 @@ const createAt = async (
     atAttributes = AT_ATTRIBUTES,
     atVersionAttributes = AT_VERSION_ATTRIBUTES,
     atModeAttributes = AT_MODE_ATTRIBUTES,
+    browserAttributes = BROWSER_ATTRIBUTES,
     options = {}
 ) => {
     const atResult = await ModelService.create(At, { name });
@@ -136,7 +154,8 @@ const createAt = async (
         atAttributes,
         [
             atVersionAssociation(atVersionAttributes),
-            atModeAssociation(atModeAttributes)
+            atModeAssociation(atModeAttributes),
+            browserAssociation(browserAttributes)
         ],
         options
     );
@@ -148,6 +167,7 @@ const createAt = async (
  * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {string[]} atVersionAttributes  - AtVersion attributes to be returned in the result
  * @param {string[]} atModeAttributes  - AtMode attributes to be returned in the result
+ * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {object} options - Generic options for Sequelize
  * @param {*} options.transaction - Sequelize transaction
  * @returns {Promise<*>}
@@ -158,6 +178,7 @@ const updateAt = async (
     atAttributes = AT_ATTRIBUTES,
     atVersionAttributes = AT_VERSION_ATTRIBUTES,
     atModeAttributes = AT_MODE_ATTRIBUTES,
+    browserAttributes = BROWSER_ATTRIBUTES,
     options = {}
 ) => {
     await ModelService.update(At, { id }, { name }, options);
@@ -168,7 +189,8 @@ const updateAt = async (
         atAttributes,
         [
             atVersionAssociation(atVersionAttributes),
-            atModeAssociation(atModeAttributes)
+            atModeAssociation(atModeAttributes),
+            browserAssociation(browserAttributes)
         ],
         options
     );

--- a/server/models/services/BrowserService.js
+++ b/server/models/services/BrowserService.js
@@ -1,5 +1,9 @@
 const ModelService = require('./ModelService');
-const { BROWSER_ATTRIBUTES, BROWSER_VERSION_ATTRIBUTES } = require('./helpers');
+const {
+    BROWSER_ATTRIBUTES,
+    BROWSER_VERSION_ATTRIBUTES,
+    AT_ATTRIBUTES
+} = require('./helpers');
 const { Sequelize, Browser, BrowserVersion } = require('../');
 const { Op } = Sequelize;
 
@@ -23,6 +27,15 @@ const browserVersionAssociation = browserVersionAttributes => ({
     attributes: browserVersionAttributes
 });
 
+/**
+ * @param atAttributes - At attributes
+ * @returns {{association: string, attributes: string[]}}
+ */
+const atAssociation = atAttributes => ({
+    association: 'ats',
+    attributes: atAttributes
+});
+
 // Browser
 
 /**
@@ -30,6 +43,7 @@ const browserVersionAssociation = browserVersionAttributes => ({
  * @param {number} id - unique id of the Browser model being queried
  * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {string[]} browserVersionAttributes  - BrowserVersion attributes to be returned in the result
+ * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {object} options - Generic options for Sequelize
  * @param {*} options.transaction - Sequelize transaction
  * @returns {Promise<*>}
@@ -38,13 +52,17 @@ const getBrowserById = async (
     id,
     browserAttributes = BROWSER_ATTRIBUTES,
     browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
+    atAttributes = AT_ATTRIBUTES,
     options = {}
 ) => {
     return ModelService.getById(
         Browser,
         id,
         browserAttributes,
-        [browserVersionAssociation(browserVersionAttributes)],
+        [
+            browserVersionAssociation(browserVersionAttributes),
+            atAssociation(atAttributes)
+        ],
         options
     );
 };
@@ -54,6 +72,7 @@ const getBrowserById = async (
  * @param {object} filter - use this define conditions to be passed to Sequelize's where clause
  * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {string[]} browserVersionAttributes  - BrowserVersion attributes to be returned in the result
+ * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {object} pagination - pagination options for query
  * @param {number} [pagination.page=0] - page to be queried in the pagination result (affected by {@param pagination.enablePagination})
  * @param {number} [pagination.limit=10] - amount of results to be returned per page (affected by {@param pagination.enablePagination})
@@ -68,6 +87,7 @@ const getBrowsers = async (
     filter = {},
     browserAttributes = BROWSER_ATTRIBUTES,
     browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
+    atAttributes = AT_ATTRIBUTES,
     pagination = {},
     options = {}
 ) => {
@@ -80,7 +100,10 @@ const getBrowsers = async (
         Browser,
         where,
         browserAttributes,
-        [browserVersionAssociation(browserVersionAttributes)],
+        [
+            browserVersionAssociation(browserVersionAttributes),
+            atAssociation(atAttributes)
+        ],
         pagination,
         options
     );
@@ -90,6 +113,7 @@ const getBrowsers = async (
  * @param {object} createParams - values to be used to create the Browser record
  * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {string[]} browserVersionAttributes  - BrowserVersion attributes to be returned in the result
+ * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {object} options - Generic options for Sequelize
  * @param {*} options.transaction - Sequelize transaction
  * @returns {Promise<*>}
@@ -98,6 +122,7 @@ const createBrowser = async (
     { name },
     browserAttributes = BROWSER_ATTRIBUTES,
     browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
+    atAttributes = AT_ATTRIBUTES,
     options = {}
 ) => {
     const browserResult = await ModelService.create(Browser, { name }, options);
@@ -108,7 +133,10 @@ const createBrowser = async (
         Browser,
         id,
         browserAttributes,
-        [browserVersionAssociation(browserVersionAttributes)],
+        [
+            browserVersionAssociation(browserVersionAttributes),
+            atAssociation(atAttributes)
+        ],
         options
     );
 };
@@ -118,6 +146,7 @@ const createBrowser = async (
  * @param {object} updateParams - values to be used to update columns for the record being referenced for {@param id}
  * @param {string[]} browserAttributes  - Browser attributes to be returned in the result
  * @param {string[]} browserVersionAttributes  - BrowserVersion attributes to be returned in the result
+ * @param {string[]} atAttributes  - At attributes to be returned in the result
  * @param {object} options - Generic options for Sequelize
  * @param {*} options.transaction - Sequelize transaction
  * @returns {Promise<*>}
@@ -127,6 +156,7 @@ const updateBrowser = async (
     { name },
     browserAttributes = BROWSER_ATTRIBUTES,
     browserVersionAttributes = BROWSER_VERSION_ATTRIBUTES,
+    atAttributes = AT_ATTRIBUTES,
     options = {}
 ) => {
     await ModelService.update(Browser, { id }, { name }, options);
@@ -135,7 +165,10 @@ const updateBrowser = async (
         Browser,
         id,
         browserAttributes,
-        [browserVersionAssociation(browserVersionAttributes)],
+        [
+            browserVersionAssociation(browserVersionAttributes),
+            atAssociation(atAttributes)
+        ],
         options
     );
 };

--- a/server/resolvers/atsResolver.js
+++ b/server/resolvers/atsResolver.js
@@ -7,6 +7,7 @@ const atsResolver = async () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         {
             order: [['name', 'asc']]
         }

--- a/server/resolvers/browsersResolver.js
+++ b/server/resolvers/browsersResolver.js
@@ -1,7 +1,7 @@
 const { getBrowsers } = require('../models/services/BrowserService');
 
 const browsersResolver = () => {
-    return getBrowsers(undefined, undefined, undefined, undefined, {
+    return getBrowsers(undefined, undefined, undefined, undefined, undefined, {
         order: [['name', 'asc']]
     });
 };

--- a/server/seeders/20230622202911-addAtBrowser.js
+++ b/server/seeders/20230622202911-addAtBrowser.js
@@ -1,0 +1,34 @@
+'use strict';
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.createTable('AtBrowsers', {
+            atId: { type: Sequelize.DataTypes.INTEGER },
+            browserId: { type: Sequelize.DataTypes.INTEGER }
+        });
+        const jawsAtId = 1;
+        const nvdaAtId = 2;
+        const voiceOverAtId = 3;
+
+        const firefoxBrowserId = 1;
+        const chromeBrowserId = 2;
+        const safariBrowserId = 3;
+        return queryInterface.bulkInsert(
+            'AtBrowsers',
+            [
+                { atId: jawsAtId, browserId: firefoxBrowserId },
+                { atId: jawsAtId, browserId: chromeBrowserId },
+                { atId: nvdaAtId, browserId: firefoxBrowserId },
+                { atId: nvdaAtId, browserId: chromeBrowserId },
+                { atId: voiceOverAtId, browserId: safariBrowserId },
+                { atId: voiceOverAtId, browserId: firefoxBrowserId },
+                { atId: voiceOverAtId, browserId: chromeBrowserId }
+            ],
+            {}
+        );
+    },
+
+    down: async (queryInterface /* , Sequelize */) => {
+        await queryInterface.dropTable('AtBrowsers');
+    }
+};

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -177,6 +177,11 @@ describe('graphql', () => {
                         __typename
                         id
                         name
+                        ats {
+                            __typename
+                            id
+                            name
+                        }
                         browserVersions {
                             __typename
                             id
@@ -187,6 +192,11 @@ describe('graphql', () => {
                         __typename
                         id
                         name
+                        browsers {
+                            __typename
+                            id
+                            name
+                        }
                         atVersions {
                             __typename
                             id

--- a/server/tests/models/services/AtService.test.js
+++ b/server/tests/models/services/AtService.test.js
@@ -26,6 +26,7 @@ describe('AtModel Data Checks', () => {
         );
         expect(at).toHaveProperty('atVersions');
         expect(at).toHaveProperty('modes');
+        expect(at).toHaveProperty('browsers');
     });
 
     it('should return valid at for id query with no associations', async () => {
@@ -33,7 +34,7 @@ describe('AtModel Data Checks', () => {
         const _id = 1;
 
         // A2
-        const at = await AtService.getAtById(_id, null, [], []);
+        const at = await AtService.getAtById(_id, null, [], [], []);
         const { id, name } = at;
 
         // A3
@@ -46,6 +47,7 @@ describe('AtModel Data Checks', () => {
         );
         expect(at).not.toHaveProperty('atVersions');
         expect(at).not.toHaveProperty('modes');
+        expect(at).not.toHaveProperty('browsers');
     });
 
     it('should not be valid at query', async () => {
@@ -83,6 +85,19 @@ describe('AtModel Data Checks', () => {
         // A3
         expect(modes).toBeInstanceOf(Array);
         expect(modes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should contain valid at with browsers array', async () => {
+        // A1
+        const _id = 1;
+
+        // A2
+        const at = await AtService.getAtById(_id);
+        const { browsers } = at;
+
+        // A3
+        expect(browsers).toBeInstanceOf(Array);
+        expect(browsers.length).toBeGreaterThanOrEqual(1);
     });
 
     it('should create and remove a new at', async () => {
@@ -160,7 +175,8 @@ describe('AtModel Data Checks', () => {
                     id: expect.any(Number),
                     name: expect.any(String),
                     atVersions: expect.any(Array),
-                    modes: expect.any(Array)
+                    modes: expect.any(Array),
+                    browsers: expect.any(Array)
                 })
             ])
         );
@@ -182,7 +198,8 @@ describe('AtModel Data Checks', () => {
                     id: expect.any(Number),
                     name: expect.stringMatching(/nvd/gi),
                     atVersions: expect.any(Array),
-                    modes: expect.any(Array)
+                    modes: expect.any(Array),
+                    browsers: expect.any(Array)
                 })
             ])
         );
@@ -190,7 +207,7 @@ describe('AtModel Data Checks', () => {
 
     it('should return collection of ats with paginated structure', async () => {
         // A1
-        const result = await AtService.getAts('', {}, ['name'], [], [], {
+        const result = await AtService.getAts('', {}, ['name'], [], [], [], {
             enablePagination: true
         });
 

--- a/server/tests/models/services/BrowserService.test.js
+++ b/server/tests/models/services/BrowserService.test.js
@@ -25,6 +25,7 @@ describe('BrowserModel Data Checks', () => {
             })
         );
         expect(browser).toHaveProperty('browserVersions');
+        expect(browser).toHaveProperty('ats');
     });
 
     it('should return valid browser for id query with no associations', async () => {
@@ -32,7 +33,7 @@ describe('BrowserModel Data Checks', () => {
         const _id = 1;
 
         // A2
-        const browser = await BrowserService.getBrowserById(_id, null, []);
+        const browser = await BrowserService.getBrowserById(_id, null, [], []);
         const { id, name } = browser;
 
         // A3
@@ -44,6 +45,7 @@ describe('BrowserModel Data Checks', () => {
             })
         );
         expect(browser).not.toHaveProperty('browserVersions');
+        expect(browser).not.toHaveProperty('ats');
     });
 
     it('should not be valid browser query', async () => {
@@ -68,6 +70,19 @@ describe('BrowserModel Data Checks', () => {
         // A3
         expect(browserVersions).toBeInstanceOf(Array);
         expect(browserVersions.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should contain valid browser with ats array', async () => {
+        // A1
+        const _id = 1;
+
+        // A2
+        const browser = await BrowserService.getBrowserById(_id);
+        const { ats } = browser;
+
+        // A3
+        expect(ats).toBeInstanceOf(Array);
+        expect(ats.length).toBeGreaterThanOrEqual(1);
     });
 
     it('should create and remove a new browser', async () => {
@@ -144,7 +159,8 @@ describe('BrowserModel Data Checks', () => {
                 expect.objectContaining({
                     id: expect.any(Number),
                     name: expect.any(String),
-                    browserVersions: expect.any(Array)
+                    browserVersions: expect.any(Array),
+                    ats: expect.any(Array)
                 })
             ])
         );
@@ -165,7 +181,8 @@ describe('BrowserModel Data Checks', () => {
                 expect.objectContaining({
                     id: expect.any(Number),
                     name: expect.stringMatching(/chr/gi),
-                    browserVersions: expect.any(Array)
+                    browserVersions: expect.any(Array),
+                    ats: expect.any(Array)
                 })
             ])
         );
@@ -173,9 +190,16 @@ describe('BrowserModel Data Checks', () => {
 
     it('should return collection of browsers with paginated structure', async () => {
         // A1
-        const result = await BrowserService.getBrowsers('', {}, ['name'], [], {
-            enablePagination: true
-        });
+        const result = await BrowserService.getBrowsers(
+            '',
+            {},
+            ['name'],
+            [],
+            [],
+            {
+                enablePagination: true
+            }
+        );
 
         // A3
         expect(result.data.length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
This PR finalizes the fix for the At and Browser combos embed in the APG. If a test was never written with a particular At and Browser combo, it would be marked "Not Applicable", which may not be accurate. Howard created a temporary fix for this problem (https://github.com/w3c/aria-at-app/pull/650). The original issue can be found here: https://github.com/w3c/aria-at-app/issues/625.
