### PR TITLE
Add NVDA bot user using a seeder

### DIFF
--- a/server/models/services/CollectionJobService.js
+++ b/server/models/services/CollectionJobService.js
@@ -18,11 +18,6 @@ const {
     createTestPlanRun,
     removeTestPlanRun
 } = require('./TestPlanRunService');
-const {
-    createUser,
-    getUserByUsername,
-    addUserToRole
-} = require('./UserService');
 const responseCollectionUser = require('../../util/responseCollectionUser');
 const { getTestPlanReportById } = require('./TestPlanReportService');
 const { HttpQueryError } = require('apollo-server-core');
@@ -106,26 +101,8 @@ const createCollectionJob = async (
     options
 ) => {
     if (!testPlanRun) {
-        let user = await getUserByUsername(responseCollectionUser.username);
-        if (!user) {
-            const roles = [{ name: User.TESTER }];
-            user = await createUser(
-                responseCollectionUser,
-                { roles },
-                undefined,
-                undefined,
-                [],
-                []
-            );
-        }
-
-        const { id: botUserId, roles } = user.get({ plain: true });
-        if (!roles.find(role => role.name === User.TESTER)) {
-            await addUserToRole(botUserId, User.TESTER);
-        }
-
         testPlanRun = await createTestPlanRun({
-            testerUserId: botUserId,
+            testerUserId: responseCollectionUser.id,
             testPlanReportId: testPlanReportId,
             isAutomated: true
         });

--- a/server/seeders/20231218191524-addNVDABot.js
+++ b/server/seeders/20231218191524-addNVDABot.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface) {
+        // Insert a user
+        const user = await queryInterface.bulkInsert(
+            'User',
+            [
+                {
+                    id: 9999,
+                    username: 'NVDA Bot',
+                    createdAt: new Date(),
+                    updatedAt: new Date()
+                }
+            ],
+            { returning: true }
+        );
+
+        await queryInterface.bulkInsert('UserRoles', [
+            {
+                userId: user[0].id,
+                roleName: 'TESTER'
+            }
+        ]);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.bulkDelete('User', { id: 9999 });
+    }
+};

--- a/server/seeders/20231218191524-addNVDABot.js
+++ b/server/seeders/20231218191524-addNVDABot.js
@@ -1,13 +1,14 @@
 'use strict';
 
+const responseCollectionUser = require('../util/responseCollectionUser');
+
 module.exports = {
     async up(queryInterface) {
-        // Insert a user
         const user = await queryInterface.bulkInsert(
             'User',
             [
                 {
-                    id: 9999,
+                    id: responseCollectionUser.id, // Specified ID for NVDA Bot
                     username: 'NVDA Bot',
                     createdAt: new Date(),
                     updatedAt: new Date()
@@ -25,6 +26,8 @@ module.exports = {
     },
 
     async down(queryInterface) {
-        await queryInterface.bulkDelete('User', { id: 9999 });
+        await queryInterface.bulkDelete('User', {
+            id: responseCollectionUser.id
+        });
     }
 };

--- a/server/seeders/20231218191524-addNVDABot.js
+++ b/server/seeders/20231218191524-addNVDABot.js
@@ -9,7 +9,7 @@ module.exports = {
             [
                 {
                     id: responseCollectionUser.id, // Specified ID for NVDA Bot
-                    username: 'NVDA Bot',
+                    username: responseCollectionUser.username,
                     createdAt: new Date(),
                     updatedAt: new Date()
                 }

--- a/server/util/responseCollectionUser.js
+++ b/server/util/responseCollectionUser.js
@@ -1,5 +1,7 @@
+// TODO: Defaults to NVDA, offer AT-specific bot once support is added
 const responseCollectionUser = {
-    username: 'NVDA Bot'
+    username: 'NVDA Bot',
+    id: 9999
 };
 
 module.exports = responseCollectionUser;


### PR DESCRIPTION
Add NVDA Bot as a User to the DB using a sequelize seeder.

Previously the NVDA Bot `User` was being added to the DB upon the creation of the first `CollectionJob`.

Note that the user has a predetermined id (9999). This was done in order to account for the way that the `User` table is populated currently. With the current approach to DB population, [seeders run before](https://github.com/w3c/aria-at-app/blob/main/.github/workflows/runtest.yml#L37-L42) the `populate-test-data-` script that [stores a DB dump](https://github.com/w3c/aria-at-app/blob/main/server/scripts/populate-test-data/pg_dump_2021_05_test_data.sql#L103-L104). This means that if an ID isn't specified in the seeder then the id of 1 will be automatically assigned causing a collision during the restoration of the dump. The NVDA bot user was not added directly to the DB dump because presumably the ID 3 is already taken and if we have to assign a "magically high number" then best to retain the down functionality of a Sequelize seeder.