### PR TITLE
Update deduplicate migration

### DIFF
--- a/client/components/TestManagement/StatusSummaryRow/index.jsx
+++ b/client/components/TestManagement/StatusSummaryRow/index.jsx
@@ -118,7 +118,7 @@ const StatusSummaryRow = ({ reportResult, testPlanVersion }) => {
         <LoadingStatus message={loadingMessage}>
             <tr>
                 <th>
-                    {testPlanVersion.title}
+                    {testPlanVersion?.title}
                     {Object.entries(reportResult).length > 0 && (
                         <PhaseText className={phase.toLowerCase()}>
                             {phase}

--- a/client/components/TestManagement/index.jsx
+++ b/client/components/TestManagement/index.jsx
@@ -260,7 +260,7 @@ const TestManagement = () => {
                                                     key={
                                                         tabularReport
                                                             .latestTestPlanVersion
-                                                            .id
+                                                            ?.id
                                                     }
                                                     testPlanVersion={
                                                         tabularReport.latestTestPlanVersion

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -185,7 +185,7 @@ const TestQueueRow = ({
         );
 
         const latestTestPlanVersion = latestTestPlanVersions.filter(
-            version => version.latestTestPlanVersion.id === testPlanVersion.id
+            version => version.latestTestPlanVersion?.id === testPlanVersion.id
         );
         const updateTestPlanVersionButton = isAdmin &&
             latestTestPlanVersion.length === 0 && (

--- a/server/migrations/20230501220810-deduplicateTestPlanVersions.js
+++ b/server/migrations/20230501220810-deduplicateTestPlanVersions.js
@@ -557,11 +557,11 @@ module.exports = {
                 // Update TestPlanVersion -> TestPlanReport fkey to add cascade deletion on
                 // TestPlanVersion row deletion
                 await queryInterface.sequelize.query(
-                    `alter table public."TestPlanReport"
-                        drop constraint "TestPlanReport_testPlan_fkey";
+                    `alter table "TestPlanReport"
+                            drop constraint "TestPlanReport_testPlan_fkey";
 
-                     alter table public."TestPlanReport"
-                        add constraint "TestPlanReport_testPlan_fkey" foreign key ("testPlanVersionId") references public."TestPlanVersion" on update cascade on delete cascade;`,
+                         alter table "TestPlanReport"
+                            add constraint "TestPlanReport_testPlan_fkey" foreign key ("testPlanVersionId") references "TestPlanVersion" on update cascade on delete cascade;`,
                     {
                         transaction
                     }
@@ -579,11 +579,11 @@ module.exports = {
                 // Update TestPlanVersion -> TestPlanReport fkey to remove cascade delete on
                 // TestPlanVersion row deletion
                 await queryInterface.sequelize.query(
-                    `alter table public."TestPlanReport"
-                        drop constraint "TestPlanReport_testPlan_fkey";
+                    `alter table "TestPlanReport"
+                            drop constraint "TestPlanReport_testPlan_fkey";
 
-                     alter table public."TestPlanReport"
-                        add constraint "TestPlanReport_testPlan_fkey" foreign key ("testPlanVersionId") references public."TestPlanVersion" on update cascade;`,
+                         alter table "TestPlanReport"
+                            add constraint "TestPlanReport_testPlan_fkey" foreign key ("testPlanVersionId") references "TestPlanVersion" on update cascade;`,
                     {
                         transaction
                     }

--- a/server/migrations/20230501220810-deduplicateTestPlanVersions.js
+++ b/server/migrations/20230501220810-deduplicateTestPlanVersions.js
@@ -552,21 +552,21 @@ module.exports = {
                 );
             }
 
-            // Update TestPlanVersion -> TestPlanReport fkey to add cascade deletion on
-            // TestPlanVersion row deletion
-            await queryInterface.sequelize.query(
-                `alter table public."TestPlanReport"
+            // Remove the TestPlanVersions not captured by removeTestPlanVersionDuplicates()
+            if (testPlanVersionIdsToDelete.length) {
+                // Update TestPlanVersion -> TestPlanReport fkey to add cascade deletion on
+                // TestPlanVersion row deletion
+                await queryInterface.sequelize.query(
+                    `alter table public."TestPlanReport"
                         drop constraint "TestPlanReport_testPlan_fkey";
 
                      alter table public."TestPlanReport"
                         add constraint "TestPlanReport_testPlan_fkey" foreign key ("testPlanVersionId") references public."TestPlanVersion" on update cascade on delete cascade;`,
-                {
-                    transaction
-                }
-            );
+                    {
+                        transaction
+                    }
+                );
 
-            // Remove the TestPlanVersions not captured by removeTestPlanVersionDuplicates()
-            if (testPlanVersionIdsToDelete.length) {
                 const toRemove = testPlanVersionIdsToDelete.flat();
                 await queryInterface.sequelize.query(
                     `DELETE FROM "TestPlanVersion" WHERE id IN (?)`,
@@ -575,29 +575,29 @@ module.exports = {
                         transaction
                     }
                 );
-            }
 
-            // Update TestPlanVersion -> TestPlanReport fkey to remove cascade delete on
-            // TestPlanVersion row deletion
-            await queryInterface.sequelize.query(
-                `alter table public."TestPlanReport"
+                // Update TestPlanVersion -> TestPlanReport fkey to remove cascade delete on
+                // TestPlanVersion row deletion
+                await queryInterface.sequelize.query(
+                    `alter table public."TestPlanReport"
                         drop constraint "TestPlanReport_testPlan_fkey";
 
                      alter table public."TestPlanReport"
                         add constraint "TestPlanReport_testPlan_fkey" foreign key ("testPlanVersionId") references public."TestPlanVersion" on update cascade;`,
-                {
-                    transaction
-                }
-            );
-
-            if (uniqueHashCount && testPlanVersionIdsToDelete.length) {
-                // eslint-disable-next-line no-console
-                console.info(
-                    'Fixed',
-                    uniqueHashCount - testPlanVersionIdsToDelete.length,
-                    'of',
-                    uniqueHashCount - testPlanVersionIdsToDelete.length
+                    {
+                        transaction
+                    }
                 );
+
+                if (uniqueHashCount) {
+                    // eslint-disable-next-line no-console
+                    console.info(
+                        'Fixed',
+                        uniqueHashCount - testPlanVersionIdsToDelete.length,
+                        'of',
+                        uniqueHashCount - testPlanVersionIdsToDelete.length
+                    );
+                }
             } else if (uniqueHashCount) {
                 // eslint-disable-next-line no-console
                 console.info('Fixed', uniqueHashCount, 'of', uniqueHashCount);

--- a/server/util/aria.js
+++ b/server/util/aria.js
@@ -8,7 +8,7 @@ const evaluateAtNameKey = atName => {
 };
 
 const testWithNoIds = test => ({
-    ...omit(test, ['id', 'renderedUrls']),
+    ...omit(test, ['id', 'renderedUrls', 'viewers']),
     assertions: test.assertions.map(assertion => omit(assertion, ['id'])),
     scenarios: test.scenarios.map(scenario => omit(scenario, ['id']))
 });

--- a/server/util/aria.test.js
+++ b/server/util/aria.test.js
@@ -31,7 +31,7 @@ describe('Verify test hashes are matching as expected', () => {
 
     it('should match TestPlanVersion.hashedTests for Alert 252 in production', () => {
         const testPlanVersionHashedTestsAlert252 =
-            'e1dc1c56213ddb29cf959590ee1b5f115952c4fd';
+            '2236c51249aa66f67720b9c9bb25d35532fd26c2';
         // InsureA is based on TestPlanVersion 252 as the tests/alert directory was updated; see
         // https://github.com/w3c/aria-at/commit/9ccc788
         const testsHashA = hashTests(testsWithInstructionsSayingInsureA);
@@ -41,7 +41,7 @@ describe('Verify test hashes are matching as expected', () => {
 
     it('should match test hash in production', () => {
         const singleTestHashInProduction =
-            '33ffd2b5ae2c13820d4abe7491a7f7361643ae59';
+            '5a0f2508e73f3de8de176923c946d6e9024144bd';
 
         const testIndex0Hash = hashTest(testsWithInstructionsSayingInsureA[0]);
         // singleTest.json is based on testsWithInstructionsSayingInsureA[0]


### PR DESCRIPTION
Resolves #579.

This updates the de-duplication migration to check the batches of git commits, and only save the test plan versions which match up with a valid git sha, referenced through the GitHub API.

This will make it so ONLY known git commits (in the database at this time) are shown for respective Test Plans, which addresses #579. Note that this PR does not back-populate any commits that may have been missed.

~**NOTE**
This causes data to be lost for the entire rows of Action Menu Button Example Using aria-activedescendant and Toggle Button when comparing against the [production /reports page](https://aria-at.w3.org/reports), because those reports were created with test plan versions that weren't valid and couldn't be easily updated by this migration.~

~Drafting to determine how the migration can avoid causing the data loss, or we may need to consider manually updating that data separately~