### PR TITLE
Make automation result posting unit tests and simulator use rowNumber instead of index

### DIFF
--- a/server/tests/integration/automation-scheduler.test.js
+++ b/server/tests/integration/automation-scheduler.test.js
@@ -436,6 +436,8 @@ describe('Automation controller', () => {
             const testResultsNumber =
                 collectionJob.testPlanRun.testResults.length;
             const selectedTestIndex = 0;
+            const selectedTestRowNumber = 1;
+
             const selectedTest = tests[selectedTestIndex];
             const numberOfScenarios = selectedTest.scenarios.filter(
                 scenario => scenario.atId === at.id
@@ -443,7 +445,7 @@ describe('Automation controller', () => {
             const response = await sessionAgent
                 .post(`/api/jobs/${jobId}/result`)
                 .send({
-                    testCsvRow: selectedTestIndex,
+                    testCsvRow: selectedTestRowNumber,
                     atVersionName: at.atVersions[0].name,
                     browserVersionName: browser.browserVersions[0].name,
                     responses: new Array(numberOfScenarios).fill(
@@ -523,6 +525,8 @@ describe('Automation controller', () => {
                 finalizedTestPlanVersion.testPlanReport.id
             );
             const selectedTestIndex = 0;
+            const selectedTestRowNumber = 1;
+
             const historicalTestResult =
                 testPlanReport.finalizedTestResults[selectedTestIndex];
             expect(historicalTestResult).not.toEqual(undefined);
@@ -534,7 +538,7 @@ describe('Automation controller', () => {
             const response = await sessionAgent
                 .post(`/api/jobs/${jobId}/result`)
                 .send({
-                    testCsvRow: selectedTestIndex,
+                    testCsvRow: selectedTestRowNumber,
                     atVersionName: atVersion.name,
                     browserVersionName: browserVersion.name,
                     responses: historicalResponses

--- a/server/tests/util/mock-automation-scheduler-server.js
+++ b/server/tests/util/mock-automation-scheduler-server.js
@@ -50,7 +50,7 @@ const setupMockAutomationSchedulerServer = async () => {
             });
         });
         const testResult = {
-            testCsvRow: currentTestIndex,
+            testCsvRow: currentTest.rowNumber,
             atVersionName,
             browserVersionName,
             responses
@@ -122,6 +122,7 @@ const setupMockAutomationSchedulerServer = async () => {
                             }
                             runnableTests {
                                 id
+                                rowNumber
                                 scenarios {
                                     id
                                 }


### PR DESCRIPTION
These changes are needed for the unit tests and simulator related to automation to pass after the changes in 6269a96156399bdc7d898a9357605f0b239a5c38.

Part of migrating from use of the test index in `TestPlanReport.runnableTests` to `TestPlanVersion.tests.rowNumber`