### PR TITLE
Fix Data management page crash when Adding Test Plans to the Test Queue and Opening Assistive Technology select to pick any option

### DIFF
--- a/client/components/DataManagement/index.jsx
+++ b/client/components/DataManagement/index.jsx
@@ -30,7 +30,6 @@ const DataManagement = () => {
 
     const [pageReady, setPageReady] = useState(false);
     const [ats, setAts] = useState([]);
-    const [browsers, setBrowsers] = useState([]);
     const [testPlans, setTestPlans] = useState([]);
     const [testPlanVersions, setTestPlanVersions] = useState([]);
     const [filter, setFilter] = useState(
@@ -42,14 +41,8 @@ const DataManagement = () => {
 
     useEffect(() => {
         if (data) {
-            const {
-                ats = [],
-                browsers = [],
-                testPlanVersions = [],
-                testPlans = []
-            } = data;
+            const { ats = [], testPlanVersions = [], testPlans = [] } = data;
             setAts(ats);
-            setBrowsers(browsers);
             setTestPlans(testPlans);
             setTestPlanVersions(testPlanVersions);
             setPageReady(true);
@@ -131,7 +124,6 @@ const DataManagement = () => {
 
                     <ManageTestQueue
                         ats={ats}
-                        browsers={browsers}
                         testPlanVersions={testPlanVersions}
                         triggerUpdate={refetch}
                     />

--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -10,6 +10,10 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
         ats {
             id
             name
+            browsers {
+                id
+                name
+            }
             atVersions {
                 id
                 name

--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -26,10 +26,6 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
                 id
             }
         }
-        browsers {
-            id
-            name
-        }
         testPlans {
             id
             directory

--- a/client/components/ManageTestQueue/index.jsx
+++ b/client/components/ManageTestQueue/index.jsx
@@ -91,7 +91,6 @@ const DisclosureContainer = styled.div`
 
 const ManageTestQueue = ({
     ats = [],
-    browsers = [],
     testPlanVersions = [],
     triggerUpdate = () => {}
 }) => {
@@ -667,9 +666,11 @@ const ManageTestQueue = ({
                                 item => item.id === selectedTestPlanVersionId
                             )}
                             at={ats.find(item => item.id === selectedAtId)}
-                            browser={browsers.find(
-                                item => item.id === selectedBrowserId
-                            )}
+                            browser={ats
+                                .find(at => at.id === selectedAtId)
+                                ?.browsers.find(
+                                    browser => browser.id === selectedBrowserId
+                                )}
                             triggerUpdate={triggerUpdate}
                             disabled={
                                 !selectedTestPlanVersionId ||
@@ -738,7 +739,6 @@ const ManageTestQueue = ({
 
 ManageTestQueue.propTypes = {
     ats: PropTypes.array,
-    browsers: PropTypes.array,
     testPlanVersions: PropTypes.array,
     triggerUpdate: PropTypes.func
 };

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -21,7 +21,6 @@ const TestQueue = () => {
     const [pageReady, setPageReady] = useState(false);
     const [testers, setTesters] = useState([]);
     const [ats, setAts] = useState([]);
-    const [browsers, setBrowsers] = useState([]);
     const [testPlanVersions, setTestPlanVersions] = useState([]);
     const [testPlanReports, setTestPlanReports] = useState([]);
     const [latestTestPlanVersions, setLatestTestPlanVersions] = useState([]);
@@ -45,7 +44,6 @@ const TestQueue = () => {
             const {
                 users = [],
                 ats = [],
-                browsers = [],
                 testPlanVersions = [],
                 testPlanReports = [],
                 testPlans = []
@@ -60,7 +58,6 @@ const TestQueue = () => {
             setAts(ats);
             setTestPlanVersions(testPlanVersions);
             setTestPlanReports(testPlanReports);
-            setBrowsers(browsers);
             setLatestTestPlanVersions(testPlans);
             setPageReady(true);
         }
@@ -254,7 +251,6 @@ const TestQueue = () => {
             {isAdmin && (
                 <ManageTestQueue
                     ats={ats}
-                    browsers={browsers}
                     testPlanVersions={testPlanVersions}
                     triggerUpdate={refetch}
                 />

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -33,10 +33,6 @@ export const TEST_QUEUE_PAGE_QUERY = gql`
                 name
             }
         }
-        browsers {
-            id
-            name
-        }
         testPlanVersions {
             id
             title

--- a/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
@@ -39,6 +39,16 @@ export default (
                                 releasedAt: '2021-11-01T04:00:00.000Z'
                             }
                         ],
+                        browsers: [
+                            {
+                                id: '2',
+                                name: 'Chrome'
+                            },
+                            {
+                                id: '1',
+                                name: 'Firefox'
+                            }
+                        ],
                         candidateBrowsers: [{ id: '2' }],
                         recommendedBrowsers: [{ id: '1' }, { id: '2' }]
                     },
@@ -50,6 +60,16 @@ export default (
                                 id: '2',
                                 name: '2020.4',
                                 releasedAt: '2021-02-19T05:00:00.000Z'
+                            }
+                        ],
+                        browsers: [
+                            {
+                                id: '2',
+                                name: 'Chrome'
+                            },
+                            {
+                                id: '1',
+                                name: 'Firefox'
                             }
                         ],
                         candidateBrowsers: [{ id: '2' }],
@@ -65,22 +85,22 @@ export default (
                                 releasedAt: '2019-09-01T04:00:00.000Z'
                             }
                         ],
+                        browsers: [
+                            {
+                                id: '2',
+                                name: 'Chrome'
+                            },
+                            {
+                                id: '1',
+                                name: 'Firefox'
+                            },
+                            {
+                                id: '3',
+                                name: 'Safari'
+                            }
+                        ],
                         candidateBrowsers: [{ id: '3' }],
                         recommendedBrowsers: [{ id: '2' }, { id: '3' }]
-                    }
-                ],
-                browsers: [
-                    {
-                        id: '2',
-                        name: 'Chrome'
-                    },
-                    {
-                        id: '1',
-                        name: 'Firefox'
-                    },
-                    {
-                        id: '3',
-                        name: 'Safari'
                     }
                 ],
                 testPlans: [


### PR DESCRIPTION
see #842 

This first commit in this PR fixes the bug. The other two commits remove the query and state for `browsers` in both `DataManagement` and `TestQueue`. Now that the `ManageTestQueue` component only uses browsers that are linked to an AT, the base `browsers` array is no longer needed as a prop. Since this was the only need for this array in the two parent components, the fetching and storing of that array is removed from the parents as well.

Note that the current design (both before and after this PR) does not allow for selecting a browser **before** selecting an AT. This seems fine from a usability standpoint but wanted to note it here.