### PR TITLE
Do not render zeros in place of omitted content

### DIFF
--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -346,9 +346,9 @@ const TestQueueRow = ({
                         />
                     )}
                     {!testPlanReport.conflictsLength &&
-                        testPlanReport.draftTestPlanRuns.length &&
+                        testPlanReport.draftTestPlanRuns.length > 0 &&
                         testPlanReport.draftTestPlanRuns[0]
-                            .testResultsLength && (
+                            .testResultsLength > 0 && (
                             <Button
                                 ref={updateTestPlanStatusButtonRef}
                                 variant="secondary"


### PR DESCRIPTION
By relying on the "truthiness" of Number values to short-circuit boolean expressions, some rendering logic produced the text "0" instead of omitting any markup at all.

Replace the sub-expressions whose value could be coerced to booleans with sub-expressions which directly evaluate to booleans (and which do not produce markup).