### PR TITLE
Deprecated phase copy

### DIFF
--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -288,9 +288,9 @@ const TestPlanVersionsPage = () => {
                                                     return (
                                                         <>
                                                             {deprecatedPill}
-                                                            before&nbsp;
+                                                            {` before `}
                                                             {draftPill}
-                                                            review
+                                                            {` review `}
                                                         </>
                                                     );
                                                 }
@@ -302,8 +302,7 @@ const TestPlanVersionsPage = () => {
                                                     return (
                                                         <>
                                                             {deprecatedPill}
-                                                            after being approved
-                                                            as&nbsp;
+                                                            {` after being approved as `}
                                                             {phasePill}
                                                         </>
                                                     );
@@ -312,9 +311,9 @@ const TestPlanVersionsPage = () => {
                                                 return (
                                                     <>
                                                         {deprecatedPill}
-                                                        during&nbsp;
+                                                        {` during `}
                                                         {phasePill}
-                                                        review
+                                                        {` review `}
                                                     </>
                                                 );
                                             }

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -273,10 +273,48 @@ const TestPlanVersionsPage = () => {
                                                     </PhasePill>
                                                 );
 
+                                                const draftPill = (
+                                                    <PhasePill
+                                                        fullWidth={false}
+                                                    >
+                                                        DRAFT
+                                                    </PhasePill>
+                                                );
+
+                                                if (
+                                                    derivedDeprecatedAtPhase ===
+                                                    'RD'
+                                                ) {
+                                                    return (
+                                                        <>
+                                                            {deprecatedPill}
+                                                            before&nbsp;
+                                                            {draftPill}
+                                                            review
+                                                        </>
+                                                    );
+                                                }
+
+                                                if (
+                                                    derivedDeprecatedAtPhase ===
+                                                    'RECOMMENDED'
+                                                ) {
+                                                    return (
+                                                        <>
+                                                            {deprecatedPill}
+                                                            after being approved
+                                                            as&nbsp;
+                                                            {phasePill}
+                                                        </>
+                                                    );
+                                                }
+
                                                 return (
                                                     <>
-                                                        {deprecatedPill} during{' '}
-                                                        {phasePill} review
+                                                        {deprecatedPill}
+                                                        during&nbsp;
+                                                        {phasePill}
+                                                        review
                                                     </>
                                                 );
                                             }

--- a/client/components/common/PhasePill/index.jsx
+++ b/client/components/common/PhasePill/index.jsx
@@ -22,7 +22,6 @@ const PhaseText = styled.span`
         vertical-align: middle;
         position: relative;
         top: -4px;
-        margin-right: 5px;
         margin-top: 4px; /* Improve appearance when text wraps */
     }
 

--- a/client/components/common/PhasePill/index.jsx
+++ b/client/components/common/PhasePill/index.jsx
@@ -21,8 +21,9 @@ const PhaseText = styled.span`
         padding: 2px 15px;
         vertical-align: middle;
         position: relative;
-        top: -1px;
+        top: -4px;
         margin-right: 5px;
+        margin-top: 4px; /* Improve appearance when text wraps */
     }
 
     &.rd {

--- a/client/components/common/ThemeTable/index.jsx
+++ b/client/components/common/ThemeTable/index.jsx
@@ -28,6 +28,7 @@ export const ThemeTable = styled(Table)`
     th {
         padding-left: 1rem;
         min-width: 165px;
+        vertical-align: middle;
     }
 `;
 

--- a/server/services/GithubService.js
+++ b/server/services/GithubService.js
@@ -15,7 +15,7 @@ const {
 const GITHUB_ISSUES_API_URL =
     ENVIRONMENT === 'production'
         ? 'https://api.github.com/repos/w3c/aria-at'
-        : 'https://api.github.com/repos/w3c/aria-at';
+        : 'https://api.github.com/repos/bocoup/aria-at';
 
 const permissionScopes = [
     // Not currently used, but this permissions scope will allow us to query for

--- a/server/services/GithubService.js
+++ b/server/services/GithubService.js
@@ -15,7 +15,7 @@ const {
 const GITHUB_ISSUES_API_URL =
     ENVIRONMENT === 'production'
         ? 'https://api.github.com/repos/w3c/aria-at'
-        : 'https://api.github.com/repos/bocoup/aria-at';
+        : 'https://api.github.com/repos/w3c/aria-at';
 
 const permissionScopes = [
     // Not currently used, but this permissions scope will allow us to query for


### PR DESCRIPTION
Addresses https://github.com/w3c/aria-at-app/issues/778 by changing the way phases are referred to when a deprecation occurs.