### PR TITLE
Include `testFormatVersion` attribute in additional instances for `TestPlanVersion` data

### DIFF
--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -438,6 +438,12 @@ const graphqlSchema = gql`
         Vendors who viewed the tests
         """
         viewers: [User]
+        """
+        Version number to indicate which of the following test writing specs this test is based on:
+        1: https://github.com/w3c/aria-at/wiki/Test-Format-V1-Definition
+        2: https://github.com/w3c/aria-at/wiki/Test-Format-Definition-V2
+        """
+        testFormatVersion: Int!
     }
 
     type RenderableContentByAt {

--- a/server/migrations/20240104150500-includeAdditionalTestFormatVersionAttributes.js
+++ b/server/migrations/20240104150500-includeAdditionalTestFormatVersionAttributes.js
@@ -14,7 +14,7 @@ module.exports = {
          * Recompute TestPlanVersion.hashedTests
          * @param transaction - The Sequelize.Transaction object.
          * See {@https://sequelize.org/api/v6/class/src/sequelize.js~sequelize#instance-method-transaction}
-         * @returns {Promise<{testPlanVersionsByHashedTests: {}}>}
+         * @returns {Promise<void>}
          */
         const computeTestPlanVersionHashedTests = async transaction => {
             const results = await queryInterface.sequelize.query(

--- a/server/migrations/20240104150500-includeAdditionalTestFormatVersionAttributes.js
+++ b/server/migrations/20240104150500-includeAdditionalTestFormatVersionAttributes.js
@@ -1,0 +1,262 @@
+'use strict';
+
+const {
+    createTestResultId,
+    createScenarioResultId,
+    createAssertionResultId
+} = require('../services/PopulatedData/locationOfDataId');
+const { hashTests } = require('../util/aria');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        /**
+         * Compute TestPlanVersion.hashedTests and return the unique TestPlanVersions found for each
+         * hash
+         * @param transaction - The Sequelize.Transaction object.
+         * See {@https://sequelize.org/api/v6/class/src/sequelize.js~sequelize#instance-method-transaction}
+         * @returns {Promise<{testPlanVersionsByHashedTests: {}}>}
+         */
+        const computeTestPlanVersionHashedTests = async transaction => {
+            const results = await queryInterface.sequelize.query(
+                `SELECT COUNT(*) FROM "TestPlanVersion"`,
+                { transaction }
+            );
+            const [[{ count: testPlanVersionCount }]] = results;
+
+            const testPlanVersionBatchSize = 10;
+            const iterationsNeeded = Math.ceil(
+                testPlanVersionCount / testPlanVersionBatchSize
+            );
+
+            for (let i = 0; i < iterationsNeeded; i += 1) {
+                const multipleOf100 = i % testPlanVersionBatchSize === 0;
+                if (multipleOf100)
+                    // eslint-disable-next-line no-console
+                    console.info(
+                        'Indexing TestPlanVersions',
+                        i * testPlanVersionBatchSize,
+                        'of',
+                        Number(testPlanVersionCount)
+                    );
+                const currentOffset = i * testPlanVersionBatchSize;
+
+                const [testPlanVersions] = await queryInterface.sequelize.query(
+                    `SELECT id, directory, "gitSha", tests, "updatedAt" FROM "TestPlanVersion" ORDER BY id LIMIT ? OFFSET ?`,
+                    {
+                        replacements: [testPlanVersionBatchSize, currentOffset],
+                        transaction
+                    }
+                );
+
+                await Promise.all(
+                    testPlanVersions.map(async testPlanVersion => {
+                        const hashedTests = hashTests(testPlanVersion.tests);
+
+                        await queryInterface.sequelize.query(
+                            `UPDATE "TestPlanVersion" SET "hashedTests" = ? WHERE id = ?`,
+                            {
+                                replacements: [hashedTests, testPlanVersion.id],
+                                transaction
+                            }
+                        );
+                    })
+                );
+            }
+        };
+
+        /**
+         * Regenerate the testIds, scenarioIds and assertionsIds in TestRun.testResults, for
+         * TestRuns
+         * @param transaction - The Sequelize.Transaction object.
+         * See {@https://sequelize.org/api/v6/class/src/sequelize.js~sequelize#instance-method-transaction}
+         * @returns {Promise<void>}
+         */
+        const regenerateExistingTestResults = async transaction => {
+            const testPlanVersions = await queryInterface.sequelize.query(
+                `SELECT id, tests FROM "TestPlanVersion"`,
+                {
+                    type: Sequelize.QueryTypes.SELECT,
+                    transaction
+                }
+            );
+
+            if (testPlanVersions.length) {
+                const testPlanReports = await queryInterface.sequelize.query(
+                    `select id, "testPlanVersionId"
+                     from "TestPlanReport"
+                     where "testPlanVersionId" in (?)`,
+                    {
+                        replacements: [testPlanVersions.map(e => e.id)],
+                        type: Sequelize.QueryTypes.SELECT,
+                        transaction
+                    }
+                );
+
+                for (const key in testPlanReports) {
+                    const { id: testPlanReportId } = testPlanReports[key];
+
+                    const testPlanRuns = await queryInterface.sequelize.query(
+                        `select testPlanRun.id, "testPlanReportId", "atId", "testPlanVersionId", "testResults", tests
+                         from "TestPlanRun" testPlanRun
+                                  join "TestPlanReport" testPlanReport
+                                       on testPlanReport.id = testPlanRun."testPlanReportId"
+                                  join "TestPlanVersion" testPlanVersion
+                                       on testPlanVersion.id = testPlanReport."testPlanVersionId"
+                         where "testPlanReportId" = ?`,
+                        {
+                            replacements: [testPlanReportId],
+                            type: Sequelize.QueryTypes.SELECT,
+                            transaction
+                        }
+                    );
+
+                    for (const key in testPlanRuns) {
+                        const {
+                            id: testPlanRunId,
+                            atId,
+                            testResults,
+                            tests
+                        } = testPlanRuns[key];
+
+                        tests.forEach(test => {
+                            const testId = test.id;
+
+                            testResults.forEach(testResult => {
+                                if (testResult.testId === testId) {
+                                    // Update testResult.id
+                                    const testResultId = createTestResultId(
+                                        testPlanRunId,
+                                        testResult.testId
+                                    );
+                                    testResult.id = testResultId;
+
+                                    // The sub-arrays should be in the same order
+                                    testResult.scenarioResults.forEach(
+                                        (eachScenarioResult, scenarioIndex) => {
+                                            eachScenarioResult.scenarioId =
+                                                test.scenarios.filter(
+                                                    scenario =>
+                                                        scenario.atId === atId
+                                                )[scenarioIndex].id;
+
+                                            // Update eachScenarioResult.id
+                                            const scenarioResultId =
+                                                createScenarioResultId(
+                                                    testResultId,
+                                                    eachScenarioResult.scenarioId
+                                                );
+                                            eachScenarioResult.id =
+                                                scenarioResultId;
+
+                                            eachScenarioResult.assertionResults.forEach(
+                                                (
+                                                    eachAssertionResult,
+                                                    assertionIndex
+                                                ) => {
+                                                    eachAssertionResult.assertionId =
+                                                        test.assertions[
+                                                            assertionIndex
+                                                        ].id;
+
+                                                    // Update eachAssertionResult.id
+                                                    eachAssertionResult.id =
+                                                        createAssertionResultId(
+                                                            scenarioResultId,
+                                                            eachAssertionResult.assertionId
+                                                        );
+                                                }
+                                            );
+                                        }
+                                    );
+                                }
+                            });
+                        });
+
+                        await queryInterface.sequelize.query(
+                            `update "TestPlanRun"
+                             set "testResults" = ?
+                             where id = ?`,
+                            {
+                                replacements: [
+                                    JSON.stringify(testResults),
+                                    testPlanRunId
+                                ],
+                                transaction
+                            }
+                        );
+                        // eslint-disable-next-line no-console
+                        console.info(
+                            'Fixing testResults for TestPlanRun',
+                            testPlanRunId
+                        );
+                    }
+                }
+            }
+        };
+
+        const updateV1TestPlanVersionsToIncludeTestFormatVersion =
+            async transaction => {
+                // No testFormatVersion indicates this is v1 TestPlanVersion data
+                const testPlanVersions = await queryInterface.sequelize.query(
+                    `SELECT id, metadata FROM "TestPlanVersion" WHERE metadata->>'testFormatVersion' IS NULL`,
+                    {
+                        type: Sequelize.QueryTypes.SELECT,
+                        transaction
+                    }
+                );
+
+                await Promise.all(
+                    testPlanVersions.map(async ({ id, metadata }) => {
+                        const updatedMetadata = JSON.stringify({
+                            ...metadata,
+                            testFormatVersion: 1
+                        });
+                        await queryInterface.sequelize.query(
+                            `UPDATE "TestPlanVersion" SET metadata = ? WHERE id = ?`,
+                            { replacements: [updatedMetadata, id], transaction }
+                        );
+                    })
+                );
+            };
+
+        const updateTestPlanVersionTestsToIncludeTestFormatVersion =
+            async transaction => {
+                const testPlanVersions = await queryInterface.sequelize.query(
+                    `SELECT id, tests, metadata FROM "TestPlanVersion"`,
+                    {
+                        type: Sequelize.QueryTypes.SELECT,
+                        transaction
+                    }
+                );
+                await Promise.all(
+                    testPlanVersions.map(async ({ id, tests, metadata }) => {
+                        const testFormatVersion = metadata.testFormatVersion;
+                        const updatedTests = JSON.stringify(
+                            tests.map(test => ({ ...test, testFormatVersion }))
+                        );
+                        await queryInterface.sequelize.query(
+                            `UPDATE "TestPlanVersion" SET tests = ? WHERE id = ?`,
+                            { replacements: [updatedTests, id], transaction }
+                        );
+                    })
+                );
+            };
+
+        return queryInterface.sequelize.transaction(async transaction => {
+            // Include testFormatVersion inside TestPlanVersion.metadata for v1 test plan versions
+            await updateV1TestPlanVersionsToIncludeTestFormatVersion(
+                transaction
+            );
+
+            // Include testFormatVersion for each test inside TestPlanVersion.tests
+            await updateTestPlanVersionTestsToIncludeTestFormatVersion(
+                transaction
+            );
+
+            // Recalculate the hashes
+            await computeTestPlanVersionHashedTests(transaction);
+            await regenerateExistingTestResults(transaction);
+        });
+    }
+};

--- a/server/migrations/20240104150500-includeAdditionalTestFormatVersionAttributes.js
+++ b/server/migrations/20240104150500-includeAdditionalTestFormatVersionAttributes.js
@@ -11,8 +11,7 @@ const { hashTests } = require('../util/aria');
 module.exports = {
     async up(queryInterface, Sequelize) {
         /**
-         * Compute TestPlanVersion.hashedTests and return the unique TestPlanVersions found for each
-         * hash
+         * Recompute TestPlanVersion.hashedTests
          * @param transaction - The Sequelize.Transaction object.
          * See {@https://sequelize.org/api/v6/class/src/sequelize.js~sequelize#instance-method-transaction}
          * @returns {Promise<{testPlanVersionsByHashedTests: {}}>}

--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -515,7 +515,8 @@ const getTests = ({
                     return scenarios;
                 })(),
                 assertions: getAssertions(common, testId),
-                viewers: []
+                viewers: [],
+                testFormatVersion: 1
             });
         }
 
@@ -595,7 +596,8 @@ const getTests = ({
                         return scenarios;
                     })(),
                     assertions: getAssertions(collected, testId),
-                    viewers: []
+                    viewers: [],
+                    testFormatVersion: 2
                 };
 
                 tests.push(test);

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -286,6 +286,7 @@ describe('graphql', () => {
                                     priority
                                     text
                                 }
+                                testFormatVersion
                             }
                         }
                         testPlanVersions {


### PR DESCRIPTION
There is a need for a wider inclusion of the `testFormatVersion` attribute for related `TestPlanVersion` row data. This PR does the following:
* Includes testFormatVersion in `TestPlanVersion.tests[]` when running the import script
* Adds database migration to include missing instances of `TestPlanVersion.metadata.testFormatVersion` for v1 TestPlanVersion rows
* Adds database migration to include missing instances of `TestPlanVersion.tests[].testFormatVersion` for every TestPlanVersion row