### PR TITLE
Fix H1 title for test plan review page

### DIFF
--- a/server/apps/test-review.js
+++ b/server/apps/test-review.js
@@ -347,7 +347,6 @@ app.get('/:commit/:pattern', async (req, res) => {
     const pattern = req.params.pattern;
     const testPlan = await getTestPlanById(pattern);
     const testPlanTitle = testPlan.title;
-    //  console.log("New Log", testPlan.title);
 
     const { commitDate, commitMessage } = await getCommitInfo(commit);
     const { tests, scripts: setupScripts } = await generateTests(

--- a/server/apps/test-review.js
+++ b/server/apps/test-review.js
@@ -346,7 +346,7 @@ app.get('/:commit/:pattern', async (req, res) => {
     const commit = req.params.commit;
     const pattern = req.params.pattern;
     const testPlan = await getTestPlanById(pattern);
-    const testPlanVersionTitle = testPlan.title;
+    const testPlanTitle = testPlan.title;
     //  console.log("New Log", testPlan.title);
 
     const { commitDate, commitMessage } = await getCommitInfo(commit);
@@ -362,7 +362,7 @@ app.get('/:commit/:pattern', async (req, res) => {
             ats,
             tests,
             pattern,
-            testPlanVersionTitle,
+            testPlanTitle,
             setupScripts,
             commitMessage: convertTextToHTML(commitMessage),
             commitDate: moment(commitDate).format('YYYY.MM.DD')

--- a/server/apps/test-review.js
+++ b/server/apps/test-review.js
@@ -11,6 +11,9 @@ const {
 const {
     createCommandTuplesATModeTaskLookup
 } = require('../handlebars/test-review/scripts/command-tuples-at-mode-task-lookup');
+const {
+    getTestPlanById
+} = require('../models/services/TestPlanVersionService');
 
 const app = express();
 
@@ -342,6 +345,9 @@ const generateTests = async (pattern, commit, commitDate) => {
 app.get('/:commit/:pattern', async (req, res) => {
     const commit = req.params.commit;
     const pattern = req.params.pattern;
+    const testPlan = await getTestPlanById(pattern);
+    const testPlanVersionTitle = testPlan.title;
+    //  console.log("New Log", testPlan.title);
 
     const { commitDate, commitMessage } = await getCommitInfo(commit);
     const { tests, scripts: setupScripts } = await generateTests(
@@ -356,6 +362,7 @@ app.get('/:commit/:pattern', async (req, res) => {
             ats,
             tests,
             pattern,
+            testPlanVersionTitle,
             setupScripts,
             commitMessage: convertTextToHTML(commitMessage),
             commitDate: moment(commitDate).format('YYYY.MM.DD')

--- a/server/handlebars/test-review/views/main.hbs
+++ b/server/handlebars/test-review/views/main.hbs
@@ -112,7 +112,7 @@
 </head>
 <body>
 
-<h1>Test plan review for pattern: {{pattern}} ({{arrayLength tests}} tests)</h1>
+<h1>Review Test Plan for {{testPlanVersionTitle}} ({{arrayLength tests}} tests)</h1>
 <h2>Version created on: {{commitDate}}</h2>
 <p class="commit-message"><b>Summary of commit:</b></p>
 {{{commitMessage}}}

--- a/server/handlebars/test-review/views/main.hbs
+++ b/server/handlebars/test-review/views/main.hbs
@@ -112,7 +112,7 @@
 </head>
 <body>
 
-<h1>Review Test Plan for {{testPlanVersionTitle}} ({{arrayLength tests}} tests)</h1>
+<h1>Review Test Plan for {{testPlanTitle}} ({{arrayLength tests}} tests)</h1>
 <h2>Version created on: {{commitDate}}</h2>
 <p class="commit-message"><b>Summary of commit:</b></p>
 {{{commitMessage}}}


### PR DESCRIPTION
see issue #789 

This pull request changes the H1 value in the test plan review page from the name of the test plan directory to the actual title of the the test plan.