### PR TITLE
Explicitly support 'DEPRECATED' phase for `TestPlanVersion.phase`

### DIFF
--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -25,7 +25,7 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
             directory
             title
         }
-        testPlanVersions {
+        testPlanVersions(phases: [RD, DRAFT, CANDIDATE, RECOMMENDED]) {
             id
             title
             phase

--- a/client/components/DisclaimerInfo/index.jsx
+++ b/client/components/DisclaimerInfo/index.jsx
@@ -70,6 +70,14 @@ const recommendedMessageContent = (
     </>
 );
 
+const deprecatedTitle = 'Deprecated Report';
+const deprecatedMessageContent = (
+    <>
+        The information in this report is generated from previously set
+        candidate or recommended tests.
+    </>
+);
+
 const content = {
     CANDIDATE: {
         title: candidateTitle,
@@ -78,6 +86,10 @@ const content = {
     RECOMMENDED: {
         title: recommendedTitle,
         messageContent: recommendedMessageContent
+    },
+    DEPRECATED: {
+        title: deprecatedTitle,
+        messageContent: deprecatedMessageContent
     }
 };
 

--- a/client/components/DisclaimerInfo/index.jsx
+++ b/client/components/DisclaimerInfo/index.jsx
@@ -84,8 +84,9 @@ const content = {
 const DisclaimerInfo = ({ phase }) => {
     const [expanded, setExpanded] = useState(false);
 
-    const title = content[phase].title;
-    const messageContent = content[phase].messageContent;
+    const title = content[phase]?.title || content.CANDIDATE.title;
+    const messageContent =
+        content[phase]?.messageContent || content.CANDIDATE.messageContent;
 
     return (
         <Container>

--- a/client/components/ManageTestQueue/index.jsx
+++ b/client/components/ManageTestQueue/index.jsx
@@ -206,13 +206,18 @@ const ManageTestQueue = ({
                 item =>
                     item.title === retrievedTestPlan.title &&
                     item.testPlan.directory ===
-                        retrievedTestPlan.testPlan.directory
+                        retrievedTestPlan.testPlan.directory &&
+                    item.phase !== 'DEPRECATED' &&
+                    item.phase !== 'RD'
             )
             .sort((a, b) =>
                 new Date(a.updatedAt) > new Date(b.updatedAt) ? -1 : 1
             );
         setMatchingTestPlanVersions(matchingTestPlanVersions);
-        setSelectedTestPlanVersionId(matchingTestPlanVersions[0].id);
+
+        if (matchingTestPlanVersions.length)
+            setSelectedTestPlanVersionId(matchingTestPlanVersions[0].id);
+        else setSelectedTestPlanVersionId(null);
     };
 
     const onManageAtChange = e => {
@@ -583,21 +588,33 @@ const ManageTestQueue = ({
                                     Test Plan Version
                                 </Form.Label>
                                 <Form.Select
-                                    value={selectedTestPlanVersionId}
+                                    value={
+                                        selectedTestPlanVersionId
+                                            ? selectedTestPlanVersionId
+                                            : ''
+                                    }
                                     onChange={onTestPlanVersionChange}
+                                    disabled={!selectedTestPlanVersionId}
+                                    aria-disabled={!selectedTestPlanVersionId}
                                 >
-                                    {matchingTestPlanVersions.map(item => (
-                                        <option
-                                            key={`${item.gitSha}-${item.id}`}
-                                            value={item.id}
-                                        >
-                                            {gitUpdatedDateToString(
-                                                item.updatedAt
-                                            )}{' '}
-                                            {item.gitMessage} (
-                                            {item.gitSha.substring(0, 7)})
+                                    {matchingTestPlanVersions.length ? (
+                                        matchingTestPlanVersions.map(item => (
+                                            <option
+                                                key={`${item.gitSha}-${item.id}`}
+                                                value={item.id}
+                                            >
+                                                {gitUpdatedDateToString(
+                                                    item.updatedAt
+                                                )}{' '}
+                                                {item.gitMessage} (
+                                                {item.gitSha.substring(0, 7)})
+                                            </option>
+                                        ))
+                                    ) : (
+                                        <option>
+                                            Versions in R&D or Deprecated
                                         </option>
-                                    ))}
+                                    )}
                                 </Form.Select>
                             </Form.Group>
                             <Form.Group className="form-group">

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -28,6 +28,7 @@ export const TEST_QUEUE_PAGE_QUERY = gql`
         testPlanVersions {
             id
             title
+            phase
             gitSha
             gitMessage
             testPlan {

--- a/client/tests/__mocks__/GraphQLMocks/TestQueuePageAdminPopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/TestQueuePageAdminPopulatedMock.js
@@ -96,6 +96,7 @@ export default testQueuePageQuery => [
                     {
                         id: '1',
                         title: 'Alert Example',
+                        phase: 'DRAFT',
                         gitSha: '97d4bd6c2078849ad4ee01eeeb3667767ca6f992',
                         gitMessage:
                             'Create tests for APG design pattern example: Navigation Menu Button (#524)',
@@ -107,6 +108,7 @@ export default testQueuePageQuery => [
                     {
                         id: '2',
                         title: 'Banner Landmark',
+                        phase: 'DRAFT',
                         gitSha: '97d4bd6c2078849ad4ee01eeeb3667767ca6f992',
                         gitMessage:
                             'Create tests for APG design pattern example: Navigation Menu Button (#524)',
@@ -118,6 +120,7 @@ export default testQueuePageQuery => [
                     {
                         id: '3',
                         title: 'Breadcrumb Example',
+                        phase: 'DRAFT',
                         gitSha: '97d4bd6c2078849ad4ee01eeeb3667767ca6f992',
                         gitMessage:
                             'Create tests for APG design pattern example: Navigation Menu Button (#524)',

--- a/client/tests/__mocks__/GraphQLMocks/TestQueuePageTesterPopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/TestQueuePageTesterPopulatedMock.js
@@ -101,6 +101,7 @@ export default testQueuePageQuery => [
                     {
                         id: '1',
                         title: 'Alert Example',
+                        phase: 'DRAFT',
                         gitSha: '97d4bd6c2078849ad4ee01eeeb3667767ca6f992',
                         gitMessage:
                             'Create tests for APG design pattern example: Navigation Menu Button (#524)',
@@ -112,6 +113,7 @@ export default testQueuePageQuery => [
                     {
                         id: '2',
                         title: 'Banner Landmark',
+                        phase: 'DRAFT',
                         gitSha: '97d4bd6c2078849ad4ee01eeeb3667767ca6f992',
                         gitMessage:
                             'Create tests for APG design pattern example: Navigation Menu Button (#524)',
@@ -123,6 +125,7 @@ export default testQueuePageQuery => [
                     {
                         id: '3',
                         title: 'Breadcrumb Example',
+                        phase: 'DRAFT',
                         gitSha: '97d4bd6c2078849ad4ee01eeeb3667767ca6f992',
                         gitMessage:
                             'Create tests for APG design pattern example: Navigation Menu Button (#524)',

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -263,7 +263,7 @@ const graphqlSchema = gql`
         """
         The TestPlanVersion is now outdated and replaced by another version.
         """
-        SUNSET
+        DEPRECATED
     }
 
     """

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -260,6 +260,10 @@ const graphqlSchema = gql`
         Reports section of the app as being recommended.
         """
         RECOMMENDED
+        """
+        The TestPlanVersion is now outdated and replaced by another version.
+        """
+        SUNSET
     }
 
     """

--- a/server/models/TestPlanVersion.js
+++ b/server/models/TestPlanVersion.js
@@ -3,7 +3,8 @@ const PHASE = {
     RD: 'RD',
     DRAFT: 'DRAFT',
     CANDIDATE: 'CANDIDATE',
-    RECOMMENDED: 'RECOMMENDED'
+    RECOMMENDED: 'RECOMMENDED',
+    SUNSET: 'SUNSET'
 };
 
 module.exports = function (sequelize, DataTypes) {

--- a/server/models/TestPlanVersion.js
+++ b/server/models/TestPlanVersion.js
@@ -4,7 +4,7 @@ const PHASE = {
     DRAFT: 'DRAFT',
     CANDIDATE: 'CANDIDATE',
     RECOMMENDED: 'RECOMMENDED',
-    SUNSET: 'SUNSET'
+    DEPRECATED: 'DEPRECATED'
 };
 
 module.exports = function (sequelize, DataTypes) {

--- a/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
+++ b/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
@@ -43,7 +43,7 @@ const updatePhaseResolver = async (
     // Immediately deprecate version without further checks
     if (phase === 'DEPRECATED') {
         await updateTestPlanVersion(testPlanVersionId, {
-            phase: 'DEPRECATED',
+            phase,
             deprecatedAt: new Date()
         });
         return populateData({ testPlanVersionId }, { context });

--- a/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
+++ b/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
@@ -42,12 +42,10 @@ const updatePhaseResolver = async (
 
     // Immediately deprecate version without further checks
     if (phase === 'DEPRECATED') {
-        if (testPlanVersionId)
-            await updateTestPlanVersion(testPlanVersionId, {
-                phase: 'DEPRECATED',
-                deprecatedAt: new Date()
-            });
-        await updateTestPlanVersion(testPlanVersionId, { phase });
+        await updateTestPlanVersion(testPlanVersionId, {
+            phase: 'DEPRECATED',
+            deprecatedAt: new Date()
+        });
         return populateData({ testPlanVersionId }, { context });
     }
 

--- a/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
+++ b/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
@@ -40,6 +40,17 @@ const updatePhaseResolver = async (
         throw new AuthenticationError();
     }
 
+    // Immediately deprecate version without further checks
+    if (phase === 'DEPRECATED') {
+        if (testPlanVersionId)
+            await updateTestPlanVersion(testPlanVersionId, {
+                phase: 'DEPRECATED',
+                deprecatedAt: new Date()
+            });
+        await updateTestPlanVersion(testPlanVersionId, { phase });
+        return populateData({ testPlanVersionId }, { context });
+    }
+
     let testPlanVersionDataToInclude;
     let testPlanReportsDataToIncludeId = [];
 
@@ -418,6 +429,7 @@ const updatePhaseResolver = async (
     // deprecate it
     if (testPlanVersionDataToIncludeId)
         await updateTestPlanVersion(testPlanVersionDataToIncludeId, {
+            phase: 'DEPRECATED',
             deprecatedAt: new Date()
         });
 


### PR DESCRIPTION
Closes #741

Currently, the 'deprecated' phase can be derived within the client. But it can be be easier to have that explicitly set so the state of the database is represented better, and so special queries and resolvers can be avoided.

Deriving in-app evaluations such as figuring out when a deprecation happened, such as for the Test Plan Version History page also proves to be more manageable in this instance.

This PR updates the usage of the 'DEPRECATED' phase for:
- [x] TestPlanVersionsPage
- [x] Preventing deprecated (and R&D) test plan versions from being shown in the data management dropdown