### PR TITLE
Promote unit test isolation

### DIFF
--- a/server/tests/models/services/AtService.test.js
+++ b/server/tests/models/services/AtService.test.js
@@ -164,170 +164,184 @@ describe('AtModel Data Checks', () => {
     });
 
     it('should return collection of ats', async () => {
-        // A1
-        const result = await AtService.getAts('');
+        await dbCleaner(async () => {
+            // A1
+            const result = await AtService.getAts('');
 
-        // A3
-        expect(result.length).toBeGreaterThanOrEqual(1);
-        expect(result).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: expect.any(Number),
-                    name: expect.any(String),
-                    atVersions: expect.any(Array),
-                    modes: expect.any(Array),
-                    browsers: expect.any(Array)
-                })
-            ])
-        );
+            // A3
+            expect(result.length).toBeGreaterThanOrEqual(1);
+            expect(result).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(Number),
+                        name: expect.any(String),
+                        atVersions: expect.any(Array),
+                        modes: expect.any(Array),
+                        browsers: expect.any(Array)
+                    })
+                ])
+            );
+        });
     });
 
     it('should return collection of ats for name query', async () => {
-        // A1
-        const search = 'nvd';
+        await dbCleaner(async () => {
+            // A1
+            const search = 'nvd';
 
-        // A2
-        const result = await AtService.getAts(search, {});
+            // A2
+            const result = await AtService.getAts(search, {});
 
-        // A3
-        expect(result).toBeInstanceOf(Array);
-        expect(result.length).toBeGreaterThanOrEqual(1);
-        expect(result).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: expect.any(Number),
-                    name: expect.stringMatching(/nvd/gi),
-                    atVersions: expect.any(Array),
-                    modes: expect.any(Array),
-                    browsers: expect.any(Array)
-                })
-            ])
-        );
+            // A3
+            expect(result).toBeInstanceOf(Array);
+            expect(result.length).toBeGreaterThanOrEqual(1);
+            expect(result).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(Number),
+                        name: expect.stringMatching(/nvd/gi),
+                        atVersions: expect.any(Array),
+                        modes: expect.any(Array),
+                        browsers: expect.any(Array)
+                    })
+                ])
+            );
+        });
     });
 
     it('should return collection of ats with paginated structure', async () => {
-        // A1
-        const result = await AtService.getAts('', {}, ['name'], [], [], [], {
-            enablePagination: true
-        });
+        await dbCleaner(async () => {
+            // A1
+            const result = await AtService.getAts('', {}, ['name'], [], [], [], {
+                enablePagination: true
+            });
 
-        // A3
-        expect(result.data.length).toBeGreaterThanOrEqual(1);
-        expect(result).toEqual(
-            expect.objectContaining({
-                page: 1,
-                pageSize: expect.any(Number),
-                resultsCount: expect.any(Number),
-                totalResultsCount: expect.any(Number),
-                pagesCount: expect.any(Number),
-                data: expect.arrayContaining([
-                    expect.objectContaining({
-                        name: expect.any(String)
-                    })
-                ])
-            })
-        );
+            // A3
+            expect(result.data.length).toBeGreaterThanOrEqual(1);
+            expect(result).toEqual(
+                expect.objectContaining({
+                    page: 1,
+                    pageSize: expect.any(Number),
+                    resultsCount: expect.any(Number),
+                    totalResultsCount: expect.any(Number),
+                    pagesCount: expect.any(Number),
+                    data: expect.arrayContaining([
+                        expect.objectContaining({
+                            name: expect.any(String)
+                        })
+                    ])
+                })
+            );
+        });
     });
 });
 
 describe('AtVersionModel Data Checks', () => {
     it('should return valid atVersion for id query with all associations', async () => {
-        // A1
-        const _id = 1;
+        await dbCleaner(async () => {
+            // A1
+            const _id = 1;
 
-        // A2
-        const atVersion = await AtService.getAtVersionById(_id);
-        const { id, name, at, releasedAt } = atVersion;
+            // A2
+            const atVersion = await AtService.getAtVersionById(_id);
+            const { id, name, at, releasedAt } = atVersion;
 
-        // A3
-        expect(id).toEqual(_id);
-        expect(name).toBeTruthy();
-        expect(releasedAt).toBeTruthy();
-        expect(at).toEqual(
-            expect.objectContaining({
-                name: expect.any(String),
-                id: expect.any(Number)
-            })
-        );
-        expect(atVersion).toHaveProperty('at');
+            // A3
+            expect(id).toEqual(_id);
+            expect(name).toBeTruthy();
+            expect(releasedAt).toBeTruthy();
+            expect(at).toEqual(
+                expect.objectContaining({
+                    name: expect.any(String),
+                    id: expect.any(Number)
+                })
+            );
+            expect(atVersion).toHaveProperty('at');
+        });
     });
     it('should return valid atVersion with at for query with all associations', async () => {
-        // A1
-        const _atId = 1;
-        const _atVersion = '2021.2111.13';
-        const _releasedAt = new Date('2021-11-01 04:00:00.000Z');
+        await dbCleaner(async () => {
+            // A1
+            const _atId = 1;
+            const _atVersion = '2021.2111.13';
+            const _releasedAt = new Date('2021-11-01 04:00:00.000Z');
 
-        // A2
-        const atVersionInstance = await AtService.getAtVersionByQuery({
-            atId: _atId,
-            name: _atVersion,
-            releasedAt: _releasedAt
-        });
-        const { atId, name, at, releasedAt } = atVersionInstance;
-
-        // A3
-        expect(atId).toBeTruthy();
-        expect(name).toBeTruthy();
-        expect(at).toBeTruthy();
-        expect(releasedAt).toBeTruthy();
-        expect(atVersionInstance).toEqual(
-            expect.objectContaining({
-                atId: _atId,
-                name: _atVersion,
-                at: expect.objectContaining({
-                    id: _atId,
-                    name: expect.any(String)
-                })
-            })
-        );
-        expect(atVersionInstance).toHaveProperty('at');
-    });
-
-    it('should return valid atVersion for query with no associations', async () => {
-        // A1
-        const _atId = 1;
-        const _atVersion = '2021.2111.13';
-        const _releasedAt = new Date('2021-11-01 04:00:00.000Z');
-
-        // A2
-        const atVersionInstance = await AtService.getAtVersionByQuery(
-            {
+            // A2
+            const atVersionInstance = await AtService.getAtVersionByQuery({
                 atId: _atId,
                 name: _atVersion,
                 releasedAt: _releasedAt
-            },
-            null,
-            []
-        );
-        const { atId, name } = atVersionInstance;
+            });
+            const { atId, name, at, releasedAt } = atVersionInstance;
 
-        // A3
-        expect(atId).toBeTruthy();
-        expect(name).toBeTruthy();
-        expect(atVersionInstance).toEqual(
-            expect.objectContaining({
-                atId: _atId,
-                name: _atVersion
-            })
-        );
-        expect(atVersionInstance).not.toHaveProperty('at');
+            // A3
+            expect(atId).toBeTruthy();
+            expect(name).toBeTruthy();
+            expect(at).toBeTruthy();
+            expect(releasedAt).toBeTruthy();
+            expect(atVersionInstance).toEqual(
+                expect.objectContaining({
+                    atId: _atId,
+                    name: _atVersion,
+                    at: expect.objectContaining({
+                        id: _atId,
+                        name: expect.any(String)
+                    })
+                })
+            );
+            expect(atVersionInstance).toHaveProperty('at');
+        });
+    });
+
+    it('should return valid atVersion for query with no associations', async () => {
+        await dbCleaner(async () => {
+            // A1
+            const _atId = 1;
+            const _atVersion = '2021.2111.13';
+            const _releasedAt = new Date('2021-11-01 04:00:00.000Z');
+
+            // A2
+            const atVersionInstance = await AtService.getAtVersionByQuery(
+                {
+                    atId: _atId,
+                    name: _atVersion,
+                    releasedAt: _releasedAt
+                },
+                null,
+                []
+            );
+            const { atId, name } = atVersionInstance;
+
+            // A3
+            expect(atId).toBeTruthy();
+            expect(name).toBeTruthy();
+            expect(atVersionInstance).toEqual(
+                expect.objectContaining({
+                    atId: _atId,
+                    name: _atVersion
+                })
+            );
+            expect(atVersionInstance).not.toHaveProperty('at');
+        });
     });
 
     it('should not be valid atVersion query', async () => {
-        // A1
-        const _atId = 53935;
-        const _atVersion = randomStringGenerator();
-        const _releasedAt = new Date('2022-04-05');
+        await dbCleaner(async () => {
+            // A1
+            const _atId = 53935;
+            const _atVersion = randomStringGenerator();
+            const _releasedAt = new Date('2022-04-05');
 
-        // A2
-        const atVersionResult = await AtService.getAtVersionByQuery({
-            atId: _atId,
-            name: _atVersion,
-            releasedAt: _releasedAt
+            // A2
+            const atVersionResult = await AtService.getAtVersionByQuery({
+                atId: _atId,
+                name: _atVersion,
+                releasedAt: _releasedAt
+            });
+
+            // A3
+            expect(atVersionResult).toBeNull();
         });
-
-        // A3
-        expect(atVersionResult).toBeNull();
     });
 
     it('should create and remove a new atVersion', async () => {

--- a/server/tests/models/services/BrowserService.test.js
+++ b/server/tests/models/services/BrowserService.test.js
@@ -149,155 +149,167 @@ describe('BrowserModel Data Checks', () => {
     });
 
     it('should return collection of browsers', async () => {
-        // A1
-        const result = await BrowserService.getBrowsers('');
+        await dbCleaner(async () => {
+            // A1
+            const result = await BrowserService.getBrowsers('');
 
-        // A3
-        expect(result.length).toBeGreaterThanOrEqual(1);
-        expect(result).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: expect.any(Number),
-                    name: expect.any(String),
-                    browserVersions: expect.any(Array),
-                    ats: expect.any(Array)
-                })
-            ])
-        );
+            // A3
+            expect(result.length).toBeGreaterThanOrEqual(1);
+            expect(result).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(Number),
+                        name: expect.any(String),
+                        browserVersions: expect.any(Array),
+                        ats: expect.any(Array)
+                    })
+                ])
+            );
+        });
     });
 
     it('should return collection of browsers for name query', async () => {
-        // A1
-        const search = 'chr';
+        await dbCleaner(async () => {
+            // A1
+            const search = 'chr';
 
-        // A2
-        const result = await BrowserService.getBrowsers(search, {});
+            // A2
+            const result = await BrowserService.getBrowsers(search, {});
 
-        // A3
-        expect(result).toBeInstanceOf(Array);
-        expect(result.length).toBeGreaterThanOrEqual(1);
-        expect(result).toEqual(
-            expect.arrayContaining([
-                expect.objectContaining({
-                    id: expect.any(Number),
-                    name: expect.stringMatching(/chr/gi),
-                    browserVersions: expect.any(Array),
-                    ats: expect.any(Array)
-                })
-            ])
-        );
+            // A3
+            expect(result).toBeInstanceOf(Array);
+            expect(result.length).toBeGreaterThanOrEqual(1);
+            expect(result).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        id: expect.any(Number),
+                        name: expect.stringMatching(/chr/gi),
+                        browserVersions: expect.any(Array),
+                        ats: expect.any(Array)
+                    })
+                ])
+            );
+        });
     });
 
     it('should return collection of browsers with paginated structure', async () => {
-        // A1
-        const result = await BrowserService.getBrowsers(
-            '',
-            {},
-            ['name'],
-            [],
-            [],
-            {
-                enablePagination: true
-            }
-        );
+        await dbCleaner(async () => {
+            // A1
+            const result = await BrowserService.getBrowsers(
+                '',
+                {},
+                ['name'],
+                [],
+                [],
+                {
+                    enablePagination: true
+                }
+            );
 
-        // A3
-        expect(result.data.length).toBeGreaterThanOrEqual(1);
-        expect(result).toEqual(
-            expect.objectContaining({
-                page: 1,
-                pageSize: expect.any(Number),
-                resultsCount: expect.any(Number),
-                totalResultsCount: expect.any(Number),
-                pagesCount: expect.any(Number),
-                data: expect.arrayContaining([
-                    expect.objectContaining({
-                        name: expect.any(String)
-                    })
-                ])
-            })
-        );
+            // A3
+            expect(result.data.length).toBeGreaterThanOrEqual(1);
+            expect(result).toEqual(
+                expect.objectContaining({
+                    page: 1,
+                    pageSize: expect.any(Number),
+                    resultsCount: expect.any(Number),
+                    totalResultsCount: expect.any(Number),
+                    pagesCount: expect.any(Number),
+                    data: expect.arrayContaining([
+                        expect.objectContaining({
+                            name: expect.any(String)
+                        })
+                    ])
+                })
+            );
+        });
     });
 });
 
 describe('BrowserVersionModel Data Checks', () => {
     it('should return valid browserVersion with browser for query with all associations', async () => {
-        // A1
-        const _browserId = 1;
-        const _name = '99.0.1';
+        await dbCleaner(async () => {
+            // A1
+            const _browserId = 1;
+            const _name = '99.0.1';
 
-        // A2
-        const browserVersionInstance =
-            await BrowserService.getBrowserVersionByQuery({
-                browserId: _browserId,
-                name: _name
-            });
-        const { id, browserId, name, browser } = browserVersionInstance;
+            // A2
+            const browserVersionInstance =
+                await BrowserService.getBrowserVersionByQuery({
+                    browserId: _browserId,
+                    name: _name
+                });
+            const { id, browserId, name, browser } = browserVersionInstance;
 
-        // A3
-        expect(browserId).toBeTruthy();
-        expect(name).toBeTruthy();
-        expect(browser).toBeTruthy();
-        expect(id).toBeTruthy();
-        expect(browserVersionInstance).toEqual(
-            expect.objectContaining({
-                id: expect.anything(),
-                browserId: _browserId,
-                name: _name,
-                browser: expect.objectContaining({
-                    id: _browserId,
-                    name: expect.any(String)
+            // A3
+            expect(browserId).toBeTruthy();
+            expect(name).toBeTruthy();
+            expect(browser).toBeTruthy();
+            expect(id).toBeTruthy();
+            expect(browserVersionInstance).toEqual(
+                expect.objectContaining({
+                    id: expect.anything(),
+                    browserId: _browserId,
+                    name: _name,
+                    browser: expect.objectContaining({
+                        id: _browserId,
+                        name: expect.any(String)
+                    })
                 })
-            })
-        );
-        expect(browserVersionInstance).toHaveProperty('browser');
+            );
+            expect(browserVersionInstance).toHaveProperty('browser');
+        });
     });
 
     it('should return valid browserVersionInstance for query with no associations', async () => {
-        // A1
-        const _browserId = 1;
-        const _name = '99.0.1';
+        await dbCleaner(async () => {
+            // A1
+            const _browserId = 1;
+            const _name = '99.0.1';
 
-        // A2
-        const browserVersionInstance =
-            await BrowserService.getBrowserVersionByQuery(
-                {
+            // A2
+            const browserVersionInstance =
+                await BrowserService.getBrowserVersionByQuery(
+                    {
+                        browserId: _browserId,
+                        name: _name
+                    },
+                    null,
+                    []
+                );
+            const { id, browserId, name } = browserVersionInstance;
+
+            // A3
+            expect(browserId).toBeTruthy();
+            expect(name).toBeTruthy();
+            expect(id).toBeTruthy();
+            expect(browserVersionInstance).toEqual(
+                expect.objectContaining({
+                    id: expect.anything(),
                     browserId: _browserId,
                     name: _name
-                },
-                null,
-                []
+                })
             );
-        const { id, browserId, name } = browserVersionInstance;
-
-        // A3
-        expect(browserId).toBeTruthy();
-        expect(name).toBeTruthy();
-        expect(id).toBeTruthy();
-        expect(browserVersionInstance).toEqual(
-            expect.objectContaining({
-                id: expect.anything(),
-                browserId: _browserId,
-                name: _name
-            })
-        );
-        expect(browserVersionInstance).not.toHaveProperty('browser');
+            expect(browserVersionInstance).not.toHaveProperty('browser');
+        });
     });
 
     it('should not be valid browserVersion query', async () => {
-        // A1
-        const _browserId = 53935;
-        const _name = randomStringGenerator();
+        await dbCleaner(async () => {
+            // A1
+            const _browserId = 53935;
+            const _name = randomStringGenerator();
 
-        // A2
-        const browserVersionInstance =
-            await BrowserService.getBrowserVersionByQuery({
-                browserId: _browserId,
-                name: _name
-            });
+            // A2
+            const browserVersionInstance =
+                await BrowserService.getBrowserVersionByQuery({
+                    browserId: _browserId,
+                    name: _name
+                });
 
-        // A3
-        expect(browserVersionInstance).toBeNull();
+            // A3
+            expect(browserVersionInstance).toBeNull();
+        });
     });
 
     it('should create and remove a new browserVersion', async () => {


### PR DESCRIPTION
The unit testing infrastructure for the project's server logic is currently built around global mutable state. Prior to this commit, some tests did not explicitly clear this state, and as a result, a failure or timeout in one test would cause failures in subsequent tests.

Insert previously-omitted invocations of the state-management function `dbCleaner` as per convention in this test suite.