### PR TITLE
No longer mark test plan reports with skipped tests as final

### DIFF
--- a/client/components/Reports/Reports.css
+++ b/client/components/Reports/Reports.css
@@ -56,36 +56,6 @@
     margin-top: 1em;
 }
 
-.skipped-tests-heading {
-    background: #fefbea;
-    padding: 1.75em 1.75em 1em 1.75em;
-    border: 1px solid #eddfbe;
-    border-bottom: 0;
-    margin-top: 2em;
-}
-
-.skipped-tests {
-    columns: 2;
-    line-height: 2;
-    border: 1px solid #eddfbe;
-    padding: 1.5em 3em;
-    background: #fdfcf6;
-}
-
-.skipped-tests li {
-    margin-bottom: 0.5em;
-    border-bottom: 1px solid #eddfbe;
-    padding-bottom: 0.5em;
-    margin-right: 3em;
-    -webkit-column-break-inside: avoid;
-    page-break-inside: avoid;
-    break-inside: avoid;
-}
-
-.skipped-tests li:last-child {
-    border-bottom: none;
-}
-
 .test-result-heading {
     display: flex;
     justify-content: space-between;
@@ -100,7 +70,6 @@
     margin-bottom: 0;
 }
 
-.skipped-tests-heading h2,
 .test-result-heading h2 {
     margin-top: 0;
 }

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -10,7 +10,6 @@ import {
     faExternalLinkAlt,
     faHome
 } from '@fortawesome/free-solid-svg-icons';
-import { differenceBy } from 'lodash';
 import { convertDateToString } from '../../utils/formatter';
 import DisclaimerInfo from '../DisclaimerInfo';
 import TestPlanResultsTable from '../common/TestPlanResultsTable';
@@ -99,12 +98,6 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
         at,
         browser
     };
-
-    const skippedTests = differenceBy(
-        testPlanReport.runnableTests,
-        testPlanReport.finalizedTestResults,
-        testOrTestResult => testOrTestResult.test?.id ?? testOrTestResult.id
-    );
 
     return (
         <Container id="main" as="main" tabIndex="-1">
@@ -231,26 +224,6 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
                     </Fragment>
                 );
             })}
-            {skippedTests.length ? (
-                <Fragment>
-                    <div className="skipped-tests-heading">
-                        <h2 id="skipped-tests" tabIndex="-1">
-                            Skipped Tests
-                        </h2>
-                        <p>
-                            The following tests have been skipped in this test
-                            run:
-                        </p>
-                    </div>
-                    <ol className="skipped-tests">
-                        {skippedTests.map(test => (
-                            <li key={test.id}>
-                                <a href={test.renderedUrl}>{test.title}</a>
-                            </li>
-                        ))}
-                    </ol>
-                </Fragment>
-            ) : null}
         </Container>
     );
 };

--- a/client/components/Reports/SummarizeTestPlanVersion.jsx
+++ b/client/components/Reports/SummarizeTestPlanVersion.jsx
@@ -1,7 +1,6 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import { differenceBy } from 'lodash';
 import getMetrics from './getMetrics';
 import { getTestPlanTargetTitle, getTestPlanVersionTitle } from './getTitles';
 import { Breadcrumb, Button, Container, Table } from 'react-bootstrap';
@@ -74,12 +73,6 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
 
             {testPlanReports.map(testPlanReport => {
                 if (testPlanReport.status === 'DRAFT') return null;
-                const skippedTests = differenceBy(
-                    testPlanReport.runnableTests,
-                    testPlanReport.finalizedTestResults,
-                    testOrTestResult =>
-                        testOrTestResult.test?.id ?? testOrTestResult.id
-                );
                 const overallMetrics = getMetrics({ testPlanReport });
 
                 const { at, browser } = testPlanReport;
@@ -105,17 +98,6 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
                                 View Complete Results
                             </Button>
                         </LinkContainer>
-                        {skippedTests.length ? (
-                            <Link
-                                to={
-                                    `/report/${testPlanVersion.id}` +
-                                    `/targets/${testPlanReport.id}` +
-                                    `#skipped-tests`
-                                }
-                            >
-                                {skippedTests.length} Tests Were Skipped
-                            </Link>
-                        ) : null}
                         <Table
                             className="mt-3"
                             bordered

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -61,11 +61,6 @@ export const TEST_QUEUE_PAGE_QUERY = gql`
                 id
                 name
             }
-            runnableTests {
-                id
-                title
-                renderedUrl
-            }
             testPlanVersion {
                 id
                 title

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -49,6 +49,11 @@ export const TEST_QUEUE_PAGE_QUERY = gql`
                 id
                 name
             }
+            runnableTests {
+                id
+                title
+                renderedUrl
+            }
             testPlanVersion {
                 id
                 title

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -414,9 +414,9 @@ const TestQueueRow = ({
             'completed'
         ].join('-');
 
-    const completedAllTests = !testPlanReport.draftTestPlanRuns.find(
+    const completedAllTests = testPlanReport.draftTestPlanRuns.every(
         testPlanRun =>
-            testPlanRun.testResultsLength !== testPlanReport.runnableTestsLength
+            testPlanRun.testResultsLength === testPlanReport.runnableTestsLength
     );
 
     return (

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -23,7 +23,6 @@ import TestPlanUpdaterModal from '../TestPlanUpdater/TestPlanUpdaterModal';
 import BasicThemedModal from '../common/BasicThemedModal';
 import { LoadingStatus, useTriggerLoad } from '../common/LoadingStatus';
 import './TestQueueRow.css';
-import { differenceBy } from 'lodash';
 
 const TestQueueRow = ({
     user = {},

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -416,8 +416,7 @@ const TestQueueRow = ({
 
     const completedAllTests = !testPlanReport.draftTestPlanRuns.find(
         testPlanRun =>
-            testPlanRun.testResultsLength !==
-            testPlanReport.runnableTests.length
+            testPlanRun.testResultsLength !== testPlanReport.runnableTestsLength
     );
 
     return (

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -23,6 +23,7 @@ import TestPlanUpdaterModal from '../TestPlanUpdater/TestPlanUpdaterModal';
 import BasicThemedModal from '../common/BasicThemedModal';
 import { LoadingStatus, useTriggerLoad } from '../common/LoadingStatus';
 import './TestQueueRow.css';
+import { differenceBy } from 'lodash';
 
 const TestQueueRow = ({
     user = {},
@@ -414,6 +415,12 @@ const TestQueueRow = ({
             'completed'
         ].join('-');
 
+    const completedAllTests = !testPlanReport.draftTestPlanRuns.find(
+        testPlanRun =>
+            testPlanRun.testResultsLength !==
+            testPlanReport.runnableTests.length
+    );
+
     return (
         <LoadingStatus message={loadingMessage}>
             <tr className="test-queue-run-row">
@@ -494,7 +501,8 @@ const TestQueueRow = ({
                             !testPlanReport.conflictsLength &&
                             testPlanReport.draftTestPlanRuns.length &&
                             testPlanReport.draftTestPlanRuns[0]
-                                .testResultsLength ? (
+                                .testResultsLength &&
+                            completedAllTests ? (
                                 <>
                                     <Button
                                         ref={updateTestPlanStatusButtonRef}

--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -135,7 +135,7 @@ button.test-navigator-toggle:focus {
     left: 4px;
 }
 
-.test-name-wrapper.skipped .progress-indicator {
+.test-name-wrapper .progress-indicator {
     background: White;
     border: 2px dashed black;
 }

--- a/server/migrations/20231031162340-verifyNoSkippedTests.js
+++ b/server/migrations/20231031162340-verifyNoSkippedTests.js
@@ -38,13 +38,9 @@ module.exports = {
             });
 
             for (const data of Object.values(dataById)) {
-                let isComplete = true;
-
-                data.runLengths.forEach(runLength => {
-                    if (runLength !== data.runnableTestsLength) {
-                        isComplete = false;
-                    }
-                });
+                const isComplete = data.runLengths.every(
+                    runLength => runLength === data.runnableTestsLength
+                );
                 if (!isComplete) {
                     console.info(`Found incomplete report ${data.id}`); // eslint-disable-line
                     // Since final test plan reports can

--- a/server/migrations/20231031162340-verifyNoSkippedTests.js
+++ b/server/migrations/20231031162340-verifyNoSkippedTests.js
@@ -1,0 +1,67 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface /* , Sequelize */) {
+        return queryInterface.sequelize.transaction(async transaction => {
+            const [rows] = await queryInterface.sequelize.query(
+                `
+                    SELECT
+                        "TestPlanReport".id,
+                        "TestPlanReport"."atId",
+                        "TestPlanRun"."testResults",
+                        "TestPlanVersion".tests
+                    FROM
+                        "TestPlanReport"
+                        INNER JOIN "TestPlanVersion" ON "TestPlanVersion".id = "TestPlanReport"."testPlanVersionId"
+                        INNER JOIN "TestPlanRun" ON "TestPlanReport".id = "TestPlanRun"."testPlanReportId"
+                    WHERE
+                        "TestPlanReport"."markedFinalAt" IS NOT NULL
+                `,
+                { transaction }
+            );
+
+            const dataById = {};
+            rows.forEach(({ id, atId, testResults, tests }) => {
+                if (dataById[id]) {
+                    dataById[id].runLengths.push(testResults.length);
+                } else {
+                    const runnableTestsLength = tests.filter(test =>
+                        test.atIds.includes(atId)
+                    ).length;
+                    dataById[id] = {
+                        id,
+                        runnableTestsLength,
+                        runLengths: [testResults.length]
+                    };
+                }
+            });
+
+            for (const data of Object.values(dataById)) {
+                let isComplete = true;
+
+                data.runLengths.forEach(runLength => {
+                    if (runLength !== data.runnableTestsLength) {
+                        isComplete = false;
+                    }
+                });
+                if (!isComplete) {
+                    console.info(`Found incomplete report ${data.id}`); // eslint-disable-line
+                    // Since final test plan reports can
+                    // no longer have skipped tests, we should
+                    // move them to the test queue where incomplete
+                    // runs are still supported.
+                    await queryInterface.sequelize.query(
+                        `
+                            UPDATE "TestPlanReport" SET "markedFinalAt" = NULL WHERE id = ?
+                        `,
+                        {
+                            replacements: [data.id],
+                            transaction
+                        }
+                    );
+                }
+            }
+        });
+    }
+};

--- a/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
+++ b/server/resolvers/TestPlanReport/finalizedTestResultsResolver.js
@@ -1,31 +1,20 @@
 const testResultsResolver = require('../TestPlanRun/testResultsResolver');
-const deepCustomMerge = require('../../util/deepCustomMerge');
 
-/**
- * Completed test results sourced from all the report's runs. The runs must be
- * merged because each run might have skipped different tests.
- */
 const finalizedTestResultsResolver = async (testPlanReport, _, context) => {
     if (!testPlanReport.testPlanRuns.length) {
         return null;
     }
 
-    let merged = [];
+    // Since conflicts are now resolved, all testPlanRuns are interchangeable.
+    const testPlanRun = testPlanReport.testPlanRuns[0];
 
-    for (let i = 0; i < testPlanReport.testPlanRuns.length; i += 1) {
-        merged = deepCustomMerge(
-            merged,
-            testPlanReport.testPlanRuns[i].testResults.filter(
-                testResult => !!testResult.completedAt
-            ),
-            {
-                identifyArrayItem: item =>
-                    item.testId ?? item.scenarioId ?? item.assertionId
-            }
-        );
-    }
     return testResultsResolver(
-        { testPlanReport, testResults: merged },
+        {
+            testPlanReport,
+            testResults: testPlanRun.testResults.filter(
+                testResult => !!testResult.completedAt
+            )
+        },
         null,
         context
     );

--- a/server/resolvers/TestPlanReportOperations/markAsFinalResolver.js
+++ b/server/resolvers/TestPlanReportOperations/markAsFinalResolver.js
@@ -3,7 +3,7 @@ const {
     getTestPlanReportById,
     updateTestPlanReport
 } = require('../../models/services/TestPlanReportService');
-const finalizedTestResultsResolver = require('../TestPlanReport/finalizedTestResultsResolver');
+const runnableTestsResolver = require('../TestPlanReport/runnableTestsResolver');
 const populateData = require('../../services/PopulatedData/populateData');
 const conflictsResolver = require('../TestPlanReport/conflictsResolver');
 
@@ -27,15 +27,17 @@ const markAsFinalResolver = async (
         );
     }
 
-    const finalizedTestResults = await finalizedTestResultsResolver(
-        testPlanReport,
-        null,
-        context
+    const runnableTests = runnableTestsResolver(testPlanReport);
+
+    const hasIncompleteTestRuns = testPlanReport.testPlanRuns.find(
+        testPlanRun => {
+            return testPlanRun.testResults.length !== runnableTests.length;
+        }
     );
-    if (!finalizedTestResults || !finalizedTestResults.length) {
+
+    if (hasIncompleteTestRuns) {
         throw new Error(
-            'Cannot mark test plan report as final because there are no ' +
-                'completed test results'
+            'Cannot mark test plan report as final because not all testers have completed their test runs.'
         );
     }
 

--- a/server/resolvers/testPlanReportsResolver.js
+++ b/server/resolvers/testPlanReportsResolver.js
@@ -30,8 +30,6 @@ const testPlanReportsResolver = async (
         attributes: testPlanReportAttributes
     } = retrieveAttributes('testPlanReport', TEST_PLAN_REPORT_ATTRIBUTES, info);
 
-    const testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES;
-
     const { attributes: testPlanVersionAttributes } = retrieveAttributes(
         'testPlanVersion',
         TEST_PLAN_VERSION_ATTRIBUTES,
@@ -59,7 +57,7 @@ const testPlanReportsResolver = async (
         null,
         where,
         testPlanReportAttributes,
-        testPlanRunAttributes,
+        TEST_PLAN_RUN_ATTRIBUTES,
         testPlanVersionAttributes,
         null,
         null,

--- a/server/resolvers/testPlanReportsResolver.js
+++ b/server/resolvers/testPlanReportsResolver.js
@@ -30,12 +30,7 @@ const testPlanReportsResolver = async (
         attributes: testPlanReportAttributes
     } = retrieveAttributes('testPlanReport', TEST_PLAN_REPORT_ATTRIBUTES, info);
 
-    const { attributes: testPlanRunAttributes } = retrieveAttributes(
-        'draftTestPlanRuns',
-        TEST_PLAN_RUN_ATTRIBUTES,
-        info,
-        true
-    );
+    const testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES;
 
     const { attributes: testPlanVersionAttributes } = retrieveAttributes(
         'testPlanVersion',

--- a/server/scripts/populate-test-data/index.js
+++ b/server/scripts/populate-test-data/index.js
@@ -64,7 +64,7 @@ const populateTestDatabase = async () => {
 
     await populateFakeTestResults(4, [
         'completeAndPassing',
-        null,
+        'completeAndPassing',
         'completeAndFailingDueToIncorrectAssertions',
         'completeAndFailingDueToNoOutputAssertions',
         'completeAndFailingDueToUnexpectedBehaviors',
@@ -78,7 +78,7 @@ const populateTestDatabase = async () => {
 
     await populateFakeTestResults(5, [
         'completeAndPassing',
-        null,
+        'completeAndPassing',
         'completeAndFailingDueToIncorrectAssertions',
         'completeAndPassing',
         'completeAndFailingDueToNoOutputAssertions',
@@ -89,7 +89,7 @@ const populateTestDatabase = async () => {
 
     await populateFakeTestResults(6, [
         'completeAndPassing',
-        null,
+        'completeAndPassing',
         'completeAndFailingDueToIncorrectAssertions',
         'completeAndPassing',
         'completeAndFailingDueToIncorrectAssertions',

--- a/server/scripts/populate-test-data/populateFakeTestResults.js
+++ b/server/scripts/populate-test-data/populateFakeTestResults.js
@@ -148,6 +148,10 @@ const populateFakeTestResults = async (testPlanRunId, fakeTestResultTypes) => {
         index += 1;
     }
 
+    // The following makes it so that fake tests are made for
+    // all possible tests that can be completed for any given
+    // test plan. Therefore, there will be no missing or skipped
+    // fake tests in the database.
     if (testPlanReport.runnableTests.length !== fakeTestResultTypes.length) {
         for (let i = index; i < testPlanReport.runnableTests.length; i += 1) {
             await getFake({

--- a/server/scripts/populate-test-data/populateFakeTestResults.js
+++ b/server/scripts/populate-test-data/populateFakeTestResults.js
@@ -12,7 +12,6 @@ const populateFakeTestResults = async (testPlanRunId, fakeTestResultTypes) => {
         query {
             populateData(locationOfData: { testPlanRunId: ${testPlanRunId} }) {
                 testPlanReport {
-                    isFinal
                     at {
                         id
                     }
@@ -149,10 +148,7 @@ const populateFakeTestResults = async (testPlanRunId, fakeTestResultTypes) => {
         index += 1;
     }
 
-    if (
-        testPlanReport.isFinal &&
-        testPlanReport.runnableTests.length - fakeTestResultTypes.length !== 0
-    ) {
+    if (testPlanReport.runnableTests.length !== fakeTestResultTypes.length) {
         for (let i = index; i < testPlanReport.runnableTests.length; i += 1) {
             await getFake({
                 testPlanReport,

--- a/server/scripts/populate-test-data/populateFakeTestResults.js
+++ b/server/scripts/populate-test-data/populateFakeTestResults.js
@@ -6,129 +6,13 @@ const {
 const { query, mutate } = require('../../tests/util/graphql-test-utilities');
 
 const populateFakeTestResults = async (testPlanRunId, fakeTestResultTypes) => {
-    let index = 0;
-    for (const fakeTestResultType of fakeTestResultTypes) {
-        // eslint-disable-next-line no-console
-        console.info(
-            'Populating sample for TestPlanRun',
-            testPlanRunId,
-            'TestResult',
-            index
-        );
-
-        switch (fakeTestResultType) {
-            case null:
-                break;
-            case 'completeAndPassing':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'passing',
-                    submit: true
-                });
-                break;
-            case 'completeAndFailingDueToIncorrectAssertions':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToIncorrectAssertions',
-                    submit: true
-                });
-                break;
-            case 'completeAndFailingDueToNoOutputAssertions':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToNoOutputAssertions',
-                    submit: true
-                });
-                break;
-            case 'completeAndFailingDueToUnexpectedBehaviors':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToUnexpectedBehaviors',
-                    submit: true
-                });
-                break;
-            case 'completeAndFailingDueToMultiple':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToMultiple',
-                    submit: true
-                });
-                break;
-            case 'incompleteAndEmpty':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'empty',
-                    submit: false
-                });
-                break;
-            case 'incompleteAndPassing':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'passing',
-                    submit: false
-                });
-                break;
-            case 'incompleteAndFailingDueToIncorrectAssertions':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToIncorrectAssertions',
-                    submit: false
-                });
-                break;
-            case 'incompleteAndFailingDueToNoOutputAssertions':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToNoOutputAssertions',
-                    submit: false
-                });
-                break;
-            case 'incompleteAndFailingDueToUnexpectedBehaviors':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToUnexpectedBehaviors',
-                    submit: false
-                });
-                break;
-            case 'incompleteAndFailingDueToMultiple':
-                await getFake({
-                    testPlanRunId,
-                    index,
-                    fakeTestResultType: 'failingDueToMultiple',
-                    submit: false
-                });
-                break;
-            default:
-                throw new Error(
-                    `Invalid fake test result type '${fakeTestResultType}'`
-                );
-        }
-
-        index += 1;
-    }
-};
-
-const getFake = async ({
-    testPlanRunId,
-    index,
-    fakeTestResultType,
-    submit
-}) => {
     const {
         populateData: { testPlanReport }
     } = await query(gql`
         query {
             populateData(locationOfData: { testPlanRunId: ${testPlanRunId} }) {
                 testPlanReport {
+                    isFinal
                     at {
                         id
                     }
@@ -143,6 +27,151 @@ const getFake = async ({
         }
     `);
 
+    let index = 0;
+
+    for (const fakeTestResultType of fakeTestResultTypes) {
+        // eslint-disable-next-line no-console
+        console.info(
+            'Populating sample for TestPlanRun',
+            testPlanRunId,
+            'TestResult',
+            index
+        );
+
+        switch (fakeTestResultType) {
+            case null:
+                break;
+            case 'completeAndPassing':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'passing',
+                    submit: true
+                });
+                break;
+            case 'completeAndFailingDueToIncorrectAssertions':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToIncorrectAssertions',
+                    submit: true
+                });
+                break;
+            case 'completeAndFailingDueToNoOutputAssertions':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToNoOutputAssertions',
+                    submit: true
+                });
+                break;
+            case 'completeAndFailingDueToUnexpectedBehaviors':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToUnexpectedBehaviors',
+                    submit: true
+                });
+                break;
+            case 'completeAndFailingDueToMultiple':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToMultiple',
+                    submit: true
+                });
+                break;
+            case 'incompleteAndEmpty':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'empty',
+                    submit: false
+                });
+                break;
+            case 'incompleteAndPassing':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'passing',
+                    submit: false
+                });
+                break;
+            case 'incompleteAndFailingDueToIncorrectAssertions':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToIncorrectAssertions',
+                    submit: false
+                });
+                break;
+            case 'incompleteAndFailingDueToNoOutputAssertions':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToNoOutputAssertions',
+                    submit: false
+                });
+                break;
+            case 'incompleteAndFailingDueToUnexpectedBehaviors':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToUnexpectedBehaviors',
+                    submit: false
+                });
+                break;
+            case 'incompleteAndFailingDueToMultiple':
+                await getFake({
+                    testPlanReport,
+                    testPlanRunId,
+                    index,
+                    fakeTestResultType: 'failingDueToMultiple',
+                    submit: false
+                });
+                break;
+            default:
+                throw new Error(
+                    `Invalid fake test result type '${fakeTestResultType}'`
+                );
+        }
+
+        index += 1;
+    }
+
+    if (
+        testPlanReport.isFinal &&
+        testPlanReport.runnableTests.length - fakeTestResultTypes.length !== 0
+    ) {
+        for (let i = index; i < testPlanReport.runnableTests.length; i += 1) {
+            await getFake({
+                testPlanReport,
+                testPlanRunId,
+                index: i,
+                fakeTestResultType: 'passing',
+                submit: true
+            });
+        }
+    }
+};
+
+const getFake = async ({
+    testPlanReport,
+    testPlanRunId,
+    index,
+    fakeTestResultType,
+    submit
+}) => {
     const testId = testPlanReport.runnableTests[index].id;
 
     const atVersion = await getAtVersionByQuery(

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -595,13 +595,13 @@ describe('graphql', () => {
                                 }
                             }
                         }
-                        markReportAsFinal: testPlanReport(id: 2) {
+                        markReportAsFinal: testPlanReport(id: 8) {
                             __typename
                             markAsFinal {
                                 locationOfData
                             }
                         }
-                        unmarkReportAsFinal: testPlanReport(id: 2) {
+                        unmarkReportAsFinal: testPlanReport(id: 8) {
                             __typename
                             unmarkAsFinal {
                                 locationOfData


### PR DESCRIPTION
This pull request removes the ability for a user to mark test reports as final that have skipped tests.

- The `Mark As Final` button will not show in the test queue for any reports that have skipped tests.
- The system (database and some files) was updated to no-longer consider the possibility of reports being marked as final that have skipped tests.
- A migration was introduced that would send tests that are not completed back to the test queue that have already been finalized.