### PR TITLE
Add links to draft reports

### DIFF
--- a/client/components/TestPlanReportStatusDialog/index.jsx
+++ b/client/components/TestPlanReportStatusDialog/index.jsx
@@ -136,13 +136,9 @@ const TestPlanReportStatusDialog = ({
     };
 
     const renderReportStatus = testPlanReport => {
-        const { metrics, at, browser, markedFinalAt } = testPlanReport;
-        const { phase } = testPlanVersion;
+        const { metrics, at, browser, isFinal } = testPlanReport;
         if (metrics) {
-            if (
-                markedFinalAt &&
-                (phase === 'CANDIDATE' || phase === 'RECOMMENDED')
-            ) {
+            if (isFinal) {
                 return renderCompleteReportStatus(testPlanReport);
             } else {
                 return renderPartialCompleteReportStatus(testPlanReport);

--- a/client/components/TestPlanReportStatusDialog/queries.js
+++ b/client/components/TestPlanReportStatusDialog/queries.js
@@ -19,6 +19,7 @@ export const TEST_PLAN_REPORT_STATUS_DIALOG_QUERY = gql`
             testPlanReports {
                 id
                 metrics
+                isFinal
                 markedFinalAt
                 at {
                     id

--- a/client/components/TestPlanVersionsPage/index.jsx
+++ b/client/components/TestPlanVersionsPage/index.jsx
@@ -642,17 +642,10 @@ const TestPlanVersionsPage = () => {
                 })}
                 disclosureContainerView={testPlanVersions.map(
                     testPlanVersion => {
-                        // Gets the derived phase even if deprecated by checking
-                        // the known dates on the testPlanVersion object
-                        const derivedDeprecatedAtPhase =
-                            deriveDeprecatedDuringPhase(testPlanVersion);
-
                         const hasFinalReports =
-                            (derivedDeprecatedAtPhase === 'CANDIDATE' ||
-                                derivedDeprecatedAtPhase === 'RECOMMENDED') &&
-                            !!testPlanVersion.testPlanReports.filter(
-                                report => report.isFinal
-                            ).length;
+                            testPlanVersion.testPlanReports.some(
+                                testPlanReport => testPlanReport.isFinal
+                            );
 
                         return (
                             <div key={testPlanVersion.id}>

--- a/server/resources/ats.json
+++ b/server/resources/ats.json
@@ -72,6 +72,34 @@
                     "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
                     "If VoiceOver said 'quick nav on', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back off."
                 ]
+            },
+            "arrowQuickKeyNavOn": {
+                "screenText": "arrow quick key nav on",
+                "instructions": [
+                    "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
+                    "If VoiceOver said 'arrow quick key nav off', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back on."
+                ]
+            },
+            "arrowQuickKeyNavOff": {
+                "screenText": "arrow quick key nav off",
+                "instructions": [
+                    "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
+                    "If VoiceOver said 'arrow quick key nav on', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back off."
+                ]
+            },
+            "singleQuickKeyNavOn": {
+                "screenText": "single quick key nav on",
+                "instructions": [
+                    "Press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt;.",
+                    "If VoiceOver said 'single quick key nav off', press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt; again to turn it back on."
+                ]
+            },
+            "singleQuickKeyNavOff": {
+                "screenText": "single quick key nav off",
+                "instructions": [
+                    "Press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt;.",
+                    "If VoiceOver said 'single quick key nav on', press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt; again to turn it back off."
+                ]
             }
         }
     }

--- a/server/resources/ats.json
+++ b/server/resources/ats.json
@@ -72,34 +72,6 @@
                     "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
                     "If VoiceOver said 'quick nav on', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back off."
                 ]
-            },
-            "arrowQuickKeyNavOn": {
-                "screenText": "arrow quick key nav on",
-                "instructions": [
-                    "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
-                    "If VoiceOver said 'arrow quick key nav off', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back on."
-                ]
-            },
-            "arrowQuickKeyNavOff": {
-                "screenText": "arrow quick key nav off",
-                "instructions": [
-                    "Simultaneously press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt;.",
-                    "If VoiceOver said 'arrow quick key nav on', press &lt;kbd&gt;Left Arrow&lt;/kbd&gt; and &lt;kbd&gt;Right Arrow&lt;/kbd&gt; again to turn it back off."
-                ]
-            },
-            "singleQuickKeyNavOn": {
-                "screenText": "single quick key nav on",
-                "instructions": [
-                    "Press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt;.",
-                    "If VoiceOver said 'single quick key nav off', press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt; again to turn it back on."
-                ]
-            },
-            "singleQuickKeyNavOff": {
-                "screenText": "single quick key nav off",
-                "instructions": [
-                    "Press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt;.",
-                    "If VoiceOver said 'single quick key nav on', press &lt;kbd&gt;Control&lt;/kbd&gt;+&lt;kbd&gt;Option&lt;/kbd&gt;+&lt;kbd&gt;q&lt;/kbd&gt; again to turn it back off."
-                ]
             }
         }
     }


### PR DESCRIPTION
See https://github.com/w3c/aria-at-app/issues/799. Although we currently have the ability to show reports for test plans currently in a draft state, currently there are no links to those reports, making them inaccessible. This PR makes draft reports accessible on both the test plan version page and within the report status dialog.