### PR TITLE
Update `Timeline for All Versions` table on Test Plan Versions Page

### DIFF
--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -304,7 +304,7 @@ const TestPlanVersionsPage = () => {
                         <tbody>
                             {testPlanVersions.map(testPlanVersion => (
                                 <tr key={testPlanVersion.id}>
-                                    <td>
+                                    <th>
                                         <VersionString
                                             date={testPlanVersion.updatedAt}
                                             iconColor={getIconColor(
@@ -312,7 +312,7 @@ const TestPlanVersionsPage = () => {
                                             )}
                                             autoWidth={false}
                                         />
-                                    </td>
+                                    </th>
                                     <td>
                                         {(() => {
                                             // Gets the derived phase even if deprecated by checking
@@ -456,7 +456,7 @@ const TestPlanVersionsPage = () => {
                             <tr
                                 key={`${testPlanVersion.id}-${testPlanVersion.phase}`}
                             >
-                                <td>{getEventDate(testPlanVersion)}</td>
+                                <th>{getEventDate(testPlanVersion)}</th>
                                 <td>
                                     {versionString}&nbsp;{eventBody}
                                 </td>
@@ -607,12 +607,12 @@ const TestPlanVersionsPage = () => {
 
                                     return events.map(([phase, date]) => (
                                         <tr key={phase}>
-                                            <td>
+                                            <th>
                                                 {convertDateToString(
                                                     date,
                                                     'MMM D, YYYY'
                                                 )}
-                                            </td>
+                                            </th>
                                             <td>{getEventBody(phase)}</td>
                                         </tr>
                                     ));

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -248,8 +248,7 @@ const TestPlanVersionsPage = () => {
 
         // If dates are the same, compare phases
         if (dateA === dateB) return phaseOrder[a.phase] - phaseOrder[b.phase];
-
-        return new Date(dateB) - new Date(dateA);
+        return new Date(dateA) - new Date(dateB);
     });
 
     const issues = uniqueBy(
@@ -262,7 +261,11 @@ const TestPlanVersionsPage = () => {
             )
         ),
         item => item.link
-    );
+    ).sort((a, b) => {
+        const aCreatedAt = new Date(a.createdAt);
+        const bCreatedAt = new Date(b.createdAt);
+        return bCreatedAt - aCreatedAt;
+    });
 
     return (
         <Container id="main" as="main" tabIndex="-1">

--- a/server/migrations/20230626203205-updatePhaseAndDraftPhaseReachedAtColumnsForTestPlanVersion.js
+++ b/server/migrations/20230626203205-updatePhaseAndDraftPhaseReachedAtColumnsForTestPlanVersion.js
@@ -37,15 +37,21 @@ module.exports = {
             for (const testPlanVersion of testPlanVersions) {
                 const { id, updatedAt, hasTestPlanReport } = testPlanVersion;
 
-                if (hasTestPlanReport)
+                if (hasTestPlanReport) {
+                    const draftPhaseReachedAt = new Date(updatedAt);
+                    draftPhaseReachedAt.setSeconds(
+                        // Set draftPhaseReachedAt to happen 60 seconds after updatedAt for general
+                        // 'correctness' and to help with any app sorts
+                        draftPhaseReachedAt.getSeconds() + 60
+                    );
                     await queryInterface.sequelize.query(
                         `UPDATE "TestPlanVersion" SET "draftPhaseReachedAt" = ? WHERE id = ?`,
                         {
-                            replacements: [updatedAt, id],
+                            replacements: [draftPhaseReachedAt, id],
                             transaction
                         }
                     );
-                else
+                } else
                     await queryInterface.sequelize.query(
                         `UPDATE "TestPlanVersion" SET phase = ? WHERE id = ?`,
                         {

--- a/server/migrations/20230830225248-addMissingDeprecatedAtAndReorderPhaseChangeDates.js
+++ b/server/migrations/20230830225248-addMissingDeprecatedAtAndReorderPhaseChangeDates.js
@@ -134,14 +134,8 @@ module.exports = {
                 }
 
                 if (testPlanVersion.deprecatedAt) {
-                    const deprecatedAt = new Date(
-                        testPlanVersion.recommendedPhaseReachedAt ||
-                            testPlanVersion.candidatePhaseReachedAt ||
-                            testPlanVersion.draftPhaseReachedAt ||
-                            testPlanVersion.updatedAt ||
-                            testPlanVersion.deprecatedAt
-                    );
-                    deprecatedAt.setSeconds(deprecatedAt.getSeconds() + 1);
+                    const deprecatedAt = new Date(testPlanVersion.deprecatedAt);
+                    deprecatedAt.setSeconds(deprecatedAt.getSeconds() - 1);
 
                     // Add deprecatedAt for applicable testPlanVersions
                     await queryInterface.sequelize.query(

--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -157,11 +157,19 @@ const importTestPlanVersions = async () => {
         });
         if (testPlanVersionsToDeprecate.length) {
             for (const testPlanVersionToDeprecate of testPlanVersionsToDeprecate) {
-                if (new Date(testPlanVersionToDeprecate.updatedAt) < updatedAt)
+                if (
+                    new Date(testPlanVersionToDeprecate.updatedAt) < updatedAt
+                ) {
+                    // Set the deprecatedAt time to a couple seconds less than the updatedAt date.
+                    // Deprecations happen slightly before update during normal app operations.
+                    // This is to maintain correctness and any app sorts issues
+                    const deprecatedAt = new Date(updatedAt);
+                    deprecatedAt.setSeconds(deprecatedAt.getSeconds() - 60);
                     await updateTestPlanVersion(testPlanVersionToDeprecate.id, {
                         phase: 'DEPRECATED',
-                        deprecatedAt: updatedAt
+                        deprecatedAt
                     });
+                }
             }
         }
 


### PR DESCRIPTION
Address:
* https://github.com/w3c/aria-at-app/issues/761#issuecomment-1719015358
> The timeline for all versions should show all events from all versions. The timeline for each individual version should show all events for that specific version. Thus, the number of rows in timeline for all versions should be the sum of all rows from the other timeline tables.
* https://github.com/w3c/aria-at-app/issues/761#issuecomment-1719021693
> It would make the tables more screen reader friendly if we used th instead of td in the version column of the version summary and the date column of the timeline tables.