### PR TITLE
Fix inverted data management status sort order, always sort ascending by name on columns other than name

### DIFF
--- a/client/components/DataManagement/filterSortHooks.js
+++ b/client/components/DataManagement/filterSortHooks.js
@@ -165,23 +165,26 @@ export const useDataManagementTableFiltering = (
 export const useDataManagementTableSorting = (
     testPlans,
     testPlanVersions,
-    ats
+    ats,
+    initialSortDirection = TABLE_SORT_ORDERS.ASC
 ) => {
     const [activeSort, setActiveSort] = useState({
         key: DATA_MANAGEMENT_TABLE_SORT_OPTIONS.PHASE,
-        direction: TABLE_SORT_ORDERS.ASC
+        direction: initialSortDirection
     });
 
     const { derivedOverallPhaseByTestPlanId } =
         useDerivedOverallPhaseByTestPlanId(testPlans, testPlanVersions);
 
     const sortedTestPlans = useMemo(() => {
+        // Ascending and descending interpreted differently for statuses
+        // (ascending = earlier phase first, descending = later phase first)
         const phaseOrder = {
-            NOT_STARTED: -1,
-            RD: 0,
-            DRAFT: 1,
-            CANDIDATE: 2,
-            RECOMMENDED: 3
+            NOT_STARTED: 4,
+            RD: 3,
+            DRAFT: 2,
+            CANDIDATE: 1,
+            RECOMMENDED: 0
         };
         const directionMod =
             activeSort.direction === TABLE_SORT_ORDERS.ASC ? -1 : 1;
@@ -192,7 +195,7 @@ export const useDataManagementTableSorting = (
         const sortByAts = (a, b) => {
             const countA = ats.length; // Stubs based on current rendering in DataManagementRow
             const countB = ats.length;
-            if (countA === countB) return sortByName(a, b);
+            if (countA === countB) return sortByName(a, b, -1);
             return directionMod * (countA - countB);
         };
 
@@ -202,7 +205,7 @@ export const useDataManagementTableSorting = (
             const testPlanVersionOverallB =
                 derivedOverallPhaseByTestPlanId[b.id] ?? 'NOT_STARTED';
             if (testPlanVersionOverallA === testPlanVersionOverallB) {
-                return sortByName(a, b, directionMod);
+                return sortByName(a, b, -1);
             }
             return (
                 directionMod *

--- a/client/components/DataManagement/index.jsx
+++ b/client/components/DataManagement/index.jsx
@@ -8,7 +8,9 @@ import ManageTestQueue from '../ManageTestQueue';
 import DataManagementRow from '@components/DataManagement/DataManagementRow';
 import './DataManagement.css';
 import { evaluateAuth } from '@client/utils/evaluateAuth';
-import SortableTableHeader from '../common/SortableTableHeader';
+import SortableTableHeader, {
+    TABLE_SORT_ORDERS
+} from '../common/SortableTableHeader';
 import FilterButtons from '../common/FilterButtons';
 import {
     useDataManagementTableFiltering,
@@ -61,7 +63,12 @@ const DataManagement = () => {
     );
 
     const { sortedTestPlans, updateSort, activeSort } =
-        useDataManagementTableSorting(filteredTestPlans, testPlanVersions, ats);
+        useDataManagementTableSorting(
+            filteredTestPlans,
+            testPlanVersions,
+            ats,
+            TABLE_SORT_ORDERS.DESC
+        );
 
     if (error) {
         return (
@@ -198,6 +205,7 @@ const DataManagement = () => {
                                         direction
                                     })
                                 }
+                                initialSortDirection={TABLE_SORT_ORDERS.DESC}
                             />
                             <th>R&D Version</th>
                             <th>Draft Review</th>

--- a/client/components/common/SortableTableHeader/index.js
+++ b/client/components/common/SortableTableHeader/index.js
@@ -55,10 +55,14 @@ export const TABLE_SORT_ORDERS = {
     DESC: 'DESCENDING'
 };
 
-const SortableTableHeader = ({ title, active, onSort = () => {} }) => {
-    const [currentSortOrder, setCurrentSortOrder] = useState(
-        TABLE_SORT_ORDERS.ASC
-    );
+const SortableTableHeader = ({
+    title,
+    active,
+    onSort = () => {},
+    initialSortDirection = TABLE_SORT_ORDERS.ASC
+}) => {
+    const [currentSortOrder, setCurrentSortOrder] =
+        useState(initialSortDirection);
 
     const { setMessage } = useAriaLiveRegion();
 
@@ -129,7 +133,11 @@ const SortableTableHeader = ({ title, active, onSort = () => {} }) => {
 SortableTableHeader.propTypes = {
     title: PropTypes.string.isRequired,
     active: PropTypes.bool.isRequired,
-    onSort: PropTypes.func.isRequired
+    onSort: PropTypes.func.isRequired,
+    initialSortDirection: PropTypes.oneOf([
+        TABLE_SORT_ORDERS.ASC,
+        TABLE_SORT_ORDERS.DESC
+    ])
 };
 
 export default SortableTableHeader;

--- a/client/tests/DataManagement.test.jsx
+++ b/client/tests/DataManagement.test.jsx
@@ -127,7 +127,12 @@ const ats = []; // ATs are stubbed until this model is defined
 describe('useDataManagementTableSorting hook', () => {
     it('sorts by phase by default', () => {
         const { result } = renderHook(() =>
-            useDataManagementTableSorting(testPlans, testPlanVersions, ats)
+            useDataManagementTableSorting(
+                testPlans,
+                testPlanVersions,
+                ats,
+                TABLE_SORT_ORDERS.DESC
+            )
         );
         expect(result.current.sortedTestPlans).toEqual([
             testPlans[3], // RECOMMENDED


### PR DESCRIPTION
This PR changes the following for the Data Management table:
- Changes the interpretation of phase order in phase-based sorting
- Inverts the starting sort sequence to ascending
- Ensures that rows are always sorted in ascending order alphabetically as a second sort on columns other than name. Descending alphabetical sort is only used when explicitly set on the Test Plan name column.

Resolves issue #786 