### PR TITLE
Add metadata to test plan report and test plan version pages

### DIFF
--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -150,7 +150,7 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
             <h2>Metadata</h2>
             <ul>
                 <li>
-                    Generated from {/* section: */}
+                    Generated from
                     <a
                         href={`/test-review/${testPlanVersion.gitSha}/${testPlanVersion.testPlan.directory}`}
                         target="_blank"
@@ -161,7 +161,6 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
                     </a>
                 </li>
                 <li>
-                    {/* Report completed on {testPlanReport.markedFinalAt} */}
                     Report completed on{' '}
                     {convertDateToString(
                         new Date(testPlanReport.markedFinalAt),

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -82,13 +82,13 @@ const getTestersRunHistory = (
 };
 
 const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
+    const { exampleUrl, designPatternUrl } = testPlanVersion.metadata;
     const location = useLocation();
     const { testPlanReportId } = useParams();
 
     const testPlanReport = testPlanReports.find(
         each => each.id == testPlanReportId
     );
-
     if (!testPlanReport) return <Navigate to="/404" />;
 
     const { at, browser } = testPlanReport;
@@ -105,7 +105,6 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
         testPlanReport.finalizedTestResults,
         testOrTestResult => testOrTestResult.test?.id ?? testOrTestResult.id
     );
-
     return (
         <Container id="main" as="main" tabIndex="-1">
             <Helmet>
@@ -148,6 +147,46 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
                 assertions. The open test button next to each test allows you to
                 preview the test in your browser.
             </p>
+            <h2>Metadata</h2>
+            <ul>
+                <li>
+                    Generated from {/* section: */}
+                    <a
+                        href={`/test-review/${testPlanVersion.gitSha}/${testPlanVersion.testPlan.directory}`}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        {testPlanVersion.versionString} of{' '}
+                        {testPlanVersion.title} Test Plan
+                    </a>
+                </li>
+                <li>
+                    {/* Report completed on {testPlanReport.markedFinalAt} */}
+                    Report completed on{' '}
+                    {convertDateToString(
+                        new Date(testPlanReport.markedFinalAt),
+                        'MMMM D, YYYY'
+                    )}
+                </li>
+                {exampleUrl ? (
+                    <li>
+                        <a href={exampleUrl} target="_blank" rel="noreferrer">
+                            Example Under Test
+                        </a>
+                    </li>
+                ) : null}
+                {designPatternUrl ? (
+                    <li>
+                        <a
+                            href={designPatternUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Design Pattern
+                        </a>
+                    </li>
+                ) : null}
+            </ul>
             {testPlanReport.finalizedTestResults.map(testResult => {
                 const test = testResult.test;
 

--- a/client/components/Reports/SummarizeTestPlanVersion.jsx
+++ b/client/components/Reports/SummarizeTestPlanVersion.jsx
@@ -11,6 +11,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/free-solid-svg-icons';
 import styled from '@emotion/styled';
 import DisclaimerInfo from '../DisclaimerInfo';
+import { convertDateToString } from '../../utils/formatter';
 
 const FullHeightContainer = styled(Container)`
     min-height: calc(100vh - 64px);
@@ -52,6 +53,17 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
             </p>
             <h2>Metadata</h2>
             <ul>
+                <li>
+                    Generated from {/* section: */}
+                    <a
+                        href={`/test-review/${testPlanVersion.gitSha}/${testPlanVersion.testPlan.directory}`}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        {testPlanVersion.versionString} of{' '}
+                        {testPlanVersion.title} Test Plan
+                    </a>
+                </li>
                 {exampleUrl ? (
                     <li>
                         <a href={exampleUrl} target="_blank" rel="noreferrer">
@@ -94,6 +106,14 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
                 return (
                     <Fragment key={testPlanReport.id}>
                         <h2>{getTestPlanTargetTitle(testPlanTarget)}</h2>
+                        <p>
+                            {/* Report completed on {testPlanReport.markedFinalAt} */}
+                            Report completed on{' '}
+                            {convertDateToString(
+                                new Date(testPlanReport.markedFinalAt),
+                                'MMMM D, YYYY'
+                            )}
+                        </p>
                         <DisclaimerInfo phase={testPlanVersion.phase} />
                         <LinkContainer
                             to={
@@ -187,7 +207,15 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
 };
 
 SummarizeTestPlanVersion.propTypes = {
+    // gitSha
+    // testPlan
+    // directory
+    // versionString
     testPlanVersion: PropTypes.shape({
+        gitSha: PropTypes.string,
+        testPlan: PropTypes.string,
+        directory: PropTypes.string,
+        versionString: PropTypes.string,
         id: PropTypes.string.isRequired,
         title: PropTypes.string,
         phase: PropTypes.string,

--- a/client/components/Reports/SummarizeTestPlanVersion.jsx
+++ b/client/components/Reports/SummarizeTestPlanVersion.jsx
@@ -54,7 +54,7 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
             <h2>Metadata</h2>
             <ul>
                 <li>
-                    Generated from {/* section: */}
+                    Generated from
                     <a
                         href={`/test-review/${testPlanVersion.gitSha}/${testPlanVersion.testPlan.directory}`}
                         target="_blank"
@@ -107,7 +107,6 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
                     <Fragment key={testPlanReport.id}>
                         <h2>{getTestPlanTargetTitle(testPlanTarget)}</h2>
                         <p>
-                            {/* Report completed on {testPlanReport.markedFinalAt} */}
                             Report completed on{' '}
                             {convertDateToString(
                                 new Date(testPlanReport.markedFinalAt),
@@ -207,10 +206,6 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
 };
 
 SummarizeTestPlanVersion.propTypes = {
-    // gitSha
-    // testPlan
-    // directory
-    // versionString
     testPlanVersion: PropTypes.shape({
         gitSha: PropTypes.string,
         testPlan: PropTypes.string,

--- a/client/components/Reports/queries.js
+++ b/client/components/Reports/queries.js
@@ -43,6 +43,7 @@ export const REPORT_PAGE_QUERY = gql`
             testPlanReports(isFinal: true) {
                 id
                 metrics
+                markedFinalAt
                 at {
                     id
                     name

--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -268,7 +268,9 @@ const readCsv = ({ sourceDirectoryPath }) => {
 };
 
 const updateCommandsJson = async () => {
-    const keysMjsPath = pathToFileURL(path.join(testsDirectory, 'resources', 'keys.mjs'));
+    const keysMjsPath = pathToFileURL(
+        path.join(testsDirectory, 'resources', 'keys.mjs')
+    );
     const commands = Object.entries(await import(keysMjsPath)).map(
         ([id, text]) => ({ id, text })
     );


### PR DESCRIPTION
see issue #803 

This pull request adds a metadata section to the report details page and adds a link to the test plan review pages on the report summary page. Both the report details page and report summary page get a link to the test plan review pages and the date of completion for the test plan report in question.