### PR TITLE
git attributes file for windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.css text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.jsx text eol=lf
+*.sql text eol=lf


### PR DESCRIPTION
A bunch of the tooling is expecting these files to have LF endings which results in giant diffs which aren't actually changes when you commit on windows unless you tell git to specifically use LF on checkout.