### PR TITLE
Correct heuristic for identifying "finished" runs

### DIFF
--- a/client/hooks/useTestPlanRunIsFinished.js
+++ b/client/hooks/useTestPlanRunIsFinished.js
@@ -25,7 +25,7 @@ export const useTestPlanRunIsFinished = testPlanRunId => {
     );
 
     const runIsFinished = useMemo(() => {
-        if (!testPlanRunCompletionQuery?.testPlanRun?.testResults?.length) {
+        if (!testPlanRunCompletionQuery?.testPlanRun?.testResults.length) {
             return false;
         }
 

--- a/client/hooks/useTestPlanRunIsFinished.js
+++ b/client/hooks/useTestPlanRunIsFinished.js
@@ -25,11 +25,11 @@ export const useTestPlanRunIsFinished = testPlanRunId => {
     );
 
     const runIsFinished = useMemo(() => {
-        if (!testPlanRunCompletionQuery) {
+        if (!testPlanRunCompletionQuery?.testPlanRun?.testResults?.length) {
             return false;
         }
 
-        return testPlanRunCompletionQuery.testPlanRun?.testResults.every(
+        return testPlanRunCompletionQuery.testPlanRun.testResults.every(
             testResult => testResult.completedAt !== null
         );
     }, [testPlanRunId, testPlanRunCompletionQuery]);


### PR DESCRIPTION
Prior to this commit, the user interface reported that Test Plan Runs were "finished" when they included zero test results. This state, though difficult to observe in development environments, will be apparent whenever there is a perceivable delay while scheduling collection jobs (including when collection jobs are never scheduled due to some unexpected error). Test Admins were unable to manage Test Plan Runs from this state.

Update the heuristic to identify Test Plan runs in this state as "unfinished."