### PR TITLE
Remove additional css meant for (now removed) 'skipped' views

### DIFF
--- a/client/components/TestRun/TestRun.css
+++ b/client/components/TestRun/TestRun.css
@@ -135,11 +135,6 @@ button.test-navigator-toggle:focus {
     left: 4px;
 }
 
-.test-name-wrapper .progress-indicator {
-    background: White;
-    border: 2px dashed black;
-}
-
 .test-name-wrapper.conflicts .progress-indicator {
     background: #ffcd00;
 }


### PR DESCRIPTION
#833 removed references to supporting skipped tests and also to remove `.skipped` related css rules. This cleans up a remaining css rule one which incorrectly affects the progress indicators on the Test Run page.

The following screenshot shows broken lines around the progress indicator on the Test Run page:
<img width="312" alt="Screenshot showing broken lines around progress indicator" src="https://github.com/w3c/aria-at-app/assets/7191577/d8fc7eb0-df1c-4cc7-b2ea-2f0bc3a0f460">

The following screenshot shows how the progress indicator should be (and is after this change):
<img width="284" alt="Screenshot showing how the progress indicator should be" src="https://github.com/w3c/aria-at-app/assets/7191577/64809ad1-d08e-4fa8-bcf2-cb2fde9064a2">
