### PR TITLE
Hide advance button when cannot advance

### DIFF
--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -212,13 +212,6 @@ const DataManagementRow = ({
     }, [testPlanVersions]);
 
     const completedRequiredReports = testPlanVersion => {
-        // if (
-        //     testPlanVersion.title ===
-        //     'Action Menu Button Example Using element.focus()'
-        // ) {
-        //     debugger;
-        // }
-
         const reportAtBrowsers = testPlanVersion.testPlanReports
             .filter(testPlanReport => testPlanReport.isFinal)
             .map(report => {

--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -21,7 +21,7 @@ import ReportStatusDot from '../../common/ReportStatusDot';
 import UpdateTargetDateModal from '@components/common/UpdateTargetDateModal';
 import VersionString from '../../common/VersionString';
 import PhasePill from '../../common/PhasePill';
-import { uniq as unique, uniqBy as uniqueBy } from 'lodash';
+import { differenceBy, uniq as unique, uniqBy as uniqueBy } from 'lodash';
 import { getVersionData } from '../utils';
 
 const StatusCell = styled.div`
@@ -210,6 +210,46 @@ const DataManagementRow = ({
             testPlanVersions.filter(({ phase }) => phase === 'RECOMMENDED')
         );
     }, [testPlanVersions]);
+
+    const completedRequiredReports = testPlanVersion => {
+        // if (
+        //     testPlanVersion.title ===
+        //     'Action Menu Button Example Using element.focus()'
+        // ) {
+        //     debugger;
+        // }
+
+        const reportAtBrowsers = testPlanVersion.testPlanReports
+            .filter(testPlanReport => testPlanReport.isFinal)
+            .map(report => {
+                return [report.at.id, report.browser.id];
+            });
+
+        let browsersKey;
+        if (testPlanVersion.phase === 'DRAFT') {
+            browsersKey = 'candidateBrowsers';
+        } else if (testPlanVersion.phase === 'CANDIDATE') {
+            browsersKey = 'recommendedBrowsers';
+        } else {
+            throw new Error('Unexpected case');
+        }
+
+        let requiredAtBrowsers = [];
+        ats.forEach(at => {
+            const browsers = at[browsersKey];
+            browsers.forEach(browser => {
+                requiredAtBrowsers.push([at.id, browser.id]);
+            });
+        });
+
+        const missingReports = differenceBy(
+            requiredAtBrowsers,
+            reportAtBrowsers,
+            (atId, browserId) => `${atId},${browserId}`
+        );
+
+        return missingReports.length === 0;
+    };
 
     const handleClickUpdateTestPlanVersionPhase = async (
         testPlanVersionId,
@@ -642,6 +682,7 @@ const DataManagementRow = ({
 
                     // Phase is "active"
                     insertActivePhaseForTestPlan(latestVersion);
+
                     return (
                         <PhaseCell role="list" aria-setsize={isAdmin ? 3 : 2}>
                             <VersionString
@@ -652,32 +693,35 @@ const DataManagementRow = ({
                             >
                                 {latestVersion.versionString}
                             </VersionString>
-                            {isAdmin && (
-                                <Button
-                                    ref={ref => setFocusRef(ref)}
-                                    className="advance-button"
-                                    variant="secondary"
-                                    onClick={async () => {
-                                        setShowAdvanceModal(true);
-                                        setAdvanceModalData({
-                                            phase: derivePhaseName('CANDIDATE'),
-                                            version:
-                                                latestVersion.versionString,
-                                            advanceFunc: () => {
-                                                setShowAdvanceModal(false);
-                                                handleClickUpdateTestPlanVersionPhase(
-                                                    latestVersion.id,
-                                                    'CANDIDATE',
-                                                    testPlanVersionDataToInclude
-                                                );
-                                            },
-                                            coveredReports
-                                        });
-                                    }}
-                                >
-                                    Advance to Candidate
-                                </Button>
-                            )}
+                            {isAdmin &&
+                                completedRequiredReports(latestVersion) && (
+                                    <Button
+                                        ref={ref => setFocusRef(ref)}
+                                        className="advance-button"
+                                        variant="secondary"
+                                        onClick={async () => {
+                                            setShowAdvanceModal(true);
+                                            setAdvanceModalData({
+                                                phase: derivePhaseName(
+                                                    'CANDIDATE'
+                                                ),
+                                                version:
+                                                    latestVersion.versionString,
+                                                advanceFunc: () => {
+                                                    setShowAdvanceModal(false);
+                                                    handleClickUpdateTestPlanVersionPhase(
+                                                        latestVersion.id,
+                                                        'CANDIDATE',
+                                                        testPlanVersionDataToInclude
+                                                    );
+                                                },
+                                                coveredReports
+                                            });
+                                        }}
+                                    >
+                                        Advance to Candidate
+                                    </Button>
+                                )}
                             <span role="listitem">
                                 <TestPlanReportStatusDialogWithButton
                                     testPlanVersionId={latestVersion.id}
@@ -830,6 +874,7 @@ const DataManagementRow = ({
                     const DAYS_TO_PROVIDE_FEEDBACK = 120;
                     const shouldShowAdvanceButton =
                         isAdmin &&
+                        completedRequiredReports(latestVersion) &&
                         issuesCount === 0 &&
                         (recommendedTestPlanVersions.length ||
                             (!recommendedTestPlanVersions.length &&

--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -15,6 +15,12 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
                 name
                 releasedAt
             }
+            candidateBrowsers {
+                id
+            }
+            recommendedBrowsers {
+                id
+            }
         }
         browsers {
             id
@@ -43,6 +49,7 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
             testPlanReports {
                 id
                 metrics
+                isFinal
                 markedFinalAt
                 at {
                     id

--- a/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
@@ -38,7 +38,9 @@ export default (
                                 name: '2021.2111.13',
                                 releasedAt: '2021-11-01T04:00:00.000Z'
                             }
-                        ]
+                        ],
+                        candidateBrowsers: [{ id: '2' }],
+                        recommendedBrowsers: [{ id: '1' }, { id: '2' }]
                     },
                     {
                         id: '2',
@@ -49,7 +51,9 @@ export default (
                                 name: '2020.4',
                                 releasedAt: '2021-02-19T05:00:00.000Z'
                             }
-                        ]
+                        ],
+                        candidateBrowsers: [{ id: '2' }],
+                        recommendedBrowsers: [{ id: '1' }, { id: '2' }]
                     },
                     {
                         id: '3',
@@ -60,7 +64,9 @@ export default (
                                 name: '11.6 (20G165)',
                                 releasedAt: '2019-09-01T04:00:00.000Z'
                             }
-                        ]
+                        ],
+                        candidateBrowsers: [{ id: '3' }],
+                        recommendedBrowsers: [{ id: '2' }, { id: '3' }]
                     }
                 ],
                 browsers: [
@@ -366,6 +372,7 @@ export default (
                                 id: '7',
                                 metrics: {},
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '3',
                                     name: 'VoiceOver for macOS'
@@ -525,6 +532,7 @@ export default (
                                     requiredAssertionsPassedCount: 28
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '1',
                                     name: 'JAWS'
@@ -1009,6 +1017,7 @@ export default (
                                     requiredAssertionsPassedCount: 48
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '2',
                                     name: 'NVDA'
@@ -1340,6 +1349,7 @@ export default (
                                     requiredAssertionsPassedCount: 44
                                 },
                                 markedFinalAt: '2022-07-06T00:00:00.000Z',
+                                isFinal: true,
                                 at: {
                                     id: '3',
                                     name: 'VoiceOver for macOS'
@@ -1488,6 +1498,7 @@ export default (
                                     requiredAssertionsPassedCount: 25
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '1',
                                     name: 'JAWS'
@@ -1576,6 +1587,7 @@ export default (
                                     requiredAssertionsPassedCount: 25
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '2',
                                     name: 'NVDA'
@@ -1683,6 +1695,7 @@ export default (
                                     requiredAssertionsPassedCount: 14
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '3',
                                     name: 'VoiceOver for macOS'
@@ -1771,6 +1784,7 @@ export default (
                                     requiredAssertionsPassedCount: 16
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '2',
                                     name: 'NVDA'
@@ -1859,6 +1873,7 @@ export default (
                                     requiredAssertionsPassedCount: 14
                                 },
                                 markedFinalAt: '2022-07-06T00:00:00.000Z',
+                                isFinal: true,
                                 at: {
                                     id: '1',
                                     name: 'JAWS'
@@ -1977,6 +1992,7 @@ export default (
                                     requiredAssertionsPassedCount: 14
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '3',
                                     name: 'VoiceOver for macOS'
@@ -2065,6 +2081,7 @@ export default (
                                     requiredAssertionsPassedCount: 20
                                 },
                                 markedFinalAt: '2022-07-06T00:00:00.000Z',
+                                isFinal: true,
                                 at: {
                                     id: '2',
                                     name: 'NVDA'
@@ -2213,6 +2230,7 @@ export default (
                                     requiredAssertionsPassedCount: 23
                                 },
                                 markedFinalAt: '2022-07-06T00:00:00.000Z',
+                                isFinal: true,
                                 at: {
                                     id: '3',
                                     name: 'VoiceOver for macOS'
@@ -2346,6 +2364,7 @@ export default (
                                     requiredAssertionsPassedCount: 16
                                 },
                                 markedFinalAt: null,
+                                isFinal: false,
                                 at: {
                                     id: '1',
                                     name: 'JAWS'
@@ -2447,6 +2466,7 @@ export default (
                             id: '7',
                             metrics: {},
                             markedFinalAt: null,
+                            isFinal: false,
                             at: {
                                 id: '3',
                                 name: 'VoiceOver for macOS'
@@ -2506,6 +2526,7 @@ export default (
                                 requiredAssertionsPassedCount: 44
                             },
                             markedFinalAt: '2022-07-06T00:00:00.000Z',
+                            isFinal: true,
                             at: {
                                 id: '3',
                                 name: 'VoiceOver for macOS'
@@ -2654,6 +2675,7 @@ export default (
                                 requiredAssertionsPassedCount: 25
                             },
                             markedFinalAt: '2022-07-06T00:00:00.000Z',
+                            isFinal: true,
                             at: {
                                 id: '1',
                                 name: 'JAWS'
@@ -2742,6 +2764,7 @@ export default (
                                 requiredAssertionsPassedCount: 25
                             },
                             markedFinalAt: '2022-07-07T00:00:00.000Z',
+                            isFinal: true,
                             at: {
                                 id: '2',
                                 name: 'NVDA'
@@ -2858,6 +2881,7 @@ export default (
                                 requiredAssertionsPassedCount: 48
                             },
                             markedFinalAt: null,
+                            isFinal: false,
                             at: {
                                 id: '2',
                                 name: 'NVDA'
@@ -3162,6 +3186,7 @@ export default (
                                 requiredAssertionsPassedCount: 14
                             },
                             markedFinalAt: null,
+                            isFinal: false,
                             at: {
                                 id: '3',
                                 name: 'VoiceOver for macOS'
@@ -3250,6 +3275,7 @@ export default (
                                 requiredAssertionsPassedCount: 16
                             },
                             markedFinalAt: null,
+                            isFinal: false,
                             at: {
                                 id: '2',
                                 name: 'NVDA'
@@ -3338,6 +3364,7 @@ export default (
                                 requiredAssertionsPassedCount: 14
                             },
                             markedFinalAt: '2022-07-06T00:00:00.000Z',
+                            isFinal: true,
                             at: {
                                 id: '1',
                                 name: 'JAWS'
@@ -3456,6 +3483,7 @@ export default (
                                 requiredAssertionsPassedCount: 14
                             },
                             markedFinalAt: null,
+                            isFinal: false,
                             at: {
                                 id: '3',
                                 name: 'VoiceOver for macOS'
@@ -3544,6 +3572,7 @@ export default (
                                 requiredAssertionsPassedCount: 20
                             },
                             markedFinalAt: '2022-07-06T00:00:00.000Z',
+                            isFinal: true,
                             at: {
                                 id: '2',
                                 name: 'NVDA'
@@ -3692,6 +3721,7 @@ export default (
                                 requiredAssertionsPassedCount: 23
                             },
                             markedFinalAt: '2022-07-06T00:00:00.000Z',
+                            isFinal: true,
                             at: {
                                 id: '3',
                                 name: 'VoiceOver for macOS'
@@ -3825,6 +3855,7 @@ export default (
                                 requiredAssertionsPassedCount: 16
                             },
                             markedFinalAt: null,
+                            isFinal: false,
                             at: {
                                 id: '1',
                                 name: 'JAWS'
@@ -3941,6 +3972,7 @@ export default (
                                 requiredAssertionsPassedCount: 28
                             },
                             markedFinalAt: null,
+                            isFinal: false,
                             at: {
                                 id: '1',
                                 name: 'JAWS'


### PR DESCRIPTION
See https://github.com/w3c/aria-at-app/issues/784 and https://github.com/w3c/aria-at-app/issues/798.

Fixes an issue that the "Advance to Candidate" and "Advance to Recommended" buttons show on the Data Management page even when the required reports have not yet been collected.