### PR TITLE
Force IPv4 for internal HTTP requests

### DIFF
--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -24,7 +24,7 @@ const axiosConfig = {
         'x-automation-secret': process.env.AUTOMATION_SCHEDULER_SECRET
     },
     timeout: 1000,
-    httpAgent,
+    httpAgent
 };
 
 const throwNoJobFoundError = jobId => {

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -16,12 +16,15 @@ const populateData = require('../services/PopulatedData/populateData');
 const {
     getFinalizedTestResults
 } = require('../models/services/TestResultReadService');
+const http = require('http');
+const httpAgent = new http.Agent({ family: 4 });
 
 const axiosConfig = {
     headers: {
         'x-automation-secret': process.env.AUTOMATION_SCHEDULER_SECRET
     },
-    timeout: 1000
+    timeout: 1000,
+    httpAgent,
 };
 
 const throwNoJobFoundError = jobId => {
@@ -240,5 +243,6 @@ module.exports = {
     cancelJob,
     getJobLog,
     updateJobStatus,
-    updateJobResults
+    updateJobResults,
+    axiosConfig
 };

--- a/server/tests/util/mock-automation-scheduler-server.js
+++ b/server/tests/util/mock-automation-scheduler-server.js
@@ -7,6 +7,7 @@ const { COLLECTION_JOB_STATUS } = require('../../util/enums');
 const { default: axios } = require('axios');
 const { gql } = require('apollo-server-core');
 const { query } = require('../util/graphql-test-utilities');
+const { axiosConfig } = require('../../controllers/AutomationController');
 
 const setupMockAutomationSchedulerServer = async () => {
     const app = express();
@@ -28,13 +29,7 @@ const setupMockAutomationSchedulerServer = async () => {
             {
                 status: newStatus
             },
-            {
-                headers: {
-                    'x-automation-secret':
-                        process.env.AUTOMATION_SCHEDULER_SECRET
-                },
-                timeout: 1000
-            }
+            axiosConfig
         );
     };
 
@@ -64,13 +59,7 @@ const setupMockAutomationSchedulerServer = async () => {
             await axios.post(
                 `${process.env.APP_SERVER}/api/jobs/${jobId}/result`,
                 testResult,
-                {
-                    headers: {
-                        'x-automation-secret':
-                            process.env.AUTOMATION_SCHEDULER_SECRET
-                    },
-                    timeout: 1000
-                }
+                axiosConfig
             );
         } catch (e) {
             // Likely just means the test was cancelled


### PR DESCRIPTION
The backend localhost server only listens on IPv4, force the http agent from axios to use that when communicating with it's own backend via http.

Without this change, a computer that has the IPv6 address for localhost "first" in the hosts file will experience a hard crash when testing the bot workflows