### PR TITLE
Store "No output was detected." for empty string output during automated tests

### DIFF
--- a/client/components/TestRenderer/OutputTextArea/constants.js
+++ b/client/components/TestRenderer/OutputTextArea/constants.js
@@ -1,1 +1,2 @@
-export const noOutputTextAreaValue = 'No output was detected.';
+// Mirror of constant in /server/utils/constants.js
+export const NO_OUTPUT_STRING = 'No output was detected.';

--- a/client/components/TestRenderer/OutputTextArea/index.jsx
+++ b/client/components/TestRenderer/OutputTextArea/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { Feedback } from '..';
 import { Form } from 'react-bootstrap';
-import { noOutputTextAreaValue } from './constants';
+import { NO_OUTPUT_STRING } from './constants';
 
 const OutputTextAreaWrapper = styled.div`
     > textarea {
@@ -28,7 +28,7 @@ const OutputTextArea = ({
     readOnly = false
 }) => {
     const [noOutput, setNoOutput] = useState(
-        atOutput.value === noOutputTextAreaValue
+        atOutput.value === NO_OUTPUT_STRING
     );
 
     const isMounted = useRef(false);
@@ -36,7 +36,7 @@ const OutputTextArea = ({
     useEffect(() => {
         if (isMounted.current) {
             if (noOutput) {
-                atOutput.change(noOutputTextAreaValue);
+                atOutput.change(NO_OUTPUT_STRING);
             } else {
                 atOutput.change('');
             }
@@ -46,7 +46,7 @@ const OutputTextArea = ({
     }, [noOutput]);
 
     useEffect(() => {
-        setNoOutput(atOutput.value === noOutputTextAreaValue);
+        setNoOutput(atOutput.value === NO_OUTPUT_STRING);
     }, [atOutput.value]);
 
     return (
@@ -68,9 +68,7 @@ const OutputTextArea = ({
             </label>
             <NoOutputCheckbox
                 checked={noOutput}
-                disabled={
-                    atOutput.value && atOutput.value !== noOutputTextAreaValue
-                }
+                disabled={atOutput.value && atOutput.value !== NO_OUTPUT_STRING}
                 label="No output"
                 id={`no-output-checkbox-${commandIndex}`}
                 type="checkbox"

--- a/client/tests/TestRenderer/OutputTextArea.test.jsx
+++ b/client/tests/TestRenderer/OutputTextArea.test.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import OutputTextArea from '../../components/TestRenderer/OutputTextArea';
 import '@testing-library/jest-dom/extend-expect';
-import { noOutputTextAreaValue } from '../../components/TestRenderer/OutputTextArea/constants';
+import { NO_OUTPUT_STRING } from '../../components/TestRenderer/OutputTextArea/constants';
 
 describe('OutputTextArea', () => {
     let atOutputMock;
@@ -66,7 +66,7 @@ describe('OutputTextArea', () => {
         expect(textarea.value).toBe('');
 
         fireEvent.click(checkbox);
-        expect(atOutputMock.value).toBe(noOutputTextAreaValue);
+        expect(atOutputMock.value).toBe(NO_OUTPUT_STRING);
     });
 
     it('should handle textarea change', () => {
@@ -124,7 +124,7 @@ describe('OutputTextArea', () => {
     });
 
     it('should enable checkbox when textarea loads with no output default value', () => {
-        const prefilledMock = { ...atOutputMock, value: noOutputTextAreaValue };
+        const prefilledMock = { ...atOutputMock, value: NO_OUTPUT_STRING };
         render(
             <OutputTextArea
                 commandIndex={0}

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -256,7 +256,11 @@ const updateJobResults = async (req, res) => {
 // Human test runners are able to use a checkbox to indicate no output was detected.
 // This checkbox stores 'No output was detected.' as the output value for that scenarioResult.
 const convertEmptyStringsToNoOutputMessages = outputs =>
-    outputs.map(output => (output === '' ? 'No output was detected.' : output));
+    outputs.map(output =>
+        output === null || output.trim() === ''
+            ? 'No output was detected.'
+            : output
+    );
 
 module.exports = {
     cancelJob,

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -239,10 +239,12 @@ const updateJobResults = async (req, res) => {
         })
     ]);
 
+    const processedResponses = convertEmptyStringsToNoOutputMessages(responses);
+
     await updateOrCreateTestResultWithResponses({
         testId,
         testCsvRow,
-        responses,
+        responses: processedResponses,
         testPlanRun: job.testPlanRun,
         atVersionId: atVersion.id,
         browserVersionId: browserVersion.id
@@ -250,6 +252,11 @@ const updateJobResults = async (req, res) => {
 
     res.json({ success: true });
 };
+
+// Human test runners are able to use a checkbox to indicate no output was detected.
+// This checkbox stores 'No output was detected.' as the output value for that scenarioResult.
+const convertEmptyStringsToNoOutputMessages = outputs =>
+    outputs.map(output => (output === '' ? 'No output was detected.' : output));
 
 module.exports = {
     cancelJob,

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -24,6 +24,7 @@ const {
 } = require('../models/services/TestResultReadService');
 const http = require('http');
 const runnableTestsResolver = require('../resolvers/TestPlanReport/runnableTestsResolver');
+const { NO_OUTPUT_STRING } = require('../util/constants');
 const httpAgent = new http.Agent({ family: 4 });
 
 const axiosConfig = {
@@ -257,9 +258,7 @@ const updateJobResults = async (req, res) => {
 // This checkbox stores 'No output was detected.' as the output value for that scenarioResult.
 const convertEmptyStringsToNoOutputMessages = outputs =>
     outputs.map(output =>
-        output === null || output.trim() === ''
-            ? 'No output was detected.'
-            : output
+        output === null || output.trim() === '' ? NO_OUTPUT_STRING : output
     );
 
 module.exports = {

--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -1,3 +1,4 @@
+// Mirror of constant in /client/components/TestRenderer/OutputTextArea/constants.js
 const NO_OUTPUT_STRING = 'No output was detected.';
 
 module.exports = {

--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -1,0 +1,5 @@
+const NO_OUTPUT_STRING = 'No output was detected.';
+
+module.exports = {
+    NO_OUTPUT_STRING
+};


### PR DESCRIPTION
This PR updates the automation controller to store "No output was detected." for any output submitted as an empty string by an automated run. This brings the behavior inline with human submitted test results that have the "No output" checkbox checked.