### PR TITLE
Fix for focus trapping in modal/dialog components

### DIFF
--- a/client/components/TestPlanReportStatusDialog/TestPlanReportStatusDialog.css
+++ b/client/components/TestPlanReportStatusDialog/TestPlanReportStatusDialog.css
@@ -1,0 +1,4 @@
+.test-plan-report-status-dialog {
+    max-width: 1200px;
+    min-width: max-content;
+}

--- a/client/components/TestPlanReportStatusDialog/index.jsx
+++ b/client/components/TestPlanReportStatusDialog/index.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Modal } from 'react-bootstrap';
 import styled from '@emotion/styled';
 import { getRequiredReports } from './isRequired';
 import AddTestToQueueWithConfirmation from '../AddTestToQueueWithConfirmation';
@@ -11,13 +10,9 @@ import getMetrics from '../Reports/getMetrics';
 import { calculateTestPlanReportCompletionPercentage } from './calculateTestPlanReportCompletionPercentage';
 import { convertDateToString } from '../../utils/formatter';
 import { ThemeTable } from '../common/ThemeTable';
+import BasicModal from '../common/BasicModal';
 
-const TestPlanReportStatusModal = styled(Modal)`
-    .modal-dialog {
-        max-width: 90%;
-        width: max-content;
-    }
-`;
+import './TestPlanReportStatusDialog.css';
 
 const IncompleteStatusReport = styled.span`
     min-width: 5rem;
@@ -169,65 +164,69 @@ const TestPlanReportStatusDialog = ({
         }
     };
 
+    const getContent = () => (
+        <>
+            {testPlanVersion.phase && (
+                <p>
+                    This plan is in the&nbsp;
+                    <span
+                        className={`status-label d-inline ${
+                            testPlanVersion.phase === 'DRAFT'
+                                ? 'not-started'
+                                : 'complete'
+                        }`}
+                    >
+                        {/* text-transform: capitalize will not work on all-caps string */}
+                        {testPlanVersion.phase[0] +
+                            testPlanVersion.phase.slice(1).toLowerCase()}
+                    </span>
+                    &nbsp;Review phase.&nbsp;
+                    <strong>{requiredReports.length} AT/browser&nbsp;</strong>
+                    pairs require reports in this phase.
+                </p>
+            )}
+
+            <ThemeTable bordered responsive>
+                <thead>
+                    <tr>
+                        <th>Required</th>
+                        <th>AT</th>
+                        <th>Browser</th>
+                        <th>Report Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {matchedReports.map(report => renderTableRow(report))}
+                    {unmatchedRequiredReports.map(report =>
+                        renderTableRow(report)
+                    )}
+                    {unmatchedTestPlanReports.map(report =>
+                        renderTableRow(report, 'No')
+                    )}
+                </tbody>
+            </ThemeTable>
+        </>
+    );
+
+    const getTitle = () => (
+        <>
+            Report Status for the&nbsp;
+            <strong>{testPlanVersion.title}</strong>
+            &nbsp;Test Plan
+        </>
+    );
+
     return (
-        <TestPlanReportStatusModal
+        <BasicModal
             show={show}
-            onHide={handleHide}
-            dialogClassName="p-3"
+            handleHide={handleHide}
+            useOnHide={true}
             animation={false}
-        >
-            <Modal.Header closeButton className="pb-1">
-                <h2>
-                    Report Status for the&nbsp;
-                    <strong>{testPlanVersion.title}</strong>
-                    &nbsp;Test Plan
-                </h2>
-            </Modal.Header>
-
-            <Modal.Body className="pt-0 pb-5">
-                {testPlanVersion.phase && (
-                    <p>
-                        This plan is in the&nbsp;
-                        <span
-                            className={`status-label d-inline ${
-                                testPlanVersion.phase === 'DRAFT'
-                                    ? 'not-started'
-                                    : 'complete'
-                            }`}
-                        >
-                            {/* text-transform: capitalize will not work on all-caps string */}
-                            {testPlanVersion.phase[0] +
-                                testPlanVersion.phase.slice(1).toLowerCase()}
-                        </span>
-                        &nbsp;Review phase.&nbsp;
-                        <strong>
-                            {requiredReports.length} AT/browser&nbsp;
-                        </strong>
-                        pairs require reports in this phase.
-                    </p>
-                )}
-
-                <ThemeTable bordered responsive>
-                    <thead>
-                        <tr>
-                            <th>Required</th>
-                            <th>AT</th>
-                            <th>Browser</th>
-                            <th>Report Status</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {matchedReports.map(report => renderTableRow(report))}
-                        {unmatchedRequiredReports.map(report =>
-                            renderTableRow(report)
-                        )}
-                        {unmatchedTestPlanReports.map(report =>
-                            renderTableRow(report, 'No')
-                        )}
-                    </tbody>
-                </ThemeTable>
-            </Modal.Body>
-        </TestPlanReportStatusModal>
+            centered
+            dialogClassName="test-plan-report-status-dialog p-3"
+            content={getContent()}
+            title={getTitle()}
+        />
     );
 };
 

--- a/client/components/common/BasicModal/index.jsx
+++ b/client/components/common/BasicModal/index.jsx
@@ -1,7 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Modal } from 'react-bootstrap';
 import styled from '@emotion/styled';
+import FocusTrapper from '../FocusTrapper';
+import { uniqueId } from 'lodash';
 
 const ModalTitleStyle = styled.h1`
     border: 0;
@@ -36,10 +38,15 @@ const BasicModal = ({
         headerRef.current.focus();
     }, [show]);
 
+    const id = useMemo(() => {
+        return uniqueId('focus-trapped-modal-');
+    }, []);
+
     return (
-        <>
+        <FocusTrapper isActive={show} trappedElId={id}>
             <Modal
                 show={show}
+                id={id}
                 centered={centered}
                 animation={animation}
                 onHide={useOnHide ? handleHide || handleClose : null}
@@ -82,7 +89,7 @@ const BasicModal = ({
                     </Modal.Footer>
                 )}
             </Modal>
-        </>
+        </FocusTrapper>
     );
 };
 

--- a/client/components/common/FocusTrapper/index.jsx
+++ b/client/components/common/FocusTrapper/index.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useEffect, useRef } from 'react';
+
+const FocusTrapper = ({ children, isActive, trappedElId }) => {
+    const focusableElsRef = useRef([]);
+
+    const updateFocusableElements = () => {
+        if (focusableElsRef.current.length > 0) return;
+
+        // Must use getElementById because a ref is not consistently populated
+        const el = document.getElementById(trappedElId);
+        if (!el) return;
+
+        focusableElsRef.current = Array.from(
+            el.querySelectorAll(
+                'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+            )
+        );
+
+        // Create two elements to trap focus before and after the dialog
+        // APG Example for Dialog used as reference
+        const before = document.createElement('div');
+        const after = document.createElement('div');
+        before.tabIndex = 0;
+        after.tabIndex = 0;
+        el.prepend(before);
+        el.append(after);
+
+        focusableElsRef.current.unshift(before);
+        focusableElsRef.current.push(after);
+    };
+
+    const trapFocus = event => {
+        const isTabPressed = event.key === 'Tab' || event.keyCode === 9;
+        if (!isTabPressed) return;
+
+        const focusableEls = focusableElsRef.current;
+
+        // First focusable element is after the blank 'before' div
+        const firstFocusableEl = focusableEls[1];
+        // Last focusable element is before the blank 'after' div
+        const lastFocusableEl = focusableEls[focusableEls.length - 2];
+
+        if (event.shiftKey && document.activeElement === firstFocusableEl) {
+            lastFocusableEl.focus();
+            event.preventDefault();
+        } else if (
+            !event.shiftKey &&
+            document.activeElement === lastFocusableEl
+        ) {
+            firstFocusableEl.focus();
+            event.preventDefault();
+        }
+    };
+
+    useEffect(() => {
+        if (isActive) {
+            updateFocusableElements();
+            document.addEventListener('keydown', trapFocus);
+        }
+
+        return () => {
+            document.removeEventListener('keydown', trapFocus);
+        };
+    }, [isActive]);
+
+    return <div>{children}</div>;
+};
+
+FocusTrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+    isActive: PropTypes.bool.isRequired,
+    trappedElId: PropTypes.string.isRequired
+};
+
+export default FocusTrapper;

--- a/client/components/common/FocusTrapper/index.jsx
+++ b/client/components/common/FocusTrapper/index.jsx
@@ -58,6 +58,8 @@ const FocusTrapper = ({ children, isActive, trappedElId }) => {
         if (isActive) {
             updateFocusableElements();
             document.addEventListener('keydown', trapFocus);
+        } else {
+            document.removeEventListener('keydown', trapFocus);
         }
 
         return () => {

--- a/client/tests/FocusTrapper.test.jsx
+++ b/client/tests/FocusTrapper.test.jsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import FocusTrapper from '../components/common/FocusTrapper';
+
+describe('FocusTrapper', () => {
+    let trappedDiv;
+
+    beforeEach(() => {
+        trappedDiv = document.createElement('div');
+        trappedDiv.id = 'trapped-div';
+        document.body.appendChild(trappedDiv);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(trappedDiv);
+    });
+
+    const renderEls = async () => {
+        return render(
+            <FocusTrapper isActive={true} trappedElId="trapped-div">
+                <button>Click Me</button>
+                <a href="www">Link</a>
+            </FocusTrapper>,
+            { container: document.body.appendChild(trappedDiv) }
+        );
+    };
+
+    it('should identify focusable elements', async () => {
+        await renderEls();
+
+        const focusables = trappedDiv.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+
+        // Two original focusable elements plus 2 for before and after trap
+        expect(focusables.length).toBe(4);
+    });
+
+    it('should trap focus and allow forward navigation when isActive is true', async () => {
+        await renderEls();
+
+        const container = document.getElementById('trapped-div');
+
+        const firstFocusable = container.querySelector('button');
+        const lastFocusable = container.querySelector('a');
+
+        act(() => {
+            lastFocusable.focus();
+        });
+
+        act(() => {
+            fireEvent.keyDown(container, {
+                key: 'Tab',
+                code: 9,
+                shiftKey: false
+            });
+        });
+
+        expect(document.activeElement).toBe(firstFocusable);
+    });
+
+    it('should trap focus when and allow backward navigation when isActive is true', async () => {
+        await renderEls();
+
+        const container = document.getElementById('trapped-div');
+
+        const firstFocusable = container.querySelector('button');
+        const lastFocusable = container.querySelector('a');
+
+        act(() => {
+            firstFocusable.focus();
+        });
+
+        act(() => {
+            fireEvent.keyDown(container, {
+                key: 'Tab',
+                code: 9,
+                shiftKey: true
+            });
+        });
+
+        expect(document.activeElement).toBe(lastFocusable);
+    });
+
+    it('should not trap focus when isActive is false', async () => {
+        const { container } = render(
+            <FocusTrapper isActive={false} trappedElId="trapped-div">
+                <button>Click Me</button>
+                <input type="text" />
+            </FocusTrapper>,
+            { container: document.body.appendChild(trappedDiv) }
+        );
+
+        const firstFocusable = container.querySelector('button');
+        const lastFocusable = container.querySelector('input');
+
+        act(() => {
+            firstFocusable.focus();
+        });
+
+        act(() => {
+            fireEvent.keyDown(container, {
+                key: 'Tab',
+                code: 9,
+                shiftKey: true
+            });
+        });
+
+        expect(document.activeElement).not.toBe(lastFocusable);
+    });
+});


### PR DESCRIPTION
### Overview

This PR adds a `FocusTrapper` component that traps focus in children regardless of whether those children are rendered in a portal. This component side steps browser restrictions on modifying focus during events that would lead to browser interface elements becoming focused. It does this by adding focusable divs before and after the child element. Focus events that would lead to focusing on the barrier divs are used to wrap the focus around to the correct focusable element within the child.

This component is added directly into the `BasicModal` component that extends the React Bootstrap modal component.

Unit tests are added for `FocusTrapper`.

### Problems addressed

- From #757 
  - [x] Focus is initially placed on the dialog.
  - [x] You can't tab backward through the dialog.
  - [x] Tab is not fully trapped; it leaves the dialog and goes into browser chrome, e.g., address bar.
- From #785 
  - [x] Accessibility issue: Like several of the other dialogs, the tab sequence is broken. Tabbing from the save button should move focus to the date input. Back tabbing from the date input should move focus to the save button. 

### Testing

Since this modifies a common component, the potential for side effects are substantial with this PR. I have done a pass of testing for all of the instances of `BasicModal` use listed below. In all instances focus wrapped to interactive elements as expected. I'd greatly appreciate any additional testing during review.

- [x] TestPlanReportStatusDialog
- [x] 'Are you sure you want to exit?' Test Plan Run
- [x] Candidate Review Completion Date Edit Dialog
- [x] UpdateTargetDateModal
- [x] Advancing Test Plan Dialog
- [x] UpdateVersionModal
- [x]  "Start Over?" Dialog

closes #805
closes #757 
partially addresses #785 