### PR TITLE
Hide links to single page test plan view for test plan versions using v2

### DIFF
--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -507,6 +507,12 @@ const DataManagementRow = ({
             }
         };
 
+        // TODO: Remove this testFormatVersion check when #745 is implemented
+        const getLinkHref = version =>
+            version.metadata?.testFormatVersion === 2
+                ? null
+                : `/test-review/${version.id}`;
+
         switch (phase) {
             case 'RD': {
                 // If the latest version of the plan is in the draft, candidate, or recommended
@@ -548,12 +554,15 @@ const DataManagementRow = ({
                 // Otherwise, show VERSION_STRING link with a draft transition button. Phase is
                 // "active"
                 insertActivePhaseForTestPlan(latestVersion);
+
+                // TODO: Remove this testFormatVersion check when #745 is implemented
+                const linkHref = getLinkHref(latestVersion);
                 return (
                     <PhaseCell role="list" aria-setsize={isAdmin ? 2 : 1}>
                         <VersionString
                             role="listitem"
                             iconColor="#2BA51C"
-                            linkHref={`/test-review/${latestVersion.id}`}
+                            linkHref={linkHref}
                         >
                             {latestVersion.versionString}
                         </VersionString>
@@ -676,13 +685,15 @@ const DataManagementRow = ({
                     // Phase is "active"
                     insertActivePhaseForTestPlan(latestVersion);
 
+                    // TODO: Remove this testFormatVersion check when #745 is implemented
+                    const linkHref = getLinkHref(latestVersion);
                     return (
                         <PhaseCell role="list" aria-setsize={isAdmin ? 3 : 2}>
                             <VersionString
                                 role="listitem"
                                 iconColor="#2BA51C"
                                 linkRef={draftVersionStringRef}
-                                linkHref={`/test-review/${latestVersion.id}`}
+                                linkHref={linkHref}
                             >
                                 {latestVersion.versionString}
                             </VersionString>
@@ -880,6 +891,9 @@ const DataManagementRow = ({
 
                     // Phase is "active"
                     insertActivePhaseForTestPlan(latestVersion);
+
+                    // TODO: Remove this testFormatVersion check when #745 is implemented
+                    const linkHref = getLinkHref(latestVersion);
                     return (
                         <PhaseCell
                             role="list"
@@ -889,7 +903,7 @@ const DataManagementRow = ({
                                 role="listitem"
                                 iconColor="#2BA51C"
                                 linkRef={candidateVersionStringRef}
-                                linkHref={`/test-review/${latestVersion.id}`}
+                                linkHref={linkHref}
                             >
                                 {latestVersion.versionString}
                             </VersionString>
@@ -998,13 +1012,16 @@ const DataManagementRow = ({
 
                 // Phase is "active"
                 insertActivePhaseForTestPlan(latestVersion);
+
+                // TODO: Remove this testFormatVersion check when #745 is implemented
+                const linkHref = getLinkHref(latestVersion);
                 return (
                     <PhaseCell role="list">
                         <VersionString
                             role="listitem"
                             iconColor="#2BA51C"
                             linkRef={recommendedVersionStringRef}
-                            linkHref={`/test-review/${latestVersion.id}`}
+                            linkHref={linkHref}
                         >
                             {latestVersion.versionString}
                         </VersionString>

--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -87,6 +87,7 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
                     }
                 }
             }
+            metadata
         }
     }
 `;
@@ -133,6 +134,7 @@ export const UPDATE_TEST_PLAN_VERSION_PHASE = gql`
                             feedbackType
                         }
                     }
+                    metadata
                 }
             }
         }
@@ -179,6 +181,7 @@ export const UPDATE_TEST_PLAN_VERSION_RECOMMENDED_TARGET_DATE = gql`
                             feedbackType
                         }
                     }
+                    metadata
                 }
             }
         }

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -409,7 +409,13 @@ const TestPlanVersionsPage = () => {
                                                 testPlanVersion
                                             )}
                                             autoWidth={false}
-                                            linkHref={`/test-review/${testPlanVersion.id}`}
+                                            // TODO: Remove this testFormatVersion check when #745 is implemented
+                                            linkHref={
+                                                testPlanVersion.metadata
+                                                    ?.testFormatVersion === 2
+                                                    ? null
+                                                    : `/test-review/${testPlanVersion.id}`
+                                            }
                                         >
                                             {testPlanVersion.versionString}
                                         </VersionString>
@@ -673,21 +679,27 @@ const TestPlanVersionsPage = () => {
                                                 : {testPlanVersion.gitMessage}
                                             </a>
                                         </li>
-                                        <li>
-                                            <a
-                                                href={`/test-review/${testPlanVersion.id}`}
-                                            >
-                                                <FontAwesomeIcon
-                                                    icon={
-                                                        faArrowUpRightFromSquare
+                                        {/* TODO: Remove this testFormatVersion check when #745 is implemented */}
+                                        {testPlanVersion.metadata
+                                            .testFormatVersion === 2 ? null : (
+                                            <li>
+                                                <a
+                                                    href={`/test-review/${testPlanVersion.id}`}
+                                                >
+                                                    <FontAwesomeIcon
+                                                        icon={
+                                                            faArrowUpRightFromSquare
+                                                        }
+                                                        size="xs"
+                                                        color="#818F98"
+                                                    />
+                                                    View tests in{' '}
+                                                    {
+                                                        testPlanVersion.versionString
                                                     }
-                                                    size="xs"
-                                                    color="#818F98"
-                                                />
-                                                View tests in{' '}
-                                                {testPlanVersion.versionString}
-                                            </a>
-                                        </li>
+                                                </a>
+                                            </li>
+                                        )}
                                         {!hasFinalReports ? null : (
                                             <li>
                                                 <a

--- a/client/components/TestPlanVersionsPage/queries.js
+++ b/client/components/TestPlanVersionsPage/queries.js
@@ -41,6 +41,7 @@ export const TEST_PLAN_VERSIONS_PAGE_QUERY = gql`
                         name
                     }
                 }
+                metadata
             }
         }
     }


### PR DESCRIPTION
This PR is meant to **temporarily** hide the links to `<url>/test-review/<testplanversion_id>` as that page cannot yet support v2 test plan versions. This is to prepare for a production push.

During #745's implementation, these changes should be reverted.