### PR TITLE
Add hidden JSON metadata to issues created by the app

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -302,12 +302,14 @@ const CandidateTestPlanRun = () => {
     // Assumes that the issues are across the entire AT/Browser combination
     const changesRequestedIssues = testPlanReport.issues?.filter(
         issue =>
+            issue.isCandidateReview === true &&
             issue.feedbackType === 'CHANGES_REQUESTED' &&
             issue.testNumberFilteredByAt === currentTest.seq
     );
 
     const feedbackIssues = testPlanReport.issues?.filter(
         issue =>
+            issue.isCandidateReview === true &&
             issue.feedbackType === 'FEEDBACK' &&
             issue.testNumberFilteredByAt === currentTest.seq
     );
@@ -316,6 +318,7 @@ const CandidateTestPlanRun = () => {
         isCandidateReview: true,
         isCandidateReviewChangesRequested: true,
         testPlanTitle: testPlanVersion.title,
+        testPlanDirectory: testPlanVersion.testPlan.directory,
         versionString,
         testTitle: currentTest.title,
         testRowNumber: currentTest.rowNumber,
@@ -428,7 +431,9 @@ const CandidateTestPlanRun = () => {
     );
 
     const feedback = testPlanReport.issues.filter(
-        issue => issue.testNumberFilteredByAt == currentTest.seq
+        issue =>
+            issue.isCandidateReview &&
+            issue.testNumberFilteredByAt == currentTest.seq
     ).length > 0 && (
         <div className="issues-container">
             <h2>

--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -302,14 +302,14 @@ const CandidateTestPlanRun = () => {
     // Assumes that the issues are across the entire AT/Browser combination
     const changesRequestedIssues = testPlanReport.issues?.filter(
         issue =>
-            issue.isCandidateReview === true &&
+            issue.isCandidateReview &&
             issue.feedbackType === 'CHANGES_REQUESTED' &&
             issue.testNumberFilteredByAt === currentTest.seq
     );
 
     const feedbackIssues = testPlanReport.issues?.filter(
         issue =>
-            issue.isCandidateReview === true &&
+            issue.isCandidateReview &&
             issue.feedbackType === 'FEEDBACK' &&
             issue.testNumberFilteredByAt === currentTest.seq
     );
@@ -670,14 +670,14 @@ const CandidateTestPlanRun = () => {
                     testPlan={testPlanVersion.title}
                     feedbackIssues={testPlanReport.issues?.filter(
                         issue =>
-                            issue.isCandidateReview === true &&
+                            issue.isCandidateReview &&
                             issue.feedbackType === 'FEEDBACK' &&
                             issue.author == data.me.username
                     )}
                     feedbackGithubUrl={feedbackGithubUrl}
                     changesRequestedIssues={testPlanReport.issues?.filter(
                         issue =>
-                            issue.isCandidateReview === true &&
+                            issue.isCandidateReview &&
                             issue.feedbackType === 'CHANGES_REQUESTED' &&
                             issue.author == data.me.username
                     )}

--- a/client/components/CandidateReview/CandidateTestPlanRun/queries.js
+++ b/client/components/CandidateReview/CandidateTestPlanRun/queries.js
@@ -45,6 +45,7 @@ export const CANDIDATE_REPORTS_QUERY = gql`
             vendorReviewStatus
             issues {
                 author
+                isCandidateReview
                 feedbackType
                 testNumberFilteredByAt
                 link

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -144,6 +144,7 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
                 const reportLink = `https://aria-at.w3.org${location.pathname}#result-${testResult.id}`;
                 const issueLink = createIssueLink({
                     testPlanTitle: testPlanVersion.title,
+                    testPlanDirectory: testPlanVersion.testPlan.directory,
                     versionString: `V${convertDateToString(
                         testPlanVersion.updatedAt,
                         'YY.MM.DD'

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -20,7 +20,6 @@ import {
     faCodeCommit
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { uniqBy as uniqueBy } from 'lodash';
 
 const H2 = styled.h2`
     font-size: 1.25em;
@@ -179,6 +178,7 @@ const TestPlanVersionsPage = () => {
     };
 
     const testPlan = data.testPlan;
+    const issues = testPlan.issues;
 
     const ats = data.ats;
 
@@ -187,18 +187,6 @@ const TestPlanVersionsPage = () => {
         .sort((a, b) => {
             return new Date(b.updatedAt) - new Date(a.updatedAt);
         });
-
-    const issues = uniqueBy(
-        testPlanVersions.flatMap(testPlanVersion =>
-            testPlanVersion.testPlanReports.flatMap(testPlanReport =>
-                testPlanReport.issues.map(issue => ({
-                    ...issue,
-                    at: testPlanReport.at
-                }))
-            )
-        ),
-        item => item.link
-    );
 
     return (
         <Container id="main" as="main" tabIndex="-1">

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -178,7 +178,9 @@ const TestPlanVersionsPage = () => {
     };
 
     const testPlan = data.testPlan;
-    const issues = testPlan.issues.sort((a, b) => {
+
+    // GraphQL results are read only so they need to be cloned before sorting
+    const issues = [...testPlan.issues].sort((a, b) => {
         const aCreatedAt = new Date(a.createdAt);
         const bCreatedAt = new Date(b.createdAt);
         return bCreatedAt - aCreatedAt;

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -324,7 +324,9 @@ const TestPlanVersionsPage = () => {
                                         </a>
                                     </td>
                                     <td>{issue.isOpen ? 'Open' : 'Closed'}</td>
-                                    <td>{issue.at.name}</td>
+                                    <td>
+                                        {issue.at?.name ?? 'AT not specified'}
+                                    </td>
                                     <td>
                                         {convertDateToString(
                                             issue.createdAt,

--- a/client/components/TestPlanVersionsPage/queries.js
+++ b/client/components/TestPlanVersionsPage/queries.js
@@ -8,6 +8,18 @@ export const TEST_PLAN_VERSIONS_PAGE_QUERY = gql`
         }
         testPlan(id: $testPlanDirectory) {
             title
+            issues {
+                author
+                title
+                link
+                feedbackType
+                isOpen
+                createdAt
+                closedAt
+                at {
+                    name
+                }
+            }
             testPlanVersions {
                 id
                 testPlan {
@@ -26,15 +38,6 @@ export const TEST_PLAN_VERSIONS_PAGE_QUERY = gql`
                     isFinal
                     at {
                         name
-                    }
-                    issues {
-                        author
-                        title
-                        link
-                        feedbackType
-                        isOpen
-                        createdAt
-                        closedAt
                     }
                 }
             }

--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -52,7 +52,9 @@ const TestNavigator = ({
                         let resultClassName = 'not-started';
                         let resultStatus = 'Not Started';
                         const issuesExist = testPlanReport.issues?.filter(
-                            issue => issue.testNumberFilteredByAt == test.seq
+                            issue =>
+                                issue.isCandidateReview &&
+                                issue.testNumberFilteredByAt == test.seq
                         ).length;
 
                         if (test) {

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -337,6 +337,7 @@ const TestRun = () => {
     if (hasLoadingCompleted) {
         issueLink = createIssueLink({
             testPlanTitle: testPlanVersion.title,
+            testPlanDirectory: testPlanVersion.testPlan.directory,
             versionString: `V${convertDateToString(
                 testPlanVersion.updatedAt,
                 'YY.MM.DD'

--- a/client/utils/createIssueLink.js
+++ b/client/utils/createIssueLink.js
@@ -50,7 +50,6 @@ const createIssueLink = ({
     }
 
     const labels =
-        'app,' +
         (isCandidateReview ? 'candidate-review,' : '') +
         `${atLabelMap[atName]},` +
         (isCandidateReviewChangesRequested ? 'changes-requested' : 'feedback');
@@ -109,7 +108,7 @@ const createIssueLink = ({
         `<!-- Write your description here -->\n\n` +
         testSetupFormatted +
         `<!-- The following data allows the issue to be imported into the ` +
-        `ARIA AT app -->\n` +
+        `ARIA AT App -->\n` +
         `<!-- ARIA_AT_APP_ISSUE_DATA = ${hiddenIssueMetadata} -->`;
 
     if (conflictMarkdown) {
@@ -139,7 +138,6 @@ export const getIssueSearchLink = ({
     }
 
     const query = [
-        `label:app`,
         isCandidateReview ? `label:candidate-review` : '',
         isCandidateReviewChangesRequested
             ? `label:changes-requested`

--- a/client/utils/createIssueLink.js
+++ b/client/utils/createIssueLink.js
@@ -12,6 +12,7 @@ const atLabelMap = {
 const createIssueLink = ({
     isCandidateReview = false,
     isCandidateReviewChangesRequested = false,
+    testPlanDirectory,
     testPlanTitle,
     versionString,
     testTitle = null,
@@ -24,7 +25,7 @@ const createIssueLink = ({
     conflictMarkdown = null,
     reportLink = null
 }) => {
-    if (!(testPlanTitle || versionString || atName)) {
+    if (!(testPlanDirectory || testPlanTitle || versionString || atName)) {
         throw new Error('Cannot create issue link due to missing parameters');
     }
 
@@ -89,15 +90,27 @@ const createIssueLink = ({
             `[${shortenedUrl}](${modifiedRenderedUrl})\n` +
             reportLinkFormatted +
             atFormatted +
-            browserFormatted;
+            browserFormatted +
+            '\n';
     }
+
+    const hiddenIssueMetadata = JSON.stringify({
+        testPlanDirectory,
+        versionString,
+        atName,
+        browserName,
+        testRowNumber,
+        isCandidateReview,
+        isCandidateReviewChangesRequested
+    });
 
     let body =
         `## Description of Behavior\n\n` +
         `<!-- Write your description here -->\n\n` +
         testSetupFormatted +
-        `\n\n<!-- DO NOT EDIT BELOW, UNLESS YOU'RE SURE -->\n\n` +
-        `<!-- ${title} -->`;
+        `<!-- The following data allows the issue to be imported into the ` +
+        `ARIA AT app -->\n` +
+        `<!-- ARIA_AT_APP_ISSUE_DATA = ${hiddenIssueMetadata} -->`;
 
     if (conflictMarkdown) {
         body += `\n${conflictMarkdown}`;

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -230,11 +230,15 @@ const graphqlSchema = gql`
         Gets the most recent version imported from the test plan's directory.
         """
         latestTestPlanVersion: TestPlanVersion
-
         """
         Gets all historic versions of the test plan.
         """
         testPlanVersions: [TestPlanVersion]!
+        """
+        A list of all issues which have filed through "Raise an Issue" buttons
+        in the app. Note that results will be cached for at least ten seconds.
+        """
+        issues: [Issue]!
     }
 
     """
@@ -825,6 +829,14 @@ const graphqlSchema = gql`
         The time the issue was closed, if it was closed.
         """
         closedAt: Timestamp
+        """
+        The AT associated with the issue.
+        """
+        at: At!
+        """
+        The browser associated with the issue, which may not be present.
+        """
+        browser: Browser
     }
 
     """
@@ -889,9 +901,8 @@ const graphqlSchema = gql`
         """
         finalizedTestResults: [TestResult]
         """
-        These are the different feedback and requested change items created for
-        the TestPlanReport and retrieved from GitHub. Note that results will be
-        cached for one minute.
+        A list of all issues which have filed through "Raise an Issue" buttons
+        in the app. Note that results will be cached for at least ten seconds.
         """
         issues: [Issue]!
         """

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -830,9 +830,12 @@ const graphqlSchema = gql`
         """
         closedAt: Timestamp
         """
-        The AT associated with the issue.
+        The AT associated with the issue. Although there are not currently any
+        cases where we generate GitHub issues without an associated AT, that
+        may not remain true forever and we do support this field being
+        undefined.
         """
-        at: At!
+        at: At
         """
         The browser associated with the issue, which may not be present.
         """

--- a/server/resolvers/TestPlan/index.js
+++ b/server/resolvers/TestPlan/index.js
@@ -1,0 +1,5 @@
+const issues = require('./issuesResolver');
+
+module.exports = {
+    issues
+};

--- a/server/resolvers/TestPlan/issuesResolver.js
+++ b/server/resolvers/TestPlan/issuesResolver.js
@@ -1,0 +1,6 @@
+const { getIssues } = require('../TestPlanReport/issuesResolver');
+
+const issuesResolver = (testPlan, _, context) =>
+    getIssues({ testPlan, context });
+
+module.exports = issuesResolver;

--- a/server/resolvers/TestPlanReport/issuesResolver.js
+++ b/server/resolvers/TestPlanReport/issuesResolver.js
@@ -61,9 +61,15 @@ const getIssues = async ({ testPlanReport, testPlan, context }) => {
                     ? 'CHANGES_REQUESTED'
                     : 'FEEDBACK';
 
-            const at = ats.find(at => at.name === hiddenIssueMetadata.atName);
+            const at = ats.find(
+                at =>
+                    at.name.toLowerCase() ===
+                    hiddenIssueMetadata.atName?.toLowerCase()
+            );
             const browser = browsers.find(
-                browser => browser.name === hiddenIssueMetadata.browserName
+                browser =>
+                    browser.name.toLowerCase() ===
+                    hiddenIssueMetadata.browserName?.toLowerCase()
             );
 
             return {

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -24,6 +24,7 @@ const User = require('./User');
 const AtOperations = require('./AtOperations');
 const AtVersionOperations = require('./AtVersionOperations');
 const BrowserOperations = require('./BrowserOperations');
+const TestPlan = require('./TestPlan');
 const TestPlanVersion = require('./TestPlanVersion');
 const TestPlanReport = require('./TestPlanReport');
 const TestPlanReportOperations = require('./TestPlanReportOperations');
@@ -65,6 +66,7 @@ const resolvers = {
     AtVersionOperations,
     BrowserOperations,
     User,
+    TestPlan,
     TestPlanVersion,
     TestPlanReport,
     TestPlanRun,

--- a/server/services/GithubService.js
+++ b/server/services/GithubService.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const NodeCache = require('node-cache');
+const staleWhileRevalidate = require('../util/staleWhileRevalidate');
 
 const {
     ENVIRONMENT,
@@ -29,17 +29,14 @@ const permissionScopes = [
 ];
 const permissionScopesURI = encodeURI(permissionScopes.join(' '));
 const graphQLEndpoint = `${GITHUB_GRAPHQL_SERVER}/graphql`;
-const nodeCache = new NodeCache();
 
-const getAllIssuesFromGitHub = async () => {
+const getAllIssues = async () => {
     let currentResults = [];
     let page = 1;
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
-        const issuesEndpoint =
-            `${GITHUB_ISSUES_API_URL}/issues` +
-            `?labels=app&state=all&per_page=100`;
+        const issuesEndpoint = `${GITHUB_ISSUES_API_URL}/issues?state=all&per_page=100`;
         const url = `${issuesEndpoint}&page=${page}`;
         const auth = {
             username: GITHUB_CLIENT_ID,
@@ -47,10 +44,15 @@ const getAllIssuesFromGitHub = async () => {
         };
         const response = await axios.get(url, { auth });
 
-        // https://docs.github.com/en/rest/issues/issues#list-repository-issues
-        // Filter out Pull Requests. GitHub's REST API v3 also considers every
-        // pull request an issue.
-        const issues = response.data.filter(data => !data.pull_request);
+        const issues = response.data
+            // https://docs.github.com/en/rest/issues/issues#list-repository-issues
+            // Filter out Pull Requests. GitHub's REST API v3 also considers every
+            // pull request an issue.
+            .filter(data => !data.pull_request)
+            // Our issue API should only return issues that were originally
+            // created by the app, indicated by the presence of metadata
+            // hidden in a comment
+            .filter(data => data.body.includes('ARIA_AT_APP_ISSUE_DATA'));
 
         currentResults = [...currentResults, ...issues];
 
@@ -65,31 +67,6 @@ const getAllIssuesFromGitHub = async () => {
     }
 
     return currentResults;
-};
-
-let activeIssuePromise;
-
-const getAllIssues = async () => {
-    const cacheResult = nodeCache.get('allIssues');
-
-    if (cacheResult) return cacheResult;
-
-    if (!activeIssuePromise) {
-        // eslint-disable-next-line no-async-promise-executor
-        activeIssuePromise = new Promise(async resolve => {
-            const result = await getAllIssuesFromGitHub();
-
-            nodeCache.set('allIssues', result, 60 /* 1 min */);
-
-            activeIssuePromise = null;
-
-            resolve();
-        });
-    }
-
-    await activeIssuePromise;
-
-    return nodeCache.get('allIssues');
 };
 
 module.exports = {
@@ -164,5 +141,7 @@ module.exports = {
 
         return isMember;
     },
-    getAllIssues
+    getAllIssues: staleWhileRevalidate(getAllIssues, {
+        millisecondsUntilStale: 10000 /* 10 seconds */
+    })
 };

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -137,7 +137,6 @@ describe('graphql', () => {
         const excludedTypeNames = [
             // Items formatted like this:
             // 'TestResult'
-            'Issue',
             'Vendor'
         ];
         const excludedTypeNameAndField = [
@@ -290,6 +289,24 @@ describe('graphql', () => {
                         }
                         testPlanVersions {
                             id
+                        }
+                        issues {
+                            __typename
+                            author
+                            title
+                            link
+                            isCandidateReview
+                            feedbackType
+                            isOpen
+                            testNumberFilteredByAt
+                            createdAt
+                            closedAt
+                            at {
+                                name
+                            }
+                            browser {
+                                name
+                            }
                         }
                     }
                     testPlans {


### PR DESCRIPTION
When users raise issues through the app we insert a hidden comment into the issue which is used to later track the issue within the app. This PR improves the system by converting the hidden comment from a string, which was difficult to parse, to JSON, allowing us to remove most of the string parsing logic from the issue system. It also fixes a problem caused by the fact that most users who raise issues do not have the ability to attach the required issue labels - the system now relies on the hidden metadata and missing labels should no longer cause issues. Related to https://github.com/w3c/aria-at-app/issues/768.