### PR TITLE
Remove last remaining "Success Criteria" section

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/InstructionsRenderer.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/InstructionsRenderer.jsx
@@ -168,8 +168,7 @@ const InstructionsRenderer = ({
     return (
         <>
             <NumberedList>{allInstructionsContent}</NumberedList>
-            <Heading>{pageContent.instructions.assertions.header}</Heading>
-            {pageContent.instructions.assertions.description}
+            <Heading>Assertions</Heading>
             <NumberedList>{assertionsContent}</NumberedList>
             <Button
                 disabled={!pageContent.instructions.openTestPage.enabled}


### PR DESCRIPTION
Removes the success criteria section from the Candidate Review page as well as the Test Review page. I tackled this in the simplest way I could (the naive way?) so I would encourage you to not be shy if you can think of a better way to do this.