### PR TITLE
Do not render zeros in place of omitted content

### DIFF
--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -569,7 +569,7 @@ const TestQueueRow = ({
                             {isAdmin && renderOpenAsDropdown()}
                             {isAdmin && renderDeleteMenu()}
                             {(!isAdmin &&
-                                currentUserTestPlanRun.testResultsLength && (
+                                currentUserTestPlanRun.testResultsLength > 0 && (
                                     <Button
                                         ref={deleteTesterResultsButtonRef}
                                         variant="danger"

--- a/client/components/common/BasicThemedModal/index.jsx
+++ b/client/components/common/BasicThemedModal/index.jsx
@@ -101,8 +101,7 @@ const BasicThemedModal = ({
                             {closeLabel}
                         </Button>
                     )}
-                    {actionButtons.length &&
-                        actionButtons.map(({ action, text }) => (
+                    {actionButtons.map(({ action, text }) => (
                             <Button
                                 key={text}
                                 variant={


### PR DESCRIPTION
By relying on the "truthiness" of Number values to short-circuit boolean expressions, some rendering logic produced the text "0" instead of omitting any markup at all.

Replace the expressions whose value could be coerced to booleans with expressions which directly evaluate to "fallback" values that do not produce markup (i.e. `false` or an empty array).