### PR TITLE
Support automation reporting test results by presentationNumber for v2 tests

### DIFF
--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -135,7 +135,7 @@ const getApprovedFinalizedTestResults = async testPlanRun => {
 };
 
 const updateOrCreateTestResultWithResponses = async ({
-    testCsvRow,
+    testRowIdentifier,
     testPlanRun,
     responses,
     atVersionId,
@@ -145,11 +145,11 @@ const updateOrCreateTestResultWithResponses = async ({
         testPlanRun.testPlanReport.testPlanVersion
     );
     const testId = allTestsForTestPlanVersion.find(
-        test => parseInt(test.rowNumber, 10) === testCsvRow
+        test => parseInt(test.rowNumber, 10) === testRowIdentifier
     )?.id;
 
     if (testId === undefined) {
-        throwNoTestFoundError(testCsvRow);
+        throwNoTestFoundError(testRowIdentifier);
     }
 
     const { testResult } = await findOrCreateTestResult({
@@ -226,8 +226,13 @@ const updateOrCreateTestResultWithResponses = async ({
 
 const updateJobResults = async (req, res) => {
     const id = req.params.jobID;
-    const { testId, testCsvRow, responses, atVersionName, browserVersionName } =
-        req.body;
+    const {
+        testCsvRow,
+        presentationNumber,
+        responses,
+        atVersionName,
+        browserVersionName
+    } = req.body;
     const job = await getCollectionJobById(id);
     if (!job) {
         throwNoJobFoundError(id);
@@ -256,9 +261,11 @@ const updateJobResults = async (req, res) => {
 
     const processedResponses = convertEmptyStringsToNoOutputMessages(responses);
 
+    // v1 tests store testCsvRow in rowNumber, v2 tests store presentationNumber in rowNumber
+    const testRowIdentifier = presentationNumber ?? testCsvRow;
+
     await updateOrCreateTestResultWithResponses({
-        testId,
-        testCsvRow,
+        testRowIdentifier,
         responses: processedResponses,
         testPlanRun: job.testPlanRun,
         atVersionId: atVersion.id,

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -43,10 +43,10 @@ const throwNoJobFoundError = jobId => {
     );
 };
 
-const throwNoTestFoundError = testCsvRow => {
+const throwNoTestFoundError = rowNumber => {
     throw new HttpQueryError(
         404,
-        `Could not find test at CSV row number ${testCsvRow}`,
+        `Could not find test at row number ${rowNumber}`,
         true
     );
 };


### PR DESCRIPTION
In the app, v1 tests have the `rawTestId` value in the `rowNumber` [property as seen here](https://github.com/w3c/aria-at-app/blob/8215cb96af64aba1cf84b31e86d480668bf8a37e/server/scripts/import-tests/index.js#L485). Whereas, v2 tests use the `presentationNumber` in the `rowNumber` property [as seen here.](https://github.com/w3c/aria-at-app/blob/56205a32f904964dbb36c943d4e3fdb9d2522ce9/server/scripts/import-tests/index.js#L533).

For this reason, the app hasn't supported receiving results from v2 tests. After [these updates to the harness](https://github.com/w3c/aria-at-automation-harness/pull/35), the harness now sends the `presentationNumber`. This change to the app will enable look up of the test by this value.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206226143670047