### PR TITLE
Correct deprecation date

### DIFF
--- a/server/migrations/20230830225248-addMissingDeprecatedAtAndReorderPhaseChangeDates.js
+++ b/server/migrations/20230830225248-addMissingDeprecatedAtAndReorderPhaseChangeDates.js
@@ -134,14 +134,28 @@ module.exports = {
                 }
 
                 if (testPlanVersion.deprecatedAt) {
+                    // Check if there is a more recent test plan version
+                    const moreRecentTestPlanVersions =
+                        await queryInterface.sequelize.query(
+                            `select "TestPlanVersion".id, "updatedAt", "deprecatedAt"
+                                from "TestPlanVersion"
+                                where "updatedAt" > '${testPlanVersion.updatedAt.toLocaleDateString()}'
+                                and "testPlanId" = ${testPlanVersion.id}
+                                order by "updatedAt" desc;`,
+                            {
+                                type: Sequelize.QueryTypes.SELECT,
+                                transaction
+                            }
+                        );
+
+                    const moreRecentTestPlanVersion =
+                        moreRecentTestPlanVersions[0];
+
                     const deprecatedAt = new Date(
-                        testPlanVersion.recommendedPhaseReachedAt ||
-                            testPlanVersion.candidatePhaseReachedAt ||
-                            testPlanVersion.draftPhaseReachedAt ||
-                            testPlanVersion.updatedAt ||
+                        moreRecentTestPlanVersion?.updatedAt ||
                             testPlanVersion.deprecatedAt
                     );
-                    deprecatedAt.setSeconds(deprecatedAt.getSeconds() + 1);
+                    deprecatedAt.setSeconds(deprecatedAt.getSeconds() - 1);
 
                     // Add deprecatedAt for applicable testPlanVersions
                     await queryInterface.sequelize.query(

--- a/server/migrations/20230830225248-addMissingDeprecatedAtAndReorderPhaseChangeDates.js
+++ b/server/migrations/20230830225248-addMissingDeprecatedAtAndReorderPhaseChangeDates.js
@@ -134,27 +134,7 @@ module.exports = {
                 }
 
                 if (testPlanVersion.deprecatedAt) {
-                    // Check if there is a more recent test plan version
-                    const moreRecentTestPlanVersions =
-                        await queryInterface.sequelize.query(
-                            `select "TestPlanVersion".id, "updatedAt", "deprecatedAt"
-                                from "TestPlanVersion"
-                                where "updatedAt" > '${testPlanVersion.updatedAt.toLocaleDateString()}'
-                                and "testPlanId" = ${testPlanVersion.id}
-                                order by "updatedAt" desc;`,
-                            {
-                                type: Sequelize.QueryTypes.SELECT,
-                                transaction
-                            }
-                        );
-
-                    const moreRecentTestPlanVersion =
-                        moreRecentTestPlanVersions[0];
-
-                    const deprecatedAt = new Date(
-                        moreRecentTestPlanVersion?.updatedAt ||
-                            testPlanVersion.deprecatedAt
-                    );
+                    const deprecatedAt = new Date(testPlanVersion.deprecatedAt);
                     deprecatedAt.setSeconds(deprecatedAt.getSeconds() - 1);
 
                     // Add deprecatedAt for applicable testPlanVersions


### PR DESCRIPTION
As discussed with @howard-e, this PR changes the migration to compare against the most recent version in the database and deprecate against that version.