### PR TITLE
Fix empty version strings on Data Management and Test Queue pages

### DIFF
--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -627,7 +627,6 @@ const DataManagementRow = ({
                     return (
                         <PhaseCell role="list">
                             <VersionString role="listitem" iconColor="#818F98">
-                                {/* section: */}
                                 {otherLatestVersion.versionString}
                             </VersionString>
                             <span role="listitem" className="review-complete">
@@ -685,7 +684,6 @@ const DataManagementRow = ({
                                 linkRef={draftVersionStringRef}
                                 linkHref={`/test-review/${latestVersion.gitSha}/${latestVersion.testPlan.directory}`}
                             >
-                                {/* section: */}
                                 {latestVersion.versionString}
                             </VersionString>
                             {isAdmin &&

--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -627,6 +627,7 @@ const DataManagementRow = ({
                     return (
                         <PhaseCell role="list">
                             <VersionString role="listitem" iconColor="#818F98">
+                                {/* section: */}
                                 {otherLatestVersion.versionString}
                             </VersionString>
                             <span role="listitem" className="review-complete">
@@ -684,6 +685,7 @@ const DataManagementRow = ({
                                 linkRef={draftVersionStringRef}
                                 linkHref={`/test-review/${latestVersion.gitSha}/${latestVersion.testPlan.directory}`}
                             >
+                                {/* section: */}
                                 {latestVersion.versionString}
                             </VersionString>
                             {isAdmin &&

--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -108,6 +108,7 @@ export const UPDATE_TEST_PLAN_VERSION_PHASE = gql`
                     phase
                     gitSha
                     gitMessage
+                    versionString
                     updatedAt
                     draftPhaseReachedAt
                     candidatePhaseReachedAt
@@ -153,6 +154,7 @@ export const UPDATE_TEST_PLAN_VERSION_RECOMMENDED_TARGET_DATE = gql`
                     phase
                     gitSha
                     gitMessage
+                    versionString
                     updatedAt
                     draftPhaseReachedAt
                     candidatePhaseReachedAt

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -113,11 +113,13 @@ export const TEST_PLAN_REPORT_QUERY = gql`
             testPlanVersion {
                 id
                 title
+                phase
                 gitSha
                 gitMessage
                 testPlan {
                     directory
                 }
+                versionString
                 updatedAt
             }
             draftTestPlanRuns {


### PR DESCRIPTION
See issue #836 

This pull request solves the issue of the version string disappearing after advancing a test plan version or changing the target date on the data management page.
Simply adding `versionString` to both mutations in the data management queries solved the issue.