### PR TITLE
Use pathToFileURL to support windows drive letter paths

### DIFF
--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const { Client } = require('pg');
 const fse = require('fs-extra');
+const { pathToFileURL } = require('url');
 const spawn = require('cross-spawn');
 const { At } = require('../../models');
 const {
@@ -267,8 +268,7 @@ const readCsv = ({ sourceDirectoryPath }) => {
 };
 
 const updateCommandsJson = async () => {
-    const keysMjsPath = path.join(testsDirectory, 'resources', 'keys.mjs');
-
+    const keysMjsPath = pathToFileURL(path.join(testsDirectory, 'resources', 'keys.mjs'));
     const commands = Object.entries(await import(keysMjsPath)).map(
         ([id, text]) => ({ id, text })
     );


### PR DESCRIPTION
Received this error trying to set the project up on windows:

```
Error found: Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'f:'
```

The `import()` line here was using `f:\\code\\aria-at\\aria-at-app` etc as a path (which is correct on windows) but requires this `url.pathToFileURL()` to be used for the `import(url)` statement or the `f:` gets processed as a url scheme for the import()