### PR TITLE
Persist version strings in database

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     {
       "name": "Import tests",
       "program": "${workspaceFolder}/server/scripts/import-tests/index.js",
+      // "args": ["-c","5fe7afd82fe51c185b8661276105190a59d47322"],
       "request": "launch",
       "envFile": "${workspaceFolder}/config/dev.env",
       "skipFiles": [

--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -281,11 +281,6 @@ const CandidateTestPlanRun = () => {
     const { testPlanVersion, vendorReviewStatus } = testPlanReport;
     const { recommendedPhaseTargetDate } = testPlanVersion;
 
-    const versionString = `V${convertDateToString(
-        testPlanVersion.updatedAt,
-        'YY.MM.DD'
-    )}`;
-
     const vendorReviewStatusMap = {
         READY: 'Ready',
         IN_PROGRESS: 'In Progress',
@@ -319,7 +314,7 @@ const CandidateTestPlanRun = () => {
         isCandidateReviewChangesRequested: true,
         testPlanTitle: testPlanVersion.title,
         testPlanDirectory: testPlanVersion.testPlan.directory,
-        versionString,
+        versionString: testPlanVersion.versionString,
         testTitle: currentTest.title,
         testRowNumber: currentTest.rowNumber,
         testRenderedUrl: currentTest.renderedUrl,
@@ -345,7 +340,7 @@ const CandidateTestPlanRun = () => {
         isCandidateReview: true,
         isCandidateReviewChangesRequested: false,
         testPlanTitle: testPlanVersion.title,
-        versionString,
+        versionString: testPlanVersion.versionString,
         testRowNumber: currentTest.rowNumber,
         username: data.me.username,
         atName: testPlanReport.at.name
@@ -467,7 +462,8 @@ const CandidateTestPlanRun = () => {
                                         index === 0,
                                     atName: testPlanReport.at.name,
                                     testPlanTitle: testPlanVersion.title,
-                                    versionString,
+                                    versionString:
+                                        testPlanVersion.versionString,
                                     testRowNumber: currentTest.rowNumber
                                 })}
                             />

--- a/client/components/CandidateReview/CandidateTestPlanRun/queries.js
+++ b/client/components/CandidateReview/CandidateTestPlanRun/queries.js
@@ -74,6 +74,7 @@ export const CANDIDATE_REPORTS_QUERY = gql`
                 metadata
                 testPageUrl
                 updatedAt
+                versionString
                 candidatePhaseReachedAt
                 recommendedPhaseTargetDate
             }

--- a/client/components/CandidateReview/TestPlans/index.jsx
+++ b/client/components/CandidateReview/TestPlans/index.jsx
@@ -554,11 +554,9 @@ const TestPlans = ({ testPlanVersions }) => {
                                                         {getTestPlanVersionTitle(
                                                             testPlanVersion
                                                         )}{' '}
-                                                        V
-                                                        {convertDateToString(
-                                                            testPlanVersion.updatedAt,
-                                                            'YY.MM.DD'
-                                                        )}{' '}
+                                                        {
+                                                            testPlanVersion.versionString
+                                                        }{' '}
                                                         ({testsCount} Test
                                                         {testsCount === 0 ||
                                                         testsCount > 1
@@ -761,11 +759,7 @@ const TestPlans = ({ testPlanVersions }) => {
                                             {getTestPlanVersionTitle(
                                                 testPlanVersion
                                             )}{' '}
-                                            V
-                                            {convertDateToString(
-                                                testPlanVersion.updatedAt,
-                                                'YY.MM.DD'
-                                            )}
+                                            {testPlanVersion.versionString}
                                         </td>
                                         <CenteredTd>
                                             {jawsDataExists

--- a/client/components/CandidateReview/queries.js
+++ b/client/components/CandidateReview/queries.js
@@ -11,7 +11,7 @@ export const CANDIDATE_REVIEW_PAGE_QUERY = gql`
                 directory
             }
             metadata
-            updatedAt
+            versionString
             candidatePhaseReachedAt
             recommendedPhaseTargetDate
             testPlanReports(isFinal: true) {

--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -519,10 +519,11 @@ const DataManagementRow = ({
                     <PhaseCell role="list" aria-setsize={isAdmin ? 2 : 1}>
                         <VersionString
                             role="listitem"
-                            date={latestVersionDate}
                             iconColor="#2BA51C"
                             linkHref={`/test-review/${latestVersion.gitSha}/${latestVersion.testPlan.directory}`}
-                        />
+                        >
+                            {latestVersion.versionString}
+                        </VersionString>
                         {isAdmin && (
                             <Button
                                 ref={ref => setFocusRef(ref)}
@@ -532,10 +533,7 @@ const DataManagementRow = ({
                                     setShowAdvanceModal(true);
                                     setAdvanceModalData({
                                         phase: derivePhaseName('DRAFT'),
-                                        version: convertDateToString(
-                                            latestVersionDate,
-                                            'YY.MM.DD'
-                                        ),
+                                        version: latestVersion.versionString,
                                         advanceFunc: () => {
                                             setShowAdvanceModal(false);
                                             handleClickUpdateTestPlanVersionPhase(
@@ -587,21 +585,17 @@ const DataManagementRow = ({
                 // least one of candidate or recommended phases, show string "Review of
                 // VERSION_STRING completed DATE"
                 if (otherTestPlanVersions.length) {
-                    const {
-                        latestVersion: otherLatestVersion,
-                        latestVersionDate: otherLatestVersionDate
-                    } = getVersionData(otherTestPlanVersions);
+                    const { latestVersion: otherLatestVersion } =
+                        getVersionData(otherTestPlanVersions);
 
                     const completionDate =
                         otherLatestVersion.candidatePhaseReachedAt;
 
                     return (
                         <PhaseCell role="list">
-                            <VersionString
-                                role="listitem"
-                                date={otherLatestVersionDate}
-                                iconColor="#818F98"
-                            />
+                            <VersionString role="listitem" iconColor="#818F98">
+                                {otherLatestVersion.versionString}
+                            </VersionString>
                             <span role="listitem" className="review-complete">
                                 Review Completed&nbsp;
                                 <b>
@@ -652,11 +646,12 @@ const DataManagementRow = ({
                         <PhaseCell role="list" aria-setsize={isAdmin ? 3 : 2}>
                             <VersionString
                                 role="listitem"
-                                date={latestVersionDate}
                                 iconColor="#2BA51C"
                                 linkRef={draftVersionStringRef}
                                 linkHref={`/test-review/${latestVersion.gitSha}/${latestVersion.testPlan.directory}`}
-                            />
+                            >
+                                {latestVersion.versionString}
+                            </VersionString>
                             {isAdmin && (
                                 <Button
                                     ref={ref => setFocusRef(ref)}
@@ -666,10 +661,8 @@ const DataManagementRow = ({
                                         setShowAdvanceModal(true);
                                         setAdvanceModalData({
                                             phase: derivePhaseName('CANDIDATE'),
-                                            version: convertDateToString(
-                                                latestVersionDate,
-                                                'YY.MM.DD'
-                                            ),
+                                            version:
+                                                latestVersion.versionString,
                                             advanceFunc: () => {
                                                 setShowAdvanceModal(false);
                                                 handleClickUpdateTestPlanVersionPhase(
@@ -738,7 +731,9 @@ const DataManagementRow = ({
                                 role="listitem"
                                 date={otherLatestVersionDate}
                                 iconColor="#818F98"
-                            />
+                            >
+                                {otherLatestVersion.versionString}
+                            </VersionString>
                             <span role="listitem" className="review-complete">
                                 Review Completed&nbsp;
                                 <b>
@@ -860,11 +855,12 @@ const DataManagementRow = ({
                         >
                             <VersionString
                                 role="listitem"
-                                date={latestVersionDate}
                                 iconColor="#2BA51C"
                                 linkRef={candidateVersionStringRef}
                                 linkHref={`/test-review/${latestVersion.gitSha}/${latestVersion.testPlan.directory}`}
-                            />
+                            >
+                                {latestVersion.versionString}
+                            </VersionString>
                             {shouldShowAdvanceButton && (
                                 <Button
                                     ref={ref => setFocusRef(ref)}
@@ -876,10 +872,8 @@ const DataManagementRow = ({
                                             phase: derivePhaseName(
                                                 'RECOMMENDED'
                                             ),
-                                            version: convertDateToString(
-                                                latestVersionDate,
-                                                'YY.MM.DD'
-                                            ),
+                                            version:
+                                                latestVersion.versionString,
                                             advanceFunc: () => {
                                                 setShowAdvanceModal(false);
                                                 handleClickUpdateTestPlanVersionPhase(
@@ -923,15 +917,7 @@ const DataManagementRow = ({
                                                 setUpdateTargetModalData({
                                                     testPlanVersionId:
                                                         latestVersion.id,
-                                                    title: `Change Recommended Phase Target Date for ${
-                                                        testPlan.title
-                                                    }, ${
-                                                        'V' +
-                                                        convertDateToString(
-                                                            latestVersionDate,
-                                                            'YY.MM.DD'
-                                                        )
-                                                    }`,
+                                                    title: `Change Recommended Phase Target Date for ${testPlan.title}, ${latestVersion.versionString}`,
                                                     dateText:
                                                         latestVersion.recommendedPhaseTargetDate
                                                 });
@@ -974,8 +960,7 @@ const DataManagementRow = ({
                     return <NoneText>None Yet</NoneText>;
 
                 // Link with text "VERSION_STRING" that targets the single-page view of the plan
-                const { latestVersion, latestVersionDate } =
-                    getVersionData(testPlanVersions);
+                const { latestVersion } = getVersionData(testPlanVersions);
 
                 const completionDate = latestVersion.recommendedPhaseReachedAt;
 
@@ -985,11 +970,12 @@ const DataManagementRow = ({
                     <PhaseCell role="list">
                         <VersionString
                             role="listitem"
-                            date={latestVersionDate}
                             iconColor="#2BA51C"
                             linkRef={recommendedVersionStringRef}
                             linkHref={`/test-review/${latestVersion.gitSha}/${latestVersion.testPlan.directory}`}
-                        />
+                        >
+                            {latestVersion.versionString}
+                        </VersionString>
                         <span role="listitem">
                             <TestPlanReportStatusDialogWithButton
                                 testPlanVersionId={latestVersion.id}
@@ -1038,7 +1024,7 @@ const DataManagementRow = ({
                 <BasicModal
                     show={showAdvanceModal}
                     closeButton={false}
-                    title={`Advancing test plan, ${testPlan.title}, V${advanceModalData.version}`}
+                    title={`Advancing test plan, ${testPlan.title}, ${advanceModalData.version}`}
                     content={
                         <>
                             This version will be updated to&nbsp;

--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -32,6 +32,7 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
             gitSha
             gitMessage
             updatedAt
+            versionString
             draftPhaseReachedAt
             candidatePhaseReachedAt
             recommendedPhaseTargetDate

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -145,10 +145,7 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
                 const issueLink = createIssueLink({
                     testPlanTitle: testPlanVersion.title,
                     testPlanDirectory: testPlanVersion.testPlan.directory,
-                    versionString: `V${convertDateToString(
-                        testPlanVersion.updatedAt,
-                        'YY.MM.DD'
-                    )}`,
+                    versionString: testPlanVersion.versionString,
                     testTitle: test.title,
                     testRowNumber: test.rowNumber,
                     testRenderedUrl: test.renderedUrl,

--- a/client/components/Reports/queries.js
+++ b/client/components/Reports/queries.js
@@ -35,7 +35,7 @@ export const REPORT_PAGE_QUERY = gql`
             title
             phase
             gitSha
-            updatedAt
+            versionString
             testPlan {
                 directory
             }

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -199,7 +199,7 @@ const TestPlanVersionsPage = () => {
     testPlanVersions.forEach(testPlanVersion => {
         const event = {
             id: testPlanVersion.id,
-            updatedAt: testPlanVersion.updatedAt
+            versionString: testPlanVersion.versionString
         };
         timelineForAllVersions.push({ ...event, phase: 'RD' });
 
@@ -299,12 +299,13 @@ const TestPlanVersionsPage = () => {
                                 <tr key={testPlanVersion.id}>
                                     <th>
                                         <VersionString
-                                            date={testPlanVersion.updatedAt}
                                             iconColor={getIconColor(
                                                 testPlanVersion
                                             )}
                                             autoWidth={false}
-                                        />
+                                        >
+                                            {testPlanVersion.versionString}
+                                        </VersionString>
                                     </th>
                                     <td>
                                         {(() => {
@@ -475,11 +476,12 @@ const TestPlanVersionsPage = () => {
                     {timelineForAllVersions.map(testPlanVersion => {
                         const versionString = (
                             <VersionString
-                                date={testPlanVersion.updatedAt}
                                 iconColor={getIconColor(testPlanVersion)}
                                 fullWidth={false}
                                 autoWidth={false}
-                            />
+                            >
+                                {testPlanVersion.versionString}
+                            </VersionString>
                         );
 
                         const eventBody = getEventBody(testPlanVersion.phase);
@@ -499,11 +501,6 @@ const TestPlanVersionsPage = () => {
             </ThemeTable>
 
             {testPlanVersions.map(testPlanVersion => {
-                const vString = `V${convertDateToString(
-                    testPlanVersion.updatedAt,
-                    'YY.MM.DD'
-                )}`;
-
                 // Gets the derived phase even if deprecated by checking
                 // the known dates on the testPlanVersion object
                 const derivedDeprecatedAtPhase =
@@ -520,21 +517,18 @@ const TestPlanVersionsPage = () => {
                     <div key={testPlanVersion.id}>
                         <H2
                             aria-label={`${
-                                'V' +
-                                convertDateToString(
-                                    testPlanVersion.updatedAt,
-                                    'YY.MM.DD'
-                                )
+                                testPlanVersion.versionString
                             } ${derivePhaseName(
                                 testPlanVersion.phase
                             )} on ${getEventDate(testPlanVersion)}`}
                         >
                             <VersionString
-                                date={testPlanVersion.updatedAt}
                                 iconColor={getIconColor(testPlanVersion)}
                                 fullWidth={false}
                                 autoWidth={false}
-                            />
+                            >
+                                {testPlanVersion.versionString}
+                            </VersionString>
                             &nbsp;
                             <PhasePill fullWidth={false}>
                                 {testPlanVersion.phase}
@@ -568,7 +562,8 @@ const TestPlanVersionsPage = () => {
                                         size="xs"
                                         color="#818F98"
                                     />
-                                    View tests in {vString}
+                                    View tests in{' '}
+                                    {testPlanVersion.versionString}
                                 </a>
                             </li>
                             {!hasFinalReports ? null : (
@@ -579,7 +574,8 @@ const TestPlanVersionsPage = () => {
                                             size="xs"
                                             color="#818F98"
                                         />
-                                        View reports generated from {vString}
+                                        View reports generated from{' '}
+                                        {testPlanVersion.versionString}
                                     </a>
                                 </li>
                             )}
@@ -594,13 +590,15 @@ const TestPlanVersionsPage = () => {
                                 </ul>
                             </dd>
                         </CoveredAtDl>
-                        <ThemeTableHeader id={`timeline-for-${vString}`}>
-                            Timeline for {vString}
+                        <ThemeTableHeader
+                            id={`timeline-for-${testPlanVersion.versionString}`}
+                        >
+                            Timeline for {testPlanVersion.versionString}
                         </ThemeTableHeader>
                         <ThemeTable
                             bordered
                             responsive
-                            aria-labelledby={`timeline-for-${vString}`}
+                            aria-labelledby={`timeline-for-${testPlanVersion.versionString}`}
                         >
                             <thead>
                                 <tr>

--- a/client/components/TestPlanVersionsPage/queries.js
+++ b/client/components/TestPlanVersionsPage/queries.js
@@ -26,7 +26,7 @@ export const TEST_PLAN_VERSIONS_PAGE_QUERY = gql`
                     directory
                 }
                 phase
-                updatedAt
+                versionString
                 deprecatedAt
                 gitSha
                 gitMessage

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -58,7 +58,7 @@ export const TEST_QUEUE_PAGE_QUERY = gql`
                 testPlan {
                     directory
                 }
-                updatedAt
+                versionString
             }
             draftTestPlanRuns {
                 id

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -22,7 +22,6 @@ import {
 import TestPlanUpdaterModal from '../TestPlanUpdater/TestPlanUpdaterModal';
 import BasicThemedModal from '../common/BasicThemedModal';
 import { LoadingStatus, useTriggerLoad } from '../common/LoadingStatus';
-import { convertDateToString } from '../../utils/formatter';
 import './TestQueueRow.css';
 
 const TestQueueRow = ({
@@ -170,14 +169,9 @@ const TestQueueRow = ({
     };
 
     const renderAssignedUserToTestPlan = () => {
-        const dateString = convertDateToString(
-            testPlanVersion.updatedAt,
-            'YY.MM.DD'
-        );
-
         const titleElement = (
             <>
-                {testPlanVersion.title} {'V' + dateString}
+                {testPlanVersion.title} {testPlanVersion.versionString}
                 &nbsp;({runnableTestsLength} Test
                 {runnableTestsLength === 0 || runnableTestsLength > 1
                     ? `s`

--- a/client/components/common/VersionString/index.js
+++ b/client/components/common/VersionString/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { convertDateToString } from '../../../utils/formatter';
 import styled from '@emotion/styled';
 
 const StyledPill = styled.span`
@@ -18,6 +17,14 @@ const StyledPill = styled.span`
     // Needed for presenting component on Version History page
     &.full-width {
         width: 100%;
+
+        /* Version strings can have different character counts and this keeps
+        them lined up in lists */
+        & b {
+            min-width: 6em;
+            display: inline-block;
+            text-align: left;
+        }
     }
 
     &:not(.full-width) {
@@ -34,20 +41,18 @@ const StyledPill = styled.span`
 `;
 
 const VersionString = ({
-    date,
     fullWidth = true,
     autoWidth = true,
     iconColor = '#818F98',
     linkRef,
     linkHref,
+    children: versionString,
     ...restProps
 }) => {
-    const dateString = convertDateToString(date, 'YY.MM.DD');
-
     const body = (
         <span>
             <FontAwesomeIcon icon={faCircleCheck} color={iconColor} />
-            <b>{'V' + dateString}</b>
+            <b>{versionString}</b>
         </span>
     );
 
@@ -86,13 +91,12 @@ const VersionString = ({
 };
 
 VersionString.propTypes = {
-    date: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)])
-        .isRequired,
     fullWidth: PropTypes.bool,
     autoWidth: PropTypes.bool,
     iconColor: PropTypes.string,
     linkRef: PropTypes.shape({ current: PropTypes.any }),
-    linkHref: PropTypes.string
+    linkHref: PropTypes.string,
+    children: PropTypes.string
 };
 
 export default VersionString;

--- a/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
@@ -263,6 +263,7 @@ export default (
                         gitMessage:
                             'Remove Tab and Shift+Tab from radiogroup tests when navigating out of the start and end of a radio group (reading mode and VoiceOver only) (#928)',
                         updatedAt: '2023-04-10T18:22:22.000Z',
+                        versionString: 'V23.04.10',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -280,6 +281,7 @@ export default (
                         gitMessage:
                             'Remove Tab and Shift+Tab from radiogroup tests when navigating out of the start and end of a radio group (reading mode and VoiceOver only) (#928)',
                         updatedAt: '2023-04-10T18:22:22.000Z',
+                        versionString: 'V23.04.10',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -297,6 +299,7 @@ export default (
                         gitMessage:
                             'Create tests for APG design pattern example: Horizontal Multi-Thumb Slider (#511)',
                         updatedAt: '2023-03-20T21:24:41.000Z',
+                        versionString: 'V23.03.20',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -314,6 +317,7 @@ export default (
                         gitMessage:
                             'Create tests for APG design pattern example: Link Example 3 (CSS :before content property on a span element) (#518)',
                         updatedAt: '2023-03-13T22:10:13.000Z',
+                        versionString: 'V23.03.13',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -331,6 +335,7 @@ export default (
                         gitMessage:
                             'Create tests for APG design pattern example: Link Example 2 (img element with alt attribute) (#516)',
                         updatedAt: '2023-03-13T19:51:48.000Z',
+                        versionString: 'V23.03.13',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -348,6 +353,7 @@ export default (
                         gitMessage:
                             'Alert and Radiogroup/activedescendent updates (#865)',
                         updatedAt: '2022-12-08T21:47:42.000Z',
+                        versionString: 'V22.12.08',
                         draftPhaseReachedAt: '2022-07-06T00:00:00.000Z',
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -381,6 +387,7 @@ export default (
                         gitMessage:
                             'Delete up arrow command for VoiceOver when navigating backwards to a disclosure button (#845)',
                         updatedAt: '2022-10-31T19:29:17.000Z',
+                        versionString: 'V22.10.31',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -398,6 +405,7 @@ export default (
                         gitMessage:
                             'Add down arrow command to the Navigate forwards out of the Breadcrumb navigation landmark task for JAWS (#803)',
                         updatedAt: '2022-08-10T18:44:16.000Z',
+                        versionString: 'V22.08.10',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -415,6 +423,7 @@ export default (
                         gitMessage:
                             'Create updated tests for APG design pattern example: Main landmark (#707)',
                         updatedAt: '2022-08-05T17:46:37.000Z',
+                        versionString: 'V22.08.05',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -432,6 +441,7 @@ export default (
                         gitMessage:
                             'Create updated tests for APG design pattern example: Meter (#692)',
                         updatedAt: '2022-08-05T17:02:59.000Z',
+                        versionString: 'V22.08.05',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -449,6 +459,7 @@ export default (
                         gitMessage:
                             'Create updated tests for APG design pattern example: Switch (#691)',
                         updatedAt: '2022-08-05T16:13:44.000Z',
+                        versionString: 'V22.08.05',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -466,6 +477,7 @@ export default (
                         gitMessage:
                             'Tasks 4, 5 and 6: corrected link name "Navigate backwards from here" (#734)',
                         updatedAt: '2022-05-26T16:14:17.000Z',
+                        versionString: 'V22.05.26',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -483,6 +495,7 @@ export default (
                         gitMessage:
                             'Delete duplicated assertion for operating a not pressed togle button (VoiceOver) (#716)',
                         updatedAt: '2022-05-18T20:51:40.000Z',
+                        versionString: 'V22.05.18',
                         draftPhaseReachedAt: '2022-07-06T00:00:00.000Z',
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -661,6 +674,7 @@ export default (
                         gitMessage:
                             'Fix navigation link positions in three test plans: link, command button and toggle button (#709)',
                         updatedAt: '2022-05-04T21:33:31.000Z',
+                        versionString: 'V22.05.04',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -678,6 +692,7 @@ export default (
                         gitMessage:
                             'Fix navigation link positions in three test plans: link, command button and toggle button (#709)',
                         updatedAt: '2022-05-04T21:33:31.000Z',
+                        versionString: 'V22.05.04',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -695,6 +710,7 @@ export default (
                         gitMessage:
                             'Create updated tests for APG design pattern example: Color Viewer Slider (#686)',
                         updatedAt: '2022-04-14T18:06:40.000Z',
+                        versionString: 'V22.04.14',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -711,6 +727,7 @@ export default (
                         gitSha: '6b2cbcbdbd5f6867cd3c9e96362817c353335187',
                         gitMessage: "typo: double word 'the' (#595)",
                         updatedAt: '2022-03-29T16:02:56.000Z',
+                        versionString: 'V22.03.29',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -728,6 +745,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -745,6 +763,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -762,6 +781,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -779,6 +799,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -796,6 +817,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -813,6 +835,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -830,6 +853,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -847,6 +871,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -864,6 +889,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -881,6 +907,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -898,6 +925,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -915,6 +943,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -932,6 +961,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -949,6 +979,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: '2022-07-06T00:00:00.000Z',
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -1243,6 +1274,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -1260,6 +1292,7 @@ export default (
                         gitMessage:
                             'Generate html source script to support aria-at-app (#646)',
                         updatedAt: '2022-03-17T18:34:51.000Z',
+                        versionString: 'V22.03.17',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: null,
                         recommendedPhaseTargetDate: null,
@@ -1277,6 +1310,7 @@ export default (
                         gitMessage:
                             'Modify VoiceOver commands for task 7 (#842)',
                         updatedAt: '2022-10-24T21:33:12.000Z',
+                        versionString: 'V22.10.24',
                         draftPhaseReachedAt: null,
                         candidatePhaseReachedAt: '2022-07-06T00:00:00.000Z',
                         recommendedPhaseTargetDate: '2023-01-02T00:00:00.000Z',
@@ -1619,6 +1653,7 @@ export default (
                         gitMessage:
                             'Delete down arrow command for navigating to the beginning of a dialog with JAWS and add the ESC command to exit forms or focus mode (#759)',
                         updatedAt: '2022-06-22T17:56:16.000Z',
+                        versionString: 'V22.06.22',
                         draftPhaseReachedAt: '2022-07-06T00:00:00.000Z',
                         candidatePhaseReachedAt: '2022-07-06T00:00:00.000Z',
                         recommendedPhaseTargetDate: '2023-01-02T00:00:00.000Z',
@@ -2399,6 +2434,7 @@ export default (
                     gitMessage:
                         'Alert and Radiogroup/activedescendent updates (#865)',
                     updatedAt: '2022-12-08T21:47:42.000Z',
+                    versionString: 'V22.12.08',
                     draftPhaseReachedAt: '2022-07-06T00:00:00.000Z',
                     candidatePhaseReachedAt: null,
                     recommendedPhaseTargetDate: null,

--- a/client/tests/__mocks__/GraphQLMocks/TestQueuePageAdminPopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/TestQueuePageAdminPopulatedMock.js
@@ -146,7 +146,7 @@ export default testQueuePageQuery => [
                             gitSha: 'b7078039f789c125e269cb8f8632f57a03d4c50b',
                             gitMessage: 'The message for this SHA',
                             testPlan: { directory: 'checkbox' },
-                            updatedAt: '2021-11-30T14:51:28.000Z'
+                            versionString: 'V21.11.30'
                         },
                         draftTestPlanRuns: [
                             {
@@ -174,7 +174,7 @@ export default testQueuePageQuery => [
                             gitSha: 'b7078039f789c125e269cb8f8632f57a03d4c50b',
                             gitMessage: 'The message for this SHA',
                             testPlan: { directory: 'checkbox' },
-                            updatedAt: '2021-11-30T14:51:28.000Z'
+                            versionString: 'V21.11.30'
                         },
                         draftTestPlanRuns: [
                             {
@@ -202,7 +202,7 @@ export default testQueuePageQuery => [
                             gitSha: 'b7078039f789c125e269cb8f8632f57a03d4c50b',
                             gitMessage: 'The message for this SHA',
                             testPlan: { directory: 'checkbox' },
-                            updatedAt: '2021-11-30T14:51:28.000Z'
+                            versionString: 'V21.11.30'
                         },
                         draftTestPlanRuns: [
                             {

--- a/client/tests/__mocks__/GraphQLMocks/TestQueuePageTesterPopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/TestQueuePageTesterPopulatedMock.js
@@ -159,7 +159,7 @@ export default testQueuePageQuery => [
                             testPlan: {
                                 directory: 'checkbox'
                             },
-                            updatedAt: '2021-11-30T14:51:28.000Z'
+                            versionString: 'V21-11-30'
                         },
                         draftTestPlanRuns: [
                             {
@@ -203,7 +203,7 @@ export default testQueuePageQuery => [
                             testPlan: {
                                 directory: 'checkbox'
                             },
-                            updatedAt: '2021-11-30T14:51:28.000Z'
+                            versionString: 'V21-11-30'
                         },
                         draftTestPlanRuns: [
                             {
@@ -239,7 +239,7 @@ export default testQueuePageQuery => [
                             testPlan: {
                                 directory: 'menubar-editor'
                             },
-                            updatedAt: '2021-11-30T14:51:28.000Z'
+                            versionString: 'V21-11-30'
                         },
                         draftTestPlanRuns: []
                     }

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -332,6 +332,12 @@ const graphqlSchema = gql`
         This can also be considered as the time for when R & D was complete
         """
         updatedAt: Timestamp!
+        """
+        An easily readable representation of the date associated with the
+        version, formatted like V23.09.28 (or V23.09.28-1 in the case that
+        there are multiple versions on the same day).
+        """
+        versionString: String!
         # TODO: consider moving to the Scenario type if we support multiple
         # test pages for one TestPlanVersion (i.e. testing that
         # <input type="button"> and <button> have equivalent behavior).

--- a/server/migrations/20230608171911-moveTestPlanReportValuesToTestPlanVersion.js
+++ b/server/migrations/20230608171911-moveTestPlanReportValuesToTestPlanVersion.js
@@ -2,7 +2,10 @@
 
 const BrowserLoader = require('../models/loaders/BrowserLoader');
 const AtLoader = require('../models/loaders/AtLoader');
-const { TEST_PLAN_REPORT_ATTRIBUTES } = require('../models/services/helpers');
+const {
+    TEST_PLAN_REPORT_ATTRIBUTES,
+    TEST_PLAN_VERSION_ATTRIBUTES
+} = require('../models/services/helpers');
 const scenariosResolver = require('../resolvers/Test/scenariosResolver');
 const {
     getTestPlanReportById,
@@ -23,6 +26,10 @@ const {
     saveTestResult
 } = require('../resolvers/TestResultOperations');
 const { hashTests } = require('../util/aria');
+
+const testPlanVersionAttributes = TEST_PLAN_VERSION_ATTRIBUTES.filter(
+    attr => attr !== 'versionString'
+);
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
@@ -310,7 +317,9 @@ module.exports = {
 
                 const currentTestPlanReport = await getTestPlanReportById(
                     testPlanReportId,
-                    testPlanReportAttributes
+                    testPlanReportAttributes,
+                    undefined,
+                    testPlanVersionAttributes
                 );
 
                 for (
@@ -324,7 +333,8 @@ module.exports = {
                         testPlanRunId,
                         null,
                         null,
-                        testPlanReportAttributes
+                        testPlanReportAttributes,
+                        testPlanVersionAttributes
                     );
                     // testPlanReport = testPlanRun?.testPlanReport;
 
@@ -465,7 +475,9 @@ module.exports = {
                             atId,
                             browserId
                         },
-                        testPlanReportAttributes
+                        testPlanReportAttributes,
+                        undefined,
+                        testPlanVersionAttributes
                     );
 
                 const candidatePhaseReachedAt =
@@ -485,7 +497,9 @@ module.exports = {
                         recommendedPhaseTargetDate,
                         vendorReviewStatus
                     },
-                    testPlanReportAttributes
+                    testPlanReportAttributes,
+                    undefined,
+                    testPlanVersionAttributes
                 );
 
                 // const locationOfData = {
@@ -521,7 +535,8 @@ module.exports = {
                         },
                         null,
                         null,
-                        testPlanReportAttributes
+                        testPlanReportAttributes,
+                        testPlanVersionAttributes
                     );
 
                     for (const testResult of testPlanRun.testResults) {

--- a/server/migrations/20230927172432-addVersionStrings.js
+++ b/server/migrations/20230927172432-addVersionStrings.js
@@ -1,0 +1,85 @@
+const convertDateToString = require('../util/convertDateToString');
+
+('use strict');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                'TestPlanVersion',
+                'versionString',
+                { type: Sequelize.DataTypes.TEXT },
+                { transaction }
+            );
+
+            const [testPlanVersions] = await queryInterface.sequelize.query(
+                `
+                    SELECT id, directory, "updatedAt"
+                    FROM "TestPlanVersion"
+                    ORDER BY directory, "updatedAt", id
+                `,
+                { transaction }
+            );
+
+            let currentDirectory;
+            let currentVersionStringBase;
+            let currentCount;
+            for (const testPlanVersion of testPlanVersions) {
+                const versionStringBase = `V${convertDateToString(
+                    testPlanVersion.updatedAt,
+                    'YY.MM.DD'
+                )}`;
+
+                if (testPlanVersion.directory !== currentDirectory) {
+                    currentDirectory = testPlanVersion.directory;
+                    currentVersionStringBase = versionStringBase;
+                    currentCount = 0;
+                } else if (versionStringBase === currentVersionStringBase) {
+                    currentCount += 1;
+                } else {
+                    currentVersionStringBase = versionStringBase;
+                    currentCount = 0;
+                }
+
+                const versionString =
+                    currentCount === 0
+                        ? currentVersionStringBase
+                        : `${currentVersionStringBase}-${currentCount}`;
+
+                await queryInterface.sequelize.query(
+                    `
+                        UPDATE "TestPlanVersion"
+                        SET "versionString" = ?
+                        WHERE id = ?
+                    `,
+                    {
+                        replacements: [versionString, testPlanVersion.id],
+                        transaction
+                    }
+                );
+            }
+
+            await queryInterface.changeColumn(
+                'TestPlanVersion',
+                'versionString',
+                {
+                    type: Sequelize.DataTypes.TEXT,
+                    allowNull: false
+                },
+                { transaction }
+            );
+
+            await queryInterface.addConstraint('TestPlanVersion', {
+                fields: ['directory', 'versionString'],
+                type: 'unique',
+                name: 'uniqueVersionStringByDirectory',
+                transaction
+            });
+        });
+    },
+
+    async down(queryInterface /* , Sequelize */) {
+        await queryInterface.removeColumn('TestPlanVersion', 'versionString');
+    }
+};

--- a/server/models/TestPlanVersion.js
+++ b/server/models/TestPlanVersion.js
@@ -23,7 +23,10 @@ module.exports = function (sequelize, DataTypes) {
                 defaultValue: PHASE.RD
             },
             title: { type: DataTypes.TEXT },
-            directory: { type: DataTypes.TEXT },
+            directory: {
+                type: DataTypes.TEXT,
+                unique: 'uniqueVersionStringByDirectory'
+            },
             gitSha: { type: DataTypes.TEXT },
             gitMessage: { type: DataTypes.TEXT },
             testPageUrl: { type: DataTypes.TEXT },
@@ -35,6 +38,11 @@ module.exports = function (sequelize, DataTypes) {
             updatedAt: {
                 type: DataTypes.DATE,
                 defaultValue: DataTypes.NOW
+            },
+            versionString: {
+                type: DataTypes.TEXT,
+                allowNull: false,
+                unique: 'uniqueVersionStringByDirectory'
             },
             tests: { type: DataTypes.JSONB },
             testPlanId: { type: DataTypes.INTEGER },

--- a/server/models/services/TestPlanVersionService.js
+++ b/server/models/services/TestPlanVersionService.js
@@ -198,6 +198,7 @@ const createTestPlanVersion = async (
         testPageUrl,
         hashedTests,
         updatedAt,
+        versionString,
         metadata,
         tests,
         testPlanId = null
@@ -220,6 +221,7 @@ const createTestPlanVersion = async (
         testPageUrl,
         hashedTests,
         updatedAt,
+        versionString,
         metadata,
         tests,
         testPlanId
@@ -261,6 +263,7 @@ const updateTestPlanVersion = async (
         testPageUrl,
         hashedTests,
         updatedAt,
+        versionString,
         metadata,
         tests,
         draftPhaseReachedAt,
@@ -289,6 +292,7 @@ const updateTestPlanVersion = async (
             testPageUrl,
             hashedTests,
             updatedAt,
+            versionString,
             metadata,
             tests,
             draftPhaseReachedAt,

--- a/server/resolvers/TestPlanReport/issuesResolver.js
+++ b/server/resolvers/TestPlanReport/issuesResolver.js
@@ -1,5 +1,4 @@
 const { GithubService } = require('../../services');
-const convertDateToString = require('../../util/convertDateToString');
 
 const issuesResolver = (testPlanReport, _, context) =>
     getIssues({ testPlanReport, context });
@@ -30,16 +29,12 @@ const getIssues = async ({ testPlanReport, testPlan, context }) => {
             if (testPlanReport) {
                 const { at, browser, testPlanVersion } = testPlanReport;
 
-                const versionString = `V${convertDateToString(
-                    testPlanVersion.updatedAt,
-                    'YY.MM.DD'
-                )}`;
-
                 return (
                     hiddenIssueMetadata &&
                     hiddenIssueMetadata.testPlanDirectory ===
                         testPlanVersion.directory &&
-                    hiddenIssueMetadata.versionString === versionString &&
+                    hiddenIssueMetadata.versionString ===
+                        testPlanVersion.versionString &&
                     hiddenIssueMetadata.atName === at.name &&
                     (!hiddenIssueMetadata.browserName ||
                         hiddenIssueMetadata.browserName === browser.name)

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -322,6 +322,7 @@ describe('graphql', () => {
                         recommendedPhaseTargetDate
                         recommendedPhaseReachedAt
                         deprecatedAt
+                        versionString
                     }
                     testPlanVersion(id: 1) {
                         __typename

--- a/server/tests/models/TestPlanVersion.spec.js
+++ b/server/tests/models/TestPlanVersion.spec.js
@@ -26,6 +26,7 @@ describe('TestPlanVersionModel', () => {
             'gitMessage',
             'testPageUrl',
             'updatedAt',
+            'versionString',
             'metadata',
             'tests'
         ].forEach(checkPropertyExists(modelInstance));

--- a/server/tests/models/services/AtService.test.js
+++ b/server/tests/models/services/AtService.test.js
@@ -212,9 +212,17 @@ describe('AtModel Data Checks', () => {
     it('should return collection of ats with paginated structure', async () => {
         await dbCleaner(async () => {
             // A1
-            const result = await AtService.getAts('', {}, ['name'], [], [], [], {
-                enablePagination: true
-            });
+            const result = await AtService.getAts(
+                '',
+                {},
+                ['name'],
+                [],
+                [],
+                [],
+                {
+                    enablePagination: true
+                }
+            );
 
             // A3
             expect(result.data.length).toBeGreaterThanOrEqual(1);

--- a/server/tests/models/services/TestPlanVersionService.test.js
+++ b/server/tests/models/services/TestPlanVersionService.test.js
@@ -101,6 +101,7 @@ describe('TestPlanReportModel Data Checks', () => {
             const _testPageUrl = randomStringGenerator();
             const _hashedTests = randomStringGenerator();
             const _updatedAt = new Date();
+            const _versionString = 'V2023.09.27';
             const _metadata = { designPattern: 'https://google.com' };
             const _tests = [{ test: 'goes here' }];
 
@@ -117,6 +118,7 @@ describe('TestPlanReportModel Data Checks', () => {
                     testPageUrl: _testPageUrl,
                     hashedTests: _hashedTests,
                     updatedAt: _updatedAt,
+                    versionString: _versionString,
                     metadata: _metadata,
                     tests: _tests
                 });
@@ -130,6 +132,7 @@ describe('TestPlanReportModel Data Checks', () => {
                 testPageUrl: createdTestPageUrl,
                 hashedTests: createdHashedTests,
                 updatedAt: createdUpdatedAt,
+                versionString: createdVersionString,
                 metadata: createdMetadata,
                 tests: createdTests
             } = testPlanVersion;
@@ -153,6 +156,7 @@ describe('TestPlanReportModel Data Checks', () => {
             expect(createdTestPageUrl).toBe(_testPageUrl);
             expect(createdHashedTests).toEqual(_hashedTests);
             expect(createdUpdatedAt).toEqual(_updatedAt);
+            expect(createdVersionString).toEqual(_versionString);
             expect(createdMetadata).toEqual(_metadata);
             expect(createdTests).toEqual(_tests);
 


### PR DESCRIPTION
Closes https://github.com/w3c/aria-at-app/issues/763. We recently added "version strings" which are short textual representations of the date a test plan was edited. For example a test plan version updated on March 1 would be represented as "V23.03.01". 

However, as of yet we have not accounted for the case that multiple updates occurred to a test plan on the same day, in which case two different versions would have an identical version string.

We decided to add a "1" (or "2" etc.) to the second version string. So the version strings would be "V23.03.01" and "V23.03.01-1".

When @mcking65 [proposed the solution](https://github.com/w3c/aria-at-app/issues/763#issuecomment-1699703715), he suggested using a underscore. For whatever reason, I found a hyphen looks noticeably better. It bugs me because I can't really articulate why. It just does. So I went with a hyphen. I'd be willing to go back to an underscore if that's a problem.

This ended up being a pretty invasive change because we previously generated the version strings with a small snippet of code wherever they were needed. Now we will generate the strings when the test plan versions are created and store them in the database.