### PR TITLE
Address clashing version string titles

### DIFF
--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -200,6 +200,32 @@ const TestPlanVersionsPage = () => {
         item => item.link
     );
 
+    // Hash the test plan version version strings. If found, record the order
+    const testPlanVersionDuplicates = new Map();
+    const testPlanVersionOrder = {};
+
+    // Given that the testPlanVersions array is sorted from most recent version
+    // to least recent version, iterate backwards to determine the duplicates.
+    // This means that the least recent versions will have a lower order if there
+    // is a duplicate version that is more recent.
+    for (let i = testPlanVersions.length - 1; i > 0; i--) {
+        const versionString = convertDateToString(
+            testPlanVersions[i].updatedAt,
+            'YYYY.MM.DD'
+        );
+        if (!testPlanVersionDuplicates.has(versionString)) {
+            testPlanVersionDuplicates.set(versionString, 1);
+        } else {
+            testPlanVersionDuplicates.set(
+                versionString,
+                testPlanVersionDuplicates.get(versionString) + 1
+            );
+        }
+
+        testPlanVersionOrder[testPlanVersions[i].id] =
+            testPlanVersionDuplicates.get(versionString);
+    }
+
     return (
         <Container id="main" as="main" tabIndex="-1">
             <Helmet>
@@ -247,6 +273,11 @@ const TestPlanVersionsPage = () => {
                                                 testPlanVersion
                                             )}
                                             autoWidth={false}
+                                            order={
+                                                testPlanVersionOrder[
+                                                    testPlanVersion.id
+                                                ]
+                                            }
                                         />
                                     </td>
                                     <td>
@@ -383,6 +414,7 @@ const TestPlanVersionsPage = () => {
                                 iconColor={getIconColor(testPlanVersion)}
                                 fullWidth={false}
                                 autoWidth={false}
+                                order={testPlanVersionOrder[testPlanVersion.id]}
                             />
                         );
 
@@ -401,10 +433,12 @@ const TestPlanVersionsPage = () => {
             </ThemeTable>
 
             {testPlanVersions.map(testPlanVersion => {
-                const vString = `V${convertDateToString(
-                    testPlanVersion.updatedAt,
-                    'YY.MM.DD'
-                )}`;
+                const vString = `V${
+                    convertDateToString(testPlanVersion.updatedAt, 'YY.MM.DD') +
+                    (testPlanVersionOrder[testPlanVersion.id] > 1
+                        ? `_${testPlanVersionOrder[testPlanVersion.id]}`
+                        : '')
+                }`;
 
                 // Gets the derived phase even if deprecated by checking
                 // the known dates on the testPlanVersion object
@@ -436,6 +470,7 @@ const TestPlanVersionsPage = () => {
                                 iconColor={getIconColor(testPlanVersion)}
                                 fullWidth={false}
                                 autoWidth={false}
+                                order={testPlanVersionOrder[testPlanVersion.id]}
                             />
                             &nbsp;
                             <PhasePill fullWidth={false}>

--- a/client/components/common/VersionString/index.js
+++ b/client/components/common/VersionString/index.js
@@ -40,14 +40,16 @@ const VersionString = ({
     iconColor = '#818F98',
     linkRef,
     linkHref,
+    order = 1,
     ...restProps
 }) => {
     const dateString = convertDateToString(date, 'YY.MM.DD');
+    const orderString = order > 1 ? `_${order}` : '';
 
     const body = (
         <span>
             <FontAwesomeIcon icon={faCircleCheck} color={iconColor} />
-            <b>{'V' + dateString}</b>
+            <b>{'V' + dateString + orderString}</b>
         </span>
     );
 
@@ -92,7 +94,8 @@ VersionString.propTypes = {
     autoWidth: PropTypes.bool,
     iconColor: PropTypes.string,
     linkRef: PropTypes.shape({ current: PropTypes.any }),
-    linkHref: PropTypes.string
+    linkHref: PropTypes.string,
+    order: PropTypes.number
 };
 
 export default VersionString;


### PR DESCRIPTION
This PR addresses issue #763, clashing version string titles. To implements the proposed ordering where a duplicate but more recent version will have the format of `YYYY.MM.DD_X`, where X is the more recent version found.