### PR TITLE
Fix timeout issues with dataManagement tests

### DIFF
--- a/server/tests/integration/dataManagement.test.js
+++ b/server/tests/integration/dataManagement.test.js
@@ -3,15 +3,13 @@ const dbCleaner = require('../util/db-cleaner');
 const { query, mutate } = require('../util/graphql-test-utilities');
 const db = require('../../models');
 
-afterAll(async () => {
-    // Closing the DB connection allows Jest to exit successfully.
-    await db.sequelize.close();
-}, 40000);
+jest.setTimeout(40000);
 
 describe('data management', () => {
-    beforeAll(() => {
-        jest.setTimeout(40000);
-    });
+    afterAll(async () => {
+        // Closing the DB connection allows Jest to exit successfully.
+        await db.sequelize.close();
+    }, 40000);
 
     const testPlanVersionsQuery = () => {
         return query(gql`

--- a/server/tests/integration/dataManagement.test.js
+++ b/server/tests/integration/dataManagement.test.js
@@ -3,9 +3,7 @@ const dbCleaner = require('../util/db-cleaner');
 const { query, mutate } = require('../util/graphql-test-utilities');
 const db = require('../../models');
 
-beforeAll(async () => {
-    jest.setTimeout(20000);
-});
+jest.setTimeout(20000);
 
 afterAll(async () => {
     // Closing the DB connection allows Jest to exit successfully.

--- a/server/tests/integration/dataManagement.test.js
+++ b/server/tests/integration/dataManagement.test.js
@@ -6,10 +6,13 @@ const db = require('../../models');
 afterAll(async () => {
     // Closing the DB connection allows Jest to exit successfully.
     await db.sequelize.close();
-}, 20000);
+}, 40000);
 
 describe('data management', () => {
-    
+    beforeAll(() => {
+        jest.setTimeout(40000);
+    });
+
     const testPlanVersionsQuery = () => {
         return query(gql`
             query {

--- a/server/tests/integration/dataManagement.test.js
+++ b/server/tests/integration/dataManagement.test.js
@@ -3,14 +3,16 @@ const dbCleaner = require('../util/db-cleaner');
 const { query, mutate } = require('../util/graphql-test-utilities');
 const db = require('../../models');
 
-jest.setTimeout(40000);
+beforeAll(async () => {
+    jest.setTimeout(20000);
+});
+
+afterAll(async () => {
+    // Closing the DB connection allows Jest to exit successfully.
+    await db.sequelize.close();
+}, 20000);
 
 describe('data management', () => {
-    afterAll(async () => {
-        // Closing the DB connection allows Jest to exit successfully.
-        await db.sequelize.close();
-    }, 40000);
-
     const testPlanVersionsQuery = () => {
         return query(gql`
             query {

--- a/server/tests/integration/dataManagement.test.js
+++ b/server/tests/integration/dataManagement.test.js
@@ -4,7 +4,7 @@ const { query, mutate } = require('../util/graphql-test-utilities');
 const db = require('../../models');
 
 beforeAll(() => {
-    jest.setTimeout(20000);
+    jest.setTimeout(40000);
 });
 
 afterAll(async () => {

--- a/server/tests/integration/dataManagement.test.js
+++ b/server/tests/integration/dataManagement.test.js
@@ -3,15 +3,12 @@ const dbCleaner = require('../util/db-cleaner');
 const { query, mutate } = require('../util/graphql-test-utilities');
 const db = require('../../models');
 
-describe('data management', () => {
-    beforeAll(() => {
-    jest.setTimeout(40000);
-    });
+afterAll(async () => {
+    // Closing the DB connection allows Jest to exit successfully.
+    await db.sequelize.close();
+}, 20000);
 
-    afterAll(async () => {
-        // Closing the DB connection allows Jest to exit successfully.
-        await db.sequelize.close();
-    });
+describe('data management', () => {
     
     const testPlanVersionsQuery = () => {
         return query(gql`

--- a/server/tests/integration/dataManagement.test.js
+++ b/server/tests/integration/dataManagement.test.js
@@ -3,16 +3,16 @@ const dbCleaner = require('../util/db-cleaner');
 const { query, mutate } = require('../util/graphql-test-utilities');
 const db = require('../../models');
 
-beforeAll(() => {
-    jest.setTimeout(40000);
-});
-
-afterAll(async () => {
-    // Closing the DB connection allows Jest to exit successfully.
-    await db.sequelize.close();
-});
-
 describe('data management', () => {
+    beforeAll(() => {
+    jest.setTimeout(40000);
+    });
+
+    afterAll(async () => {
+        // Closing the DB connection allows Jest to exit successfully.
+        await db.sequelize.close();
+    });
+    
     const testPlanVersionsQuery = () => {
         return query(gql`
             query {


### PR DESCRIPTION
See title.

Global jest timeout is typically set outside of any hooks and hooks like `afterAll` have a different timeout context. This should fix the intermittently failing tests.