### PR TITLE
Prevent multiple bot runs in the same test plan report

### DIFF
--- a/client/components/AddTestToQueueWithConfirmation/index.jsx
+++ b/client/components/AddTestToQueueWithConfirmation/index.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import BasicModal from '../common/BasicModal';
@@ -44,12 +44,16 @@ function AddTestToQueueWithConfirmation({
         at,
         browser
     });
-    const alreadyHasBotInTestPlanReport =
-        testPlanReportsInitiatedByAutomation?.testPlanVersion.testPlanReports.some(
-            tpr =>
-                tpr.markedFinalAt === null &&
-                tpr.draftTestPlanRuns.some(run => run.initiatedByAutomation)
-        );
+
+    const alreadyHasBotInTestPlanReport = useMemo(
+        () =>
+            testPlanReportsInitiatedByAutomation?.testPlanVersion.testPlanReports.some(
+                tpr =>
+                    tpr.markedFinalAt === null &&
+                    tpr.draftTestPlanRuns.some(run => run.initiatedByAutomation)
+            ),
+        [testPlanReportsInitiatedByAutomation?.testPlanVersion.testPlanReports]
+    );
 
     const feedbackModalTitle =
         hasAutomationSupport && testPlanVersion

--- a/client/components/AddTestToQueueWithConfirmation/queries.js
+++ b/client/components/AddTestToQueueWithConfirmation/queries.js
@@ -8,3 +8,18 @@ export const SCHEDULE_COLLECTION_JOB_MUTATION = gql`
         }
     }
 `;
+
+export const TEST_PLAN_RUN_REPORTS_INITIATED_BY_AUTOMATION = gql`
+    query DraftTestPlanRunsTestPlanReports($testPlanVersionId: ID!) {
+        testPlanVersion(id: $testPlanVersionId) {
+            id
+            testPlanReports {
+                id
+                markedFinalAt
+                draftTestPlanRuns {
+                    initiatedByAutomation
+                }
+            }
+        }
+    }
+`;

--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -132,7 +132,9 @@ const AssignTesterDropdown = ({
                                 ? 'assigned'
                                 : 'not-assigned';
                             let icon;
-                            if (isBot(tester) && !testerIsAssigned) {
+                            if (testerIsAssigned) {
+                                icon = faCheck;
+                            } else if (isBot(tester)) {
                                 const supportedByBot =
                                     isSupportedByResponseCollector(
                                         testPlanReportAtBrowserQuery?.testPlanReport
@@ -141,8 +143,6 @@ const AssignTesterDropdown = ({
                                     return null;
                                 }
                                 icon = faRobot;
-                            } else if (testerIsAssigned) {
-                                icon = faCheck;
                             }
                             return (
                                 <Dropdown.Item

--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -132,7 +132,7 @@ const AssignTesterDropdown = ({
                                 ? 'assigned'
                                 : 'not-assigned';
                             let icon;
-                            if (isBot(tester)) {
+                            if (isBot(tester) && !testerIsAssigned) {
                                 const supportedByBot =
                                     isSupportedByResponseCollector(
                                         testPlanReportAtBrowserQuery?.testPlanReport

--- a/client/tests/AddTestToQueueWithConfirmation.test.jsx
+++ b/client/tests/AddTestToQueueWithConfirmation.test.jsx
@@ -11,7 +11,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import { TEST_QUEUE_MUTATION_MOCK } from './__mocks__/GraphQLMocks';
 import AddTestToQueueWithConfirmation from '../components/AddTestToQueueWithConfirmation';
 import { BrowserRouter } from 'react-router-dom';
-import { InMemoryCache, useMutation } from '@apollo/client';
+import { InMemoryCache, useMutation, useQuery } from '@apollo/client';
 
 jest.mock('@apollo/client');
 
@@ -23,8 +23,26 @@ let mockTestPlanVersion,
     getByTestId,
     findByRole;
 
+const mockTestPlanReportsQueryResult = {
+    testPlanVersion: {
+        testPlanReports: [
+            {
+                id: 'report1',
+                testPlanRun: {
+                    id: 'testPlanRunId',
+                    isInitiatedByAutomation: false,
+                    markedFinalAt: null
+                }
+            }
+        ]
+    }
+};
+
 const setup = (props, mockMutation) => {
     useMutation.mockReturnValue([mockMutation, {}]);
+    useQuery.mockReturnValue({
+        data: mockTestPlanReportsQueryResult
+    });
     return render(
         <BrowserRouter>
             <MockedProvider

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -779,7 +779,6 @@ const graphqlSchema = gql`
         Postgres-provided numeric ID.
         """
         id: ID!
-        # TODO: make optional once automation is introduced.
         """
         The person who executed the tests.
         """


### PR DESCRIPTION
refer to title.

There is currently a single avenue by which one can create multiple bot runs in the same test plan report. This is through the Test Queue -> Add Tests to Test Queue flow. This PR prevents this.