### PR TITLE
Show tests as queued even before the job starts running, BotRunTestStatusList

### DIFF
--- a/client/components/BotRunTestStatusList/index.js
+++ b/client/components/BotRunTestStatusList/index.js
@@ -80,6 +80,7 @@ const BotRunTestStatusList = ({ testPlanReportId, runnableTestsLength }) => {
                     switch (status) {
                         case 'COMPLETED':
                         case 'RUNNING':
+                        case 'QUEUED':
                             res[1] +=
                                 runnableTestsLength -
                                 botTestPlanRuns[i].testResults.length;


### PR DESCRIPTION
see title.

Previously the BotRunTestStatusList would not show tests as "queued" until the test runner was running the test. This changes makes it so that tests show as queued immediately upon initialization.