### PR TITLE
Passed/failed for assertion results in TestRenderer and migrate to pass/fail for report comparison algorithms

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/queries.js
+++ b/client/components/CandidateReview/CandidateTestPlanRun/queries.js
@@ -114,7 +114,6 @@ export const CANDIDATE_REPORTS_QUERY = gql`
                             text
                         }
                         passed
-                        failedReason
                     }
                     requiredAssertionResults: assertionResults(
                         priority: REQUIRED
@@ -123,7 +122,6 @@ export const CANDIDATE_REPORTS_QUERY = gql`
                             text
                         }
                         passed
-                        failedReason
                     }
                     optionalAssertionResults: assertionResults(
                         priority: OPTIONAL
@@ -132,14 +130,12 @@ export const CANDIDATE_REPORTS_QUERY = gql`
                             text
                         }
                         passed
-                        failedReason
                     }
                     mayAssertionResults: assertionResults(priority: MAY) {
                         assertion {
                             text
                         }
                         passed
-                        failedReason
                     }
                     unexpectedBehaviors {
                         id

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -297,7 +297,6 @@ SummarizeTestPlanReport.propTypes = {
                                 PropTypes.shape({
                                     id: PropTypes.string.isRequired,
                                     passed: PropTypes.bool.isRequired,
-                                    failedReason: PropTypes.string,
                                     assertion: PropTypes.shape({
                                         text: PropTypes.string.isRequired
                                     }).isRequired

--- a/client/components/Reports/queries.js
+++ b/client/components/Reports/queries.js
@@ -80,7 +80,6 @@ export const REPORT_PAGE_QUERY = gql`
                                 text
                             }
                             passed
-                            failedReason
                         }
                         requiredAssertionResults: assertionResults(
                             priority: REQUIRED
@@ -89,7 +88,6 @@ export const REPORT_PAGE_QUERY = gql`
                                 text
                             }
                             passed
-                            failedReason
                         }
                         optionalAssertionResults: assertionResults(
                             priority: OPTIONAL
@@ -98,14 +96,12 @@ export const REPORT_PAGE_QUERY = gql`
                                 text
                             }
                             passed
-                            failedReason
                         }
                         mayAssertionResults: assertionResults(priority: MAY) {
                             assertion {
                                 text
                             }
                             passed
-                            failedReason
                         }
                         unexpectedBehaviors {
                             id

--- a/client/components/ReviewConflicts/ReviewConflicts.jsx
+++ b/client/components/ReviewConflicts/ReviewConflicts.jsx
@@ -53,15 +53,9 @@ const ReviewConflicts = ({
         const results = conflictingResults.map(result => {
             const { testPlanRun, scenarioResult, assertionResult } = result;
             let assertionResultFormatted;
-            if (assertionResult.passed) {
-                assertionResultFormatted = 'passing';
-            } else {
-                const reasonFormatted =
-                    assertionResult.failedReason === 'INCORRECT_OUTPUT'
-                        ? 'incorrect output'
-                        : 'no output';
-                assertionResultFormatted = `failing with ${reasonFormatted}`;
-            }
+            assertionResultFormatted = assertionResult.passed
+                ? 'passing'
+                : 'failing';
             return (
                 <li key={testPlanRun.id}>
                     Tester {testPlanRun.tester.username} recorded output &quot;
@@ -167,8 +161,7 @@ ReviewConflicts.propTypes = {
                             ).isRequired
                         }),
                         assertionResult: PropTypes.shape({
-                            passed: PropTypes.bool.isRequired,
-                            failedReason: PropTypes.string
+                            passed: PropTypes.bool.isRequired
                         })
                     })
                 ).isRequired

--- a/client/components/TestPlanUpdater/TestPlanUpdaterModal.jsx
+++ b/client/components/TestPlanUpdater/TestPlanUpdaterModal.jsx
@@ -181,9 +181,7 @@ const TestPlanUpdaterModal = ({
                                         ];
                                     return {
                                         id: assertionResultSkeleton.id,
-                                        passed: assertionResult.passed,
-                                        failedReason:
-                                            assertionResult.failedReason
+                                        passed: assertionResult.passed
                                     };
                                 }
                             ),

--- a/client/components/TestPlanUpdater/queries.js
+++ b/client/components/TestPlanUpdater/queries.js
@@ -79,7 +79,6 @@ export const VERSION_QUERY = gql`
                         output
                         assertionResults {
                             passed
-                            failedReason
                         }
                         unexpectedBehaviors {
                             id

--- a/client/components/TestRenderer/AssertionsFieldset/index.jsx
+++ b/client/components/TestRenderer/AssertionsFieldset/index.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Fieldset } from '..';
+import styled from '@emotion/styled';
+
+const Label = styled.label`
+    display: block;
+`;
+
+const AssertionsFieldset = ({ assertions, commandIndex }) => {
+    return (
+        <Fieldset>
+            <legend>Assertions</legend>
+            {assertions.map((assertion, assertionIndex) => {
+                const { description, passed, click } = assertion;
+
+                return (
+                    <Label key={`AssertionKey_${assertionIndex}`}>
+                        <input
+                            type="checkbox"
+                            id={`pass-${commandIndex}-${assertionIndex}`}
+                            name={`assertion-${commandIndex}-${assertionIndex}`}
+                            defaultChecked={passed}
+                            onClick={click}
+                        />
+                        {description[0]}
+                    </Label>
+                );
+            })}
+        </Fieldset>
+    );
+};
+
+AssertionsFieldset.propTypes = {
+    assertions: PropTypes.array.isRequired,
+    commandIndex: PropTypes.number.isRequired
+};
+
+export default AssertionsFieldset;

--- a/client/components/TestRenderer/AssertionsFieldset/index.jsx
+++ b/client/components/TestRenderer/AssertionsFieldset/index.jsx
@@ -1,16 +1,31 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Fieldset } from '..';
 import styled from '@emotion/styled';
+import supportJson from '../../../resources/support.json';
 
 const Label = styled.label`
     display: block;
+
+    input {
+        margin-right: 0.25rem;
+    }
 `;
 
-const AssertionsFieldset = ({ assertions, commandIndex }) => {
+const AssertionsFieldset = ({ assertions, commandIndex, assertionsHeader }) => {
+    // Handle case where build process didn't include assertionResponseQuestion
+    const normalizedHeader = useMemo(() => {
+        return assertionsHeader?.descriptionHeader?.replace(
+            'undefined',
+            supportJson.testPlanStrings.assertionResponseQuestion
+        );
+    }, [assertionsHeader]);
+
     return (
         <Fieldset>
-            <legend>Assertions</legend>
+            <legend id={`command-${commandIndex}-assertions-heading`}>
+                {normalizedHeader}
+            </legend>
             {assertions.map((assertion, assertionIndex) => {
                 const { description, passed, click } = assertion;
 
@@ -33,7 +48,8 @@ const AssertionsFieldset = ({ assertions, commandIndex }) => {
 
 AssertionsFieldset.propTypes = {
     assertions: PropTypes.array.isRequired,
-    commandIndex: PropTypes.number.isRequired
+    commandIndex: PropTypes.number.isRequired,
+    assertionsHeader: PropTypes.string.isRequired
 };
 
 export default AssertionsFieldset;

--- a/client/components/TestRenderer/AssertionsFieldset/index.jsx
+++ b/client/components/TestRenderer/AssertionsFieldset/index.jsx
@@ -49,7 +49,7 @@ const AssertionsFieldset = ({ assertions, commandIndex, assertionsHeader }) => {
 AssertionsFieldset.propTypes = {
     assertions: PropTypes.array.isRequired,
     commandIndex: PropTypes.number.isRequired,
-    assertionsHeader: PropTypes.string.isRequired
+    assertionsHeader: PropTypes.object.isRequired
 };
 
 export default AssertionsFieldset;

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -24,6 +24,7 @@ import { evaluateAtNameKey } from '../../utils/aria';
 import OutputTextArea from './OutputTextArea';
 import supportJson from '../../resources/support.json';
 import commandsJson from '../../resources/commands.json';
+import AssertionsFieldset from './AssertionsFieldset';
 
 const Container = styled.div`
     width: 100%;
@@ -76,49 +77,7 @@ export const Feedback = styled.span`
     }
 `;
 
-const Table = styled.table`
-    width: 100%;
-
-    display: table;
-    margin-bottom: 1em;
-    border-spacing: 2px;
-
-    border: black solid 1px;
-
-    text-indent: initial;
-    box-sizing: border-box;
-    border-collapse: collapse;
-
-    > tbody > tr {
-        td,
-        th {
-            border: 1px solid black;
-            padding: 0.25em;
-        }
-
-        td {
-            > label {
-                display: initial;
-                vertical-align: middle;
-            }
-
-            > input[type='radio'] {
-                margin: 0 5px 0 0;
-                vertical-align: middle;
-
-                &:nth-of-type(n + 2) {
-                    margin: 0 5px;
-                }
-            }
-        }
-
-        th {
-            font-weight: bold;
-        }
-    }
-`;
-
-const Fieldset = styled.fieldset`
+export const Fieldset = styled.fieldset`
     display: block;
     margin-inline-start: 2px;
     margin-inline-end: 2px;
@@ -425,11 +384,6 @@ const TestRenderer = ({
                 const atOutputError = item.atOutput.highlightRequired;
                 if (atOutputError) return true;
 
-                const assertionsError = item.assertions.some(
-                    item => item.highlightRequired
-                );
-                if (assertionsError) return true;
-
                 const unexpectedError = item.unexpected.highlightRequired;
                 if (unexpectedError) return true;
 
@@ -453,11 +407,6 @@ const TestRenderer = ({
                 const atOutputError =
                     item.atOutput.description[1].highlightRequired;
                 if (atOutputError) return true;
-
-                const assertionsError = item.assertions.some(
-                    item => item.description[1].highlightRequired
-                );
-                if (assertionsError) return true;
 
                 const unexpectedBehaviorError =
                     item.unexpectedBehaviors.description[1].highlightRequired;
@@ -613,7 +562,6 @@ const TestRenderer = ({
                                 const {
                                     header,
                                     atOutput,
-                                    assertionsHeader,
                                     assertions,
                                     unexpectedBehaviors
                                 } = value;
@@ -635,203 +583,10 @@ const TestRenderer = ({
                                         >
                                             Assertions {header}
                                         </h4>
-                                        <Table
-                                            aria-labelledby={`command-${commandIndex}-assertions-heading`}
-                                        >
-                                            <tbody>
-                                                <tr>
-                                                    <th>
-                                                        {assertionsHeader.descriptionHeader ||
-                                                            'Assertion'}
-                                                    </th>
-                                                    <th>
-                                                        {assertionsHeader.passHeader ||
-                                                            'Success case'}
-                                                    </th>
-                                                    <th>
-                                                        {assertionsHeader.failHeader ||
-                                                            'Failure cases'}
-                                                    </th>
-                                                </tr>
-                                                {assertions.map(
-                                                    (
-                                                        assertion,
-                                                        assertionIndex
-                                                    ) => {
-                                                        const {
-                                                            description,
-                                                            passChoice,
-                                                            failChoices
-                                                        } = assertion;
-
-                                                        const [
-                                                            missingChoice,
-                                                            failureChoice
-                                                        ] = failChoices;
-
-                                                        return (
-                                                            <tr
-                                                                key={`AssertionKey_${assertionIndex}`}
-                                                            >
-                                                                {/*Assertion*/}
-                                                                <td
-                                                                    id={`assertion-${commandIndex}-${assertionIndex}`}
-                                                                >
-                                                                    {
-                                                                        description[0]
-                                                                    }
-                                                                    {isSubmitted && (
-                                                                        <Feedback
-                                                                            className={`${
-                                                                                description[1]
-                                                                                    .required &&
-                                                                                'required'
-                                                                            } ${
-                                                                                description[1]
-                                                                                    .highlightRequired &&
-                                                                                'highlight-required'
-                                                                            }`}
-                                                                        >
-                                                                            {
-                                                                                description[1]
-                                                                                    .description
-                                                                            }
-                                                                        </Feedback>
-                                                                    )}
-                                                                </td>
-                                                                {/*Success case*/}
-                                                                <td>
-                                                                    <input
-                                                                        key={`Pass__${commandIndex}__${assertionIndex}`}
-                                                                        type="radio"
-                                                                        id={`pass-${commandIndex}-${assertionIndex}`}
-                                                                        name={`result-${commandIndex}-${assertionIndex}`}
-                                                                        aria-labelledby={`pass-${commandIndex}-${assertionIndex}-label assertion-${commandIndex}-${assertionIndex}`}
-                                                                        autoFocus={
-                                                                            isSubmitted &&
-                                                                            passChoice.focus
-                                                                        }
-                                                                        defaultChecked={
-                                                                            passChoice.checked
-                                                                        }
-                                                                        onClick={
-                                                                            passChoice.click
-                                                                        }
-                                                                    />
-                                                                    <label
-                                                                        id={`pass-${commandIndex}-${assertionIndex}-label`}
-                                                                        htmlFor={`pass-${commandIndex}-${assertionIndex}`}
-                                                                    >
-                                                                        {
-                                                                            passChoice
-                                                                                .label[0]
-                                                                        }
-                                                                        <Feedback
-                                                                            className={`${
-                                                                                passChoice
-                                                                                    .label[1]
-                                                                                    .offScreen &&
-                                                                                'off-screen'
-                                                                            }`}
-                                                                        >
-                                                                            {
-                                                                                passChoice
-                                                                                    .label[1]
-                                                                                    .description
-                                                                            }
-                                                                        </Feedback>
-                                                                    </label>
-                                                                </td>
-                                                                {/*Failure cases*/}
-                                                                <td>
-                                                                    <input
-                                                                        key={`Missing__${commandIndex}__${assertionIndex}`}
-                                                                        type="radio"
-                                                                        id={`missing-${commandIndex}-${assertionIndex}`}
-                                                                        name={`result-${commandIndex}-${assertionIndex}`}
-                                                                        aria-labelledby={`missing-${commandIndex}-${assertionIndex}-label assertion-${commandIndex}-${assertionIndex}`}
-                                                                        autoFocus={
-                                                                            isSubmitted &&
-                                                                            missingChoice.focus
-                                                                        }
-                                                                        defaultChecked={
-                                                                            missingChoice.checked
-                                                                        }
-                                                                        onClick={
-                                                                            missingChoice.click
-                                                                        }
-                                                                    />
-                                                                    <label
-                                                                        id={`missing-${commandIndex}-${assertionIndex}-label`}
-                                                                        htmlFor={`missing-${commandIndex}-${assertionIndex}`}
-                                                                    >
-                                                                        {
-                                                                            missingChoice
-                                                                                .label[0]
-                                                                        }
-                                                                        <Feedback
-                                                                            className={`${
-                                                                                missingChoice
-                                                                                    .label[1]
-                                                                                    .offScreen &&
-                                                                                'off-screen'
-                                                                            }`}
-                                                                        >
-                                                                            {
-                                                                                missingChoice
-                                                                                    .label[1]
-                                                                                    .description
-                                                                            }
-                                                                        </Feedback>
-                                                                    </label>
-
-                                                                    <input
-                                                                        key={`Fail__${commandIndex}__${assertionIndex}`}
-                                                                        type="radio"
-                                                                        id={`fail-${commandIndex}-${assertionIndex}`}
-                                                                        name={`result-${commandIndex}-${assertionIndex}`}
-                                                                        aria-labelledby={`fail-${commandIndex}-${assertionIndex}-label assertion-${commandIndex}-${assertionIndex}`}
-                                                                        autoFocus={
-                                                                            isSubmitted &&
-                                                                            failureChoice.focus
-                                                                        }
-                                                                        defaultChecked={
-                                                                            failureChoice.checked
-                                                                        }
-                                                                        onClick={
-                                                                            failureChoice.click
-                                                                        }
-                                                                    />
-                                                                    <label
-                                                                        id={`fail-${commandIndex}-${assertionIndex}-label`}
-                                                                        htmlFor={`fail-${commandIndex}-${assertionIndex}`}
-                                                                    >
-                                                                        {
-                                                                            failureChoice
-                                                                                .label[0]
-                                                                        }
-                                                                        <Feedback
-                                                                            className={`${
-                                                                                failureChoice
-                                                                                    .label[1]
-                                                                                    .offScreen &&
-                                                                                'off-screen'
-                                                                            }`}
-                                                                        >
-                                                                            {
-                                                                                failureChoice
-                                                                                    .label[1]
-                                                                                    .description
-                                                                            }
-                                                                        </Feedback>
-                                                                    </label>
-                                                                </td>
-                                                            </tr>
-                                                        );
-                                                    }
-                                                )}
-                                            </tbody>
-                                        </Table>
+                                        <AssertionsFieldset
+                                            assertions={assertions}
+                                            commandIndex={commandIndex}
+                                        />
                                         {/*Unexpected Behaviors*/}
                                         <Fieldset
                                             id={`cmd-${commandIndex}-problems`}

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -262,13 +262,9 @@ const TestRenderer = ({
                 const assertionResult = assertionResults[j];
                 const { highlightRequired } = assertionResult;
 
-                if (assertionResult.passed)
-                    commands[i].assertions[j].result = 'pass';
-                else if (assertionResult.failedReason === 'NO_OUTPUT')
-                    commands[i].assertions[j].result = 'failMissing';
-                else if (assertionResult.failedReason === 'INCORRECT_OUTPUT')
-                    commands[i].assertions[j].result = 'failIncorrect';
-                else commands[i].assertions[j].result = 'notSet';
+                commands[i].assertions[j].result = assertionResult.passed
+                    ? 'pass'
+                    : 'fail';
 
                 commands[i].assertions[j].highlightRequired = highlightRequired;
             }

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -563,9 +563,9 @@ const TestRenderer = ({
                                     header,
                                     atOutput,
                                     assertions,
-                                    unexpectedBehaviors
+                                    unexpectedBehaviors,
+                                    assertionsHeader
                                 } = value;
-
                                 return (
                                     <Fragment
                                         key={`AtOutputKey_${commandIndex}`}
@@ -578,14 +578,10 @@ const TestRenderer = ({
                                             atOutput={atOutput}
                                             isSubmitted={isSubmitted}
                                         />
-                                        <h4
-                                            id={`command-${commandIndex}-assertions-heading`}
-                                        >
-                                            Assertions {header}
-                                        </h4>
                                         <AssertionsFieldset
                                             assertions={assertions}
                                             commandIndex={commandIndex}
+                                            assertionsHeader={assertionsHeader}
                                         />
                                         {/*Unexpected Behaviors*/}
                                         <Fieldset

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -387,13 +387,7 @@ const TestRun = () => {
                 const { result, highlightRequired } = assertions[j];
                 const assertionResult = {
                     ...scenarioResult.assertionResults[j],
-                    passed: result === 'pass',
-                    failedReason:
-                        result === 'failMissing'
-                            ? 'NO_OUTPUT'
-                            : result === 'failIncorrect'
-                            ? 'INCORRECT_OUTPUT'
-                            : null
+                    passed: result === 'pass'
                 };
                 assertionResults.push(
                     captureHighlightRequired
@@ -633,7 +627,6 @@ const TestRun = () => {
          * ....{
          * ......id
          * ......passed
-         * ......failedReason
          * ....},
          * ....other assertionResults,
          * ..],
@@ -645,13 +638,10 @@ const TestRun = () => {
                 id,
                 output: output,
                 unexpectedBehaviors: unexpectedBehaviors,
-                assertionResults: assertionResults.map(
-                    ({ failedReason, id, passed }) => ({
-                        id,
-                        passed: passed,
-                        failedReason: failedReason
-                    })
-                )
+                assertionResults: assertionResults.map(({ id, passed }) => ({
+                    id,
+                    passed
+                }))
             })
         );
 

--- a/client/components/TestRun/queries.js
+++ b/client/components/TestRun/queries.js
@@ -34,7 +34,6 @@ export const TEST_RUN_PAGE_QUERY = gql`
                             text
                         }
                         passed
-                        failedReason
                     }
                     requiredAssertionResults: assertionResults(
                         priority: REQUIRED
@@ -43,7 +42,6 @@ export const TEST_RUN_PAGE_QUERY = gql`
                             text
                         }
                         passed
-                        failedReason
                     }
                     optionalAssertionResults: assertionResults(
                         priority: OPTIONAL
@@ -52,14 +50,12 @@ export const TEST_RUN_PAGE_QUERY = gql`
                             text
                         }
                         passed
-                        failedReason
                     }
                     mayAssertionResults: assertionResults(priority: MAY) {
                         assertion {
                             text
                         }
                         passed
-                        failedReason
                     }
                     unexpectedBehaviors {
                         id
@@ -112,7 +108,6 @@ export const TEST_RUN_PAGE_QUERY = gql`
                         }
                         assertionResult {
                             passed
-                            failedReason
                         }
                     }
                 }
@@ -223,7 +218,6 @@ export const TEST_RUN_PAGE_ANON_QUERY = gql`
                     }
                     assertionResult {
                         passed
-                        failedReason
                     }
                 }
             }
@@ -333,7 +327,6 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             requiredAssertionResults: assertionResults(
                                 priority: REQUIRED
@@ -342,7 +335,6 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             optionalAssertionResults: assertionResults(
                                 priority: OPTIONAL
@@ -351,7 +343,6 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             mayAssertionResults: assertionResults(
                                 priority: MAY
@@ -360,7 +351,6 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             unexpectedBehaviors {
                                 id
@@ -413,7 +403,6 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                                 }
                                 assertionResult {
                                     passed
-                                    failedReason
                                 }
                             }
                         }
@@ -510,7 +499,6 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                             }
                             assertionResult {
                                 passed
-                                failedReason
                             }
                         }
                     }
@@ -623,7 +611,6 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             requiredAssertionResults: assertionResults(
                                 priority: REQUIRED
@@ -632,7 +619,6 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             optionalAssertionResults: assertionResults(
                                 priority: OPTIONAL
@@ -641,7 +627,6 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             mayAssertionResults: assertionResults(
                                 priority: MAY
@@ -650,7 +635,6 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             unexpectedBehaviors {
                                 id
@@ -703,7 +687,6 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                                 }
                                 assertionResult {
                                     passed
-                                    failedReason
                                 }
                             }
                         }
@@ -800,7 +783,6 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                             }
                             assertionResult {
                                 passed
-                                failedReason
                             }
                         }
                     }
@@ -913,7 +895,6 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             requiredAssertionResults: assertionResults(
                                 priority: REQUIRED
@@ -922,7 +903,6 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             optionalAssertionResults: assertionResults(
                                 priority: OPTIONAL
@@ -931,7 +911,6 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             mayAssertionResults: assertionResults(
                                 priority: MAY
@@ -940,7 +919,6 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                                     text
                                 }
                                 passed
-                                failedReason
                             }
                             unexpectedBehaviors {
                                 id
@@ -993,7 +971,6 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                                 }
                                 assertionResult {
                                     passed
-                                    failedReason
                                 }
                             }
                         }
@@ -1090,7 +1067,6 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                             }
                             assertionResult {
                                 passed
-                                failedReason
                             }
                         }
                     }

--- a/client/resources/aria-at-harness.mjs
+++ b/client/resources/aria-at-harness.mjs
@@ -8,7 +8,12 @@ import {
   focus,
   render,
 } from './vrender.mjs';
-import { userCloseWindow, userOpenWindow, WhitespaceStyleMap } from './aria-at-test-run.mjs';
+import {
+  AssertionResultMap,
+  userCloseWindow,
+  userOpenWindow,
+  WhitespaceStyleMap,
+} from './aria-at-test-run.mjs';
 import { TestRunExport, TestRunInputOutput } from './aria-at-test-io-format.mjs';
 import { TestWindow } from './aria-at-test-window.mjs';
 
@@ -37,6 +42,14 @@ const PAGE_STYLES = `
   fieldset.problem-select {
    margin-top: 1em;
    margin-left: 1em;
+  }
+
+  fieldset.assertions {
+    margin-bottom: 1em;
+  }
+
+  label.assertion {
+    display: block;
   }
 
   .required:not(.highlight-required) {
@@ -382,12 +395,9 @@ function renderVirtualInstructionDocument(doc) {
           )
         )
       ),
-      table(
-        tr(
-          th(rich(command.assertionsHeader.descriptionHeader)),
-          th(rich(command.assertionsHeader.passHeader)),
-          th(rich(command.assertionsHeader.failHeader))
-        ),
+      fieldset(
+        className(['assertions']),
+        legend(rich(command.assertionsHeader.descriptionHeader)),
         ...command.assertions.map(bind(commandResultAssertion, commandIndex))
       ),
       ...[command.unexpectedBehaviors].map(bind(commandResultUnexpectedBehavior, commandIndex))
@@ -479,26 +489,15 @@ function renderVirtualInstructionDocument(doc) {
    * @param {number} assertionIndex
    */
   function commandResultAssertion(commandIndex, assertion, assertionIndex) {
-    return tr(
-      td(rich(assertion.description)),
-      td(
-        ...[assertion.passChoice].map(choice =>
-          radioChoice(
-            `pass-${commandIndex}-${assertionIndex}`,
-            `result-${commandIndex}-${assertionIndex}`,
-            choice
-          )
-        )
+    return label(
+      className(['assertion']),
+      input(
+        type('checkbox'),
+        id(`cmd-${commandIndex}-${assertionIndex}`),
+        checked(assertion.passed === AssertionResultMap.PASS),
+        onclick(assertion.click)
       ),
-      td(
-        ...assertion.failChoices.map((choice, failIndex) =>
-          radioChoice(
-            `${failIndex === 0 ? 'missing' : 'fail'}-${commandIndex}-${assertionIndex}`,
-            `result-${commandIndex}-${assertionIndex}`,
-            choice
-          )
-        )
-      )
+      rich(assertion.description)
     );
   }
 

--- a/client/resources/aria-at-test-io-format.mjs
+++ b/client/resources/aria-at-test-io-format.mjs
@@ -777,6 +777,7 @@ class BehaviorInput {
         specificUserInstruction: json.specific_user_instruction,
         setupScriptDescription: json.setup_script_description,
         setupTestPage: json.setupTestPage,
+        assertionResponseQuestion: json.assertionResponseQuestion,
         commands: commandsAndSettings,
         assertions: (json.output_assertions ? json.output_assertions : []).map(assertion => {
           // Tuple array [ priorityNumber, assertionText ]
@@ -1176,6 +1177,7 @@ export class TestRunInputOutput {
       openTest: {
         enabled: true,
       },
+      assertionResponseQuestion: test.assertionResponseQuestion,
       commands: test.commands.map(
         command =>
           /** @type {import("./aria-at-test-run.mjs").TestRunCommand} */ ({
@@ -1468,7 +1470,7 @@ export class TestRunInputOutput {
                 ? 'failIncorrect'
                 : assertionResult.failedReason === 'NO_OUTPUT'
                 ? 'failMissing'
-                : 'notSet',
+                : 'fail',
             };
           }),
           unexpected: {
@@ -1549,6 +1551,7 @@ export class TestRunExport extends TestRun {
 
 const AssertionPassJSONMap = createEnumMap({
   GOOD_OUTPUT: 'Good Output',
+  PASS: 'Pass',
 });
 
 /**
@@ -1570,6 +1573,7 @@ const AssertionFailJSONMap = createEnumMap({
   NO_OUTPUT: 'No Output',
   INCORRECT_OUTPUT: 'Incorrect Output',
   NO_SUPPORT: 'No Support',
+  FAIL: 'Fail',
 });
 
 /** @typedef {SubmitResultDetailsCommandsAssertionsPass | SubmitResultDetailsCommandsAssertionsFail} SubmitResultAssertionsJSON */

--- a/client/resources/aria-at-test-run.mjs
+++ b/client/resources/aria-at-test-run.mjs
@@ -210,24 +210,6 @@ export function instructionDocument(resultState, hooks) {
   };
 
   /**
-   * @param {T} resultAssertion
-   * @param {T["result"]} resultValue
-   * @param {Omit<InstructionDocumentAssertionChoice, 'checked' | 'focus'>} partialChoice
-   * @returns {InstructionDocumentAssertionChoice}
-   * @template {TestRunAssertion | TestRunAdditionalAssertion} T
-   */
-  function assertionChoice(resultAssertion, resultValue, partialChoice) {
-    return {
-      ...partialChoice,
-      checked: resultAssertion.result === resultValue,
-      focus:
-        resultState.currentUserAction === 'validateResults' &&
-        resultAssertion.highlightRequired &&
-        focusFirstRequired(),
-    };
-  }
-
-  /**
    * @param {string} command
    * @param {number} commandIndex
    * @returns {InstructionDocumentResultsCommand}
@@ -261,9 +243,9 @@ export function instructionDocument(resultState, hooks) {
         change: atOutput => hooks.setCommandOutput({ commandIndex, atOutput }),
       },
       assertionsHeader: {
-        descriptionHeader: 'Assertion',
-        passHeader: 'Success case',
-        failHeader: 'Failure cases',
+        descriptionHeader: `${resultState.assertionResponseQuestion} ${command}${
+          settingsText && settings !== 'defaultMode' ? ` (${settingsText})` : ''
+        }?`,
       },
       assertions: [
         ...assertions.map(bind(assertionResult, commandIndex)),
@@ -382,57 +364,17 @@ export function instructionDocument(resultState, hooks) {
   function assertionResult(commandIndex, assertion, assertionIndex) {
     const resultAssertion = resultState.commands[commandIndex].assertions[assertionIndex];
     return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
-      description: [
-        assertion,
-        {
-          required: true,
-          highlightRequired: resultAssertion.highlightRequired,
-          description: '(required: mark output)',
-        },
-      ],
-      passChoice: assertionChoice(resultAssertion, CommonResultMap.PASS, {
-        label: [
-          `Good Output `,
-          {
-            offScreen: true,
-            description: 'for assertion',
-          },
-        ],
-        click: () =>
-          hooks.setCommandAssertion({ commandIndex, assertionIndex, result: CommonResultMap.PASS }),
-      }),
-      failChoices: [
-        assertionChoice(resultAssertion, AssertionResultMap.FAIL_MISSING, {
-          label: [
-            `No Output `,
-            {
-              offScreen: true,
-              description: 'for assertion',
-            },
-          ],
-          click: () =>
-            hooks.setCommandAssertion({
-              commandIndex,
-              assertionIndex,
-              result: AssertionResultMap.FAIL_MISSING,
-            }),
+      description: [assertion],
+      passed: resultAssertion.result === AssertionResultMap.PASS,
+      click: () =>
+        hooks.setCommandAssertion({
+          commandIndex,
+          assertionIndex,
+          result:
+            resultAssertion.result === AssertionResultMap.PASS
+              ? AssertionResultMap.FAIL
+              : AssertionResultMap.PASS,
         }),
-        assertionChoice(resultAssertion, AssertionResultMap.FAIL_INCORRECT, {
-          label: [
-            `Incorrect Output `,
-            {
-              offScreen: true,
-              description: 'for assertion',
-            },
-          ],
-          click: () =>
-            hooks.setCommandAssertion({
-              commandIndex,
-              assertionIndex,
-              result: AssertionResultMap.FAIL_INCORRECT,
-            }),
-        }),
-      ],
     });
   }
 
@@ -445,34 +387,17 @@ export function instructionDocument(resultState, hooks) {
     const resultAdditionalAssertion =
       resultState.commands[commandIndex].additionalAssertions[assertionIndex];
     return /** @type {InstructionDocumentResultsCommandsAssertion} */ ({
-      description: [
-        assertion,
-        {
-          required: true,
-          highlightRequired: resultAdditionalAssertion.highlightRequired,
-          description: '(required: mark support)',
-        },
-      ],
-      passChoice: assertionChoice(resultAdditionalAssertion, AdditionalAssertionResultMap.PASS, {
-        label: ['Good Support ', { offScreen: true, description: 'for assertion' }],
-        click: () =>
-          hooks.setCommandAdditionalAssertion({
-            commandIndex,
-            additionalAssertionIndex: assertionIndex,
-            result: AdditionalAssertionResultMap.PASS,
-          }),
-      }),
-      failChoices: [
-        assertionChoice(resultAdditionalAssertion, AdditionalAssertionResultMap.FAIL_SUPPORT, {
-          label: ['No Support ', { offScreen: true, description: 'for assertion' }],
-          click: () =>
-            hooks.setCommandAdditionalAssertion({
-              commandIndex,
-              additionalAssertionIndex: assertionIndex,
-              result: AdditionalAssertionResultMap.FAIL_SUPPORT,
-            }),
+      description: [assertion],
+      passed: resultAdditionalAssertion.result === CommonResultMap.PASS,
+      click: () =>
+        hooks.setCommandAssertion({
+          commandIndex,
+          assertionIndex,
+          result:
+            resultAdditionalAssertion.result === AssertionResultMap.PASS
+              ? AssertionResultMap.FAIL
+              : AssertionResultMap.PASS,
         }),
-      ],
     });
   }
 }
@@ -535,6 +460,7 @@ export const AssertionResultMap = createEnumMap({
   ...CommonResultMap,
   FAIL_MISSING: 'failMissing',
   FAIL_INCORRECT: 'failIncorrect',
+  FAIL: 'fail',
 });
 
 /**
@@ -796,10 +722,6 @@ function isSomeFieldRequired(state) {
   return state.commands.some(
     command =>
       command.atOutput.value.trim() === '' ||
-      command.assertions.some(assertion => assertion.result === CommonResultMap.NOT_SET) ||
-      command.additionalAssertions.some(
-        assertion => assertion.result === CommonResultMap.NOT_SET
-      ) ||
       command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.NOT_SET ||
       (command.unexpected.hasUnexpected === HasUnexpectedBehaviorMap.HAS_UNEXPECTED &&
         (command.unexpected.behaviors.every(({ checked }) => !checked) ||
@@ -975,14 +897,6 @@ export function userValidateState() {
             ...command.atOutput,
             highlightRequired: !command.atOutput.value.trim(),
           },
-          assertions: command.assertions.map(assertion => ({
-            ...assertion,
-            highlightRequired: assertion.result === CommonResultMap.NOT_SET,
-          })),
-          additionalAssertions: command.additionalAssertions.map(assertion => ({
-            ...assertion,
-            highlightRequired: assertion.result === CommonResultMap.NOT_SET,
-          })),
           unexpected: {
             ...command.unexpected,
             highlightRequired:
@@ -1100,15 +1014,14 @@ export function userValidateState() {
 /**
  * @typedef InstructionDocumentResultsCommandsAssertion
  * @property {Description} description
- * @property {InstructionDocumentAssertionChoice} passChoice
- * @property {InstructionDocumentAssertionChoice[]} failChoices
+ * @property {Boolean} passed
+ * @property {boolean} [focus]
+ * @property {() => void} click
  */
 
 /**
  * @typedef InstructionDocumentResultsCommandsAssertionsHeader
  * @property {Description} descriptionHeader
- * @property {Description} passHeader
- * @property {Description} failHeader
  */
 
 /**

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -645,8 +645,7 @@ const graphqlSchema = gql`
         unexpectedBehaviors: [UnexpectedBehaviorInput]
     }
 
-    # TODO: figure out if this type can be removed and NO_OUTPUT can become an
-    # unexpected behavior instead
+    # NOTE: This has been deprecated
     enum AssertionFailedReason {
         INCORRECT_OUTPUT
         NO_OUTPUT
@@ -672,7 +671,7 @@ const graphqlSchema = gql`
         passed: Boolean
         # TODO: propose removing this for the reason given above
         """
-        When passed is false, a failedReason must be given.
+        NOTE: This has been deprecated, legacy use = when passed is false, a failedReason must be given.
         """
         failedReason: AssertionFailedReason
     }

--- a/server/migrations/20230608171911-moveTestPlanReportValuesToTestPlanVersion.js
+++ b/server/migrations/20230608171911-moveTestPlanReportValuesToTestPlanVersion.js
@@ -81,9 +81,7 @@ module.exports = {
                                             ];
                                         return {
                                             id: assertionResultSkeleton.id,
-                                            passed: assertionResult.passed,
-                                            failedReason:
-                                                assertionResult.failedReason
+                                            passed: assertionResult.passed
                                         };
                                     }
                                 ),
@@ -413,11 +411,9 @@ module.exports = {
                                                         assertionResults:
                                                             assertionResults.map(
                                                                 ({
-                                                                    failedReason,
                                                                     passed
                                                                 }) => ({
-                                                                    passed,
-                                                                    failedReason
+                                                                    passed
                                                                 })
                                                             ),
                                                         unexpectedBehaviors:

--- a/server/resolvers/TestPlanReport/conflictsResolver.js
+++ b/server/resolvers/TestPlanReport/conflictsResolver.js
@@ -85,8 +85,7 @@ const conflictsResolver = async (testPlanReport, _, context) => {
             ) {
                 const assertionResultComparisons = testResults.map(testResult =>
                     pick(testResult.scenarioResults[i].assertionResults[j], [
-                        'passed',
-                        'failedReason'
+                        'passed'
                     ])
                 );
                 if (!allEqual(assertionResultComparisons)) {

--- a/server/resolvers/TestPlanReportOperations/updateTestPlanReportTestPlanVersionResolver.js
+++ b/server/resolvers/TestPlanReportOperations/updateTestPlanReportTestPlanVersionResolver.js
@@ -61,8 +61,7 @@ const copyTestResult = (testResultSkeleton, testResult) => {
                                     ];
                                 return {
                                     id: assertionResultSkeleton.id,
-                                    passed: assertionResult.passed,
-                                    failedReason: assertionResult.failedReason
+                                    passed: assertionResult.passed
                                 };
                             }
                         ),
@@ -192,9 +191,8 @@ const updateTestPlanReportTestPlanVersionResolver = async (
                                 }) => ({
                                     output,
                                     assertionResults: assertionResults.map(
-                                        ({ failedReason, passed }) => ({
-                                            passed,
-                                            failedReason
+                                        ({ passed }) => ({
+                                            passed
                                         })
                                     ),
                                     unexpectedBehaviors:

--- a/server/resolvers/TestPlanRunOperations/createTestResultSkeleton.js
+++ b/server/resolvers/TestPlanRunOperations/createTestResultSkeleton.js
@@ -37,8 +37,7 @@ const createTestResultSkeleton = ({
                                 assertion.id
                             ),
                             assertionId: assertion.id,
-                            passed: null,
-                            failedReason: null
+                            passed: null
                         };
                     }),
                     unexpectedBehaviors: null

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -130,9 +130,7 @@ const assertTestResultIsValid = newTestResult => {
     let failed = false;
 
     const checkAssertionResult = assertionResult => {
-        if (
-            !assertionResult.passed
-        ) {
+        if (!assertionResult.passed) {
             failed = true;
         }
     };

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -131,12 +131,8 @@ const assertTestResultIsValid = newTestResult => {
 
     const checkAssertionResult = assertionResult => {
         if (
-            !(
-                (assertionResult.passed === true &&
-                    !assertionResult.failedReason) ||
-                (assertionResult.passed === false &&
-                    !!assertionResult.failedReason)
-            )
+            assertionResult.passed === null ||
+            assertionResult.passed === undefined
         ) {
             failed = true;
         }

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -131,8 +131,7 @@ const assertTestResultIsValid = newTestResult => {
 
     const checkAssertionResult = assertionResult => {
         if (
-            assertionResult.passed === null ||
-            assertionResult.passed === undefined
+            !assertionResult.passed
         ) {
             failed = true;
         }

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -130,7 +130,10 @@ const assertTestResultIsValid = newTestResult => {
     let failed = false;
 
     const checkAssertionResult = assertionResult => {
-        if (!assertionResult.passed) {
+        if (
+            assertionResult.passed === null ||
+            assertionResult.passed === undefined
+        ) {
             failed = true;
         }
     };

--- a/server/scripts/populate-test-data/populateFakeTestResults.js
+++ b/server/scripts/populate-test-data/populateFakeTestResults.js
@@ -205,7 +205,6 @@ const getFake = async ({
                             assertionResults {
                                 id
                                 passed
-                                failedReason
                             }
                         }
                     }

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -142,6 +142,7 @@ describe('graphql', () => {
         const excludedTypeNameAndField = [
             // Items formatted like this:
             // ['TestResult', 'startedAt'],
+            ['AssertionResult', 'failedReason'], // Deprecated
             ['PopulatedData', 'atVersion'],
             ['PopulatedData', 'browserVersion'],
             ['TestPlanReport', 'issues'],
@@ -396,7 +397,6 @@ describe('graphql', () => {
                                             id
                                         }
                                         passed
-                                        failedReason
                                     }
                                     unexpectedBehaviors {
                                         __typename
@@ -818,7 +818,6 @@ const getMutationInputs = async () => {
                 assertionResults {
                     id
                     passed
-                    failedReason
                 }
                 unexpectedBehaviors {
                     id

--- a/server/tests/integration/testPlanRun.test.js
+++ b/server/tests/integration/testPlanRun.test.js
@@ -193,17 +193,14 @@ describe('testPlanRun', () => {
                                             {
                                                 id: "${assertionResultId1}"
                                                 passed: true
-                                                failedReason: null
                                             }
                                             {
                                                 id: "${assertionResultId2}"
                                                 passed: null
-                                                failedReason: null
                                             }
                                             {
                                                 id: "${assertionResultId3}"
                                                 passed: null
-                                                failedReason: null
                                             }
                                         ]
                                         unexpectedBehaviors: []
@@ -252,17 +249,14 @@ describe('testPlanRun', () => {
                                             {
                                                 id: "${assertionResultId1}"
                                                 passed: true
-                                                failedReason: null
                                             }
                                             {
                                                 id: "${assertionResultId2}"
                                                 passed: null
-                                                failedReason: null
                                             }
                                             {
                                                 id: "invalid-id-123" # invalid
                                                 passed: null
-                                                failedReason: null
                                             }
                                         ]
                                         unexpectedBehaviors: []
@@ -305,17 +299,14 @@ describe('testPlanRun', () => {
                                                 {
                                                     id: "${assertionResultId1}"
                                                     passed: true
-                                                    failedReason: null
                                                 }
                                                 {
                                                     id: "${assertionResultId2}"
                                                     passed: false
-                                                    failedReason: NO_OUTPUT
                                                 }
                                                 {
                                                     id: "${assertionResultId3}"
                                                     passed: false
-                                                    failedReason: INCORRECT_OUTPUT
                                                 }
                                             ]
                                             unexpectedBehaviors: []
@@ -359,17 +350,14 @@ describe('testPlanRun', () => {
                                             {
                                                 id: "${assertionResultId1}"
                                                 passed: true
-                                                failedReason: null
                                             }
                                             {
                                                 id: "${assertionResultId2}"
                                                 passed: false
-                                                failedReason: NO_OUTPUT
                                             }
                                             {
                                                 id: "${assertionResultId3}"
                                                 passed: null # invalid
-                                                failedReason: INCORRECT_OUTPUT
                                             }
                                         ]
                                         unexpectedBehaviors: []

--- a/server/tests/integration/testQueue.test.js
+++ b/server/tests/integration/testQueue.test.js
@@ -418,7 +418,6 @@ describe('test queue', () => {
                             }
                             assertionResult {
                                 passed
-                                failedReason
                             }
                         }
                     }
@@ -445,7 +444,6 @@ describe('test queue', () => {
                   "conflictingResults": [
                     {
                       "assertionResult": {
-                        "failedReason": null,
                         "passed": true,
                       },
                       "scenarioResult": {
@@ -461,7 +459,6 @@ describe('test queue', () => {
                     },
                     {
                       "assertionResult": {
-                        "failedReason": "INCORRECT_OUTPUT",
                         "passed": false,
                       },
                       "scenarioResult": {

--- a/server/tests/integration/testQueue.test.js
+++ b/server/tests/integration/testQueue.test.js
@@ -496,58 +496,6 @@ describe('test queue', () => {
                 {
                   "conflictingResults": [
                     {
-                      "assertionResult": {
-                        "failedReason": "INCORRECT_OUTPUT",
-                        "passed": false,
-                      },
-                      "scenarioResult": {
-                        "output": "automatically seeded sample output",
-                        "unexpectedBehaviors": [],
-                      },
-                      "testPlanRun": {
-                        "id": "2",
-                        "tester": {
-                          "username": "esmeralda-baggins",
-                        },
-                      },
-                    },
-                    {
-                      "assertionResult": {
-                        "failedReason": "NO_OUTPUT",
-                        "passed": false,
-                      },
-                      "scenarioResult": {
-                        "output": "automatically seeded sample output",
-                        "unexpectedBehaviors": [],
-                      },
-                      "testPlanRun": {
-                        "id": "3",
-                        "tester": {
-                          "username": "tom-proudfeet",
-                        },
-                      },
-                    },
-                  ],
-                  "source": {
-                    "assertion": {
-                      "text": "Role 'combobox' is conveyed",
-                    },
-                    "scenario": {
-                      "commands": [
-                        {
-                          "text": "Insert+Tab",
-                        },
-                      ],
-                    },
-                    "test": {
-                      "rowNumber": 7,
-                      "title": "Read information about a collapsed select-only combobox in reading mode",
-                    },
-                  },
-                },
-                {
-                  "conflictingResults": [
-                    {
                       "assertionResult": null,
                       "scenarioResult": {
                         "output": "automatically seeded sample output",
@@ -634,67 +582,6 @@ describe('test queue', () => {
                   ],
                   "source": {
                     "assertion": null,
-                    "scenario": {
-                      "commands": [
-                        {
-                          "text": "Alt+Down",
-                        },
-                      ],
-                    },
-                    "test": {
-                      "rowNumber": 10,
-                      "title": "Open a collapsed select-only combobox in reading mode",
-                    },
-                  },
-                },
-                {
-                  "conflictingResults": [
-                    {
-                      "assertionResult": {
-                        "failedReason": "NO_OUTPUT",
-                        "passed": false,
-                      },
-                      "scenarioResult": {
-                        "output": "automatically seeded sample output",
-                        "unexpectedBehaviors": [],
-                      },
-                      "testPlanRun": {
-                        "id": "2",
-                        "tester": {
-                          "username": "esmeralda-baggins",
-                        },
-                      },
-                    },
-                    {
-                      "assertionResult": {
-                        "failedReason": "INCORRECT_OUTPUT",
-                        "passed": false,
-                      },
-                      "scenarioResult": {
-                        "output": "automatically seeded sample output",
-                        "unexpectedBehaviors": [
-                          {
-                            "otherUnexpectedBehaviorText": null,
-                            "text": "Output is excessively verbose, e.g., includes redundant and/or irrelevant speech",
-                          },
-                          {
-                            "otherUnexpectedBehaviorText": "Seeded other unexpected behavior",
-                            "text": "Other",
-                          },
-                        ],
-                      },
-                      "testPlanRun": {
-                        "id": "3",
-                        "tester": {
-                          "username": "tom-proudfeet",
-                        },
-                      },
-                    },
-                  ],
-                  "source": {
-                    "assertion": {
-                      "text": "State of the combobox (expanded) is conveyed",
-                    },
                     "scenario": {
                       "commands": [
                         {


### PR DESCRIPTION
see #736 

This PR does the following:
- Changes input elements for test runs to a fieldset with checkbox inputs.
- Updates test rendered component to use correct input change callbacks on updated assertion data structure
- Updates result comparison algorithm so that it no longer takes `failedReason` into account when calculating conflicts

For reviewers, the `client/resources` changes are not relevant to this PR and have been reviewed elsewhere.

