### PR TITLE
Show major browser version on first load of Test Run

### DIFF
--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -50,7 +50,7 @@ const TestRun = () => {
     const routerQuery = useRouterQuery();
 
     // Detect UA information
-    const { uaBrowser, uaMajor, uaMinor, uaPatch } = useDetectUa();
+    const { uaBrowser, uaMajor } = useDetectUa();
 
     const titleRef = useRef();
     // To prevent default AT/Browser versions being set before initial
@@ -223,12 +223,18 @@ const TestRun = () => {
             ) ||
             'N/A';
 
-        const currentBrowserVersion =
+        let currentBrowserVersion =
             currentTest.testResult?.browserVersion ||
             testPlanReport.browser.browserVersions.find(
                 item => item.id === currentTestBrowserVersionId
             ) ||
             'N/A';
+
+        // Only show major version of browser
+        currentBrowserVersion = {
+            id: currentAtVersion.id,
+            name: currentBrowserVersion.name.split('.')[0]
+        };
 
         // Auto batch the states
         setUsers(users);
@@ -709,7 +715,7 @@ const TestRun = () => {
                     <>
                         You are currently using{' '}
                         <b>
-                            {uaBrowser} {uaMajor}.{uaMinor}.{uaPatch}
+                            {uaBrowser} {uaMajor}
                         </b>
                         , but are trying to edit a test result that was
                         submitted with{' '}
@@ -772,7 +778,7 @@ const TestRun = () => {
 
             if (
                 !adminReviewerOriginalTestRef.current.testResult?.browserVersion?.name.includes(
-                    `${uaMajor}.${uaMinor}.${uaPatch}`
+                    `${uaMajor}`
                 )
             ) {
                 setThemedModalTitle(
@@ -782,7 +788,7 @@ const TestRun = () => {
                     <>
                         You are currently using{' '}
                         <b>
-                            {uaBrowser} {uaMajor}.{uaMinor}.{uaPatch}
+                            {uaBrowser} {uaMajor}
                         </b>
                         , but are trying to edit a test result that was
                         submitted with{' '}

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -846,6 +846,12 @@ const TestRun = () => {
                     ?.findOrCreateBrowserVersion;
         }
 
+        // Only show major browser version
+        browserVersion = {
+            id: browserVersion.id,
+            name: browserVersion.name.split('.')[0]
+        };
+
         const updateMessageComponent = updateMessage ? (
             <>
                 <FontAwesomeIcon icon={faCheckCircle} />

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -198,17 +198,17 @@ const AtAndBrowserDetailsModal = ({
         // Discard trailing zeros in found minor and patches.
         // This also accounts for trailing numbers after the patch.
         let fullVersion = '';
-        let [majorVersion, minorVersion, patch, ...rest] =
+        let [majorVersion, minorVersion = '0', patchVersion = '0', ...rest] =
             updatedBrowserVersion.split('.');
 
-        if (minorVersion === '0' && (patch === '0' || patch === undefined)) {
+        if (minorVersion === '0' && patchVersion === '0') {
             fullVersion = `${majorVersion}`;
-        } else if (patch === '0' || patch === undefined) {
+        } else if (patchVersion === '0') {
             fullVersion = `${majorVersion}.${minorVersion}`;
         } else if (rest === undefined || rest.length === 0) {
-            fullVersion = `${majorVersion}.${minorVersion}.${patch}`;
+            fullVersion = `${majorVersion}.${minorVersion}.${patchVersion}`;
         } else {
-            fullVersion = `${majorVersion}.${minorVersion}.${patch}.${rest.join(
+            fullVersion = `${majorVersion}.${minorVersion}.${patchVersion}.${rest.join(
                 '.'
             )}`;
         }

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -54,6 +54,8 @@ const AtAndBrowserDetailsModal = ({
     handleAction = () => {},
     handleClose = () => {}
 }) => {
+    // Only take into account the major version
+    // of the provided browser version
     if (browserVersion.includes('.')) {
         browserVersion = browserVersion.split('.')[0];
     }
@@ -93,15 +95,13 @@ const AtAndBrowserDetailsModal = ({
         }
 
         const foundBrowserVersion =
-            uaBrowser === browserName &&
-            uaMajor !== '0' &&
-            `${uaMajor}.${uaMinor}.${uaPatch}`;
+            uaBrowser === browserName && uaMajor !== '0' && `${uaMajor}`;
 
         if (
             // don't force browserVersion update with admin (unless first run)
             (!isAdmin || (isAdmin && firstLoad)) &&
             // check that saved browserVersion is the same as detected
-            !browserVersion.includes(`${uaMajor}.${uaMinor}.${uaPatch}`) &&
+            !browserVersion.includes(`${uaMajor}`) &&
             uaBrowser === browserName &&
             foundBrowserVersion
         ) {
@@ -194,7 +194,16 @@ const AtAndBrowserDetailsModal = ({
                 );
         }
 
-        handleAction(updatedAtVersion, updatedBrowserVersion, updateMessage);
+        // Save full version even though we don't display it
+        // This will only take effect if the updatedBrowserVersion
+        // matches the found major version
+        let fullVersion = updatedBrowserVersion;
+
+        if (!fullVersion.includes('.') && fullVersion == uaMajor) {
+            fullVersion = `${uaMajor}.${uaMinor}.${uaPatch}`;
+        }
+
+        handleAction(updatedAtVersion, fullVersion, updateMessage);
     };
 
     const handleHide = () => setShowExitModal(true);

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -205,7 +205,7 @@ const AtAndBrowserDetailsModal = ({
             fullVersion = `${majorVersion}`;
         } else if (patch === '0' || patch === undefined) {
             fullVersion = `${majorVersion}.${minorVersion}`;
-        } else if (rest === undefined) {
+        } else if (rest === undefined || rest.length === 0) {
             fullVersion = `${majorVersion}.${minorVersion}.${patch}`;
         } else {
             fullVersion = `${majorVersion}.${minorVersion}.${patch}.${rest.join(

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -95,13 +95,13 @@ const AtAndBrowserDetailsModal = ({
         }
 
         const foundBrowserVersion =
-            uaBrowser === browserName && uaMajor !== '0' && `${uaMajor}`;
+            uaBrowser === browserName && uaMajor !== '0' && uaMajor;
 
         if (
             // don't force browserVersion update with admin (unless first run)
             (!isAdmin || (isAdmin && firstLoad)) &&
             // check that saved browserVersion is the same as detected
-            !browserVersion.includes(`${uaMajor}`) &&
+            !browserVersion.includes(uaMajor) &&
             uaBrowser === browserName &&
             foundBrowserVersion
         ) {

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -54,6 +54,9 @@ const AtAndBrowserDetailsModal = ({
     handleAction = () => {},
     handleClose = () => {}
 }) => {
+    if (browserVersion.includes('.')) {
+        browserVersion = browserVersion.split('.')[0];
+    }
     // Detect UA information
     const { uaBrowser, uaMajor, uaMinor, uaPatch } = useDetectUa();
 
@@ -109,10 +112,7 @@ const AtAndBrowserDetailsModal = ({
 
     useEffect(() => {
         // check to support Tester Scenario 5
-        if (
-            uaMajor !== '0' &&
-            !updatedBrowserVersion.includes(`${uaMajor}.${uaMinor}.${uaPatch}`)
-        )
+        if (uaMajor !== '0' && !updatedBrowserVersion.includes(`${uaMajor}`))
             setBrowserVersionMismatchMessage(true);
         else setBrowserVersionMismatchMessage(!isAdmin && false);
     }, [updatedBrowserVersion, uaMajor, uaMinor, uaPatch]);
@@ -414,8 +414,7 @@ const AtAndBrowserDetailsModal = ({
                                                 We have automatically detected
                                                 you are using{' '}
                                                 <b>
-                                                    {uaBrowser} {uaMajor}.
-                                                    {uaMinor}.{uaPatch}
+                                                    {uaBrowser} {uaMajor}
                                                 </b>
                                                 . This test plan requires{' '}
                                                 <b>{browserName}</b>. If you are
@@ -441,8 +440,7 @@ const AtAndBrowserDetailsModal = ({
                                                 We have automatically detected
                                                 you are now using{' '}
                                                 <b>
-                                                    {uaBrowser} {uaMajor}.
-                                                    {uaMinor}.{uaPatch}
+                                                    {uaBrowser} {uaMajor}
                                                 </b>
                                                 , which is a different browser
                                                 from the last one you were
@@ -457,8 +455,7 @@ const AtAndBrowserDetailsModal = ({
                                                 You can&apos;t edit your Browser
                                                 type, but you can continue with{' '}
                                                 <b>
-                                                    {uaBrowser} {uaMajor}.
-                                                    {uaMinor}.{uaPatch}
+                                                    {uaBrowser} {uaMajor}
                                                 </b>
                                                 . Keep in mind that your test
                                                 results will be recorded as if
@@ -487,10 +484,7 @@ const AtAndBrowserDetailsModal = ({
                                                 have set is different from the
                                                 one we have automatically
                                                 detected, which is{' '}
-                                                <b>
-                                                    {uaMajor}.{uaMinor}.
-                                                    {uaPatch}
-                                                </b>
+                                                <b>{uaMajor}</b>
                                                 .
                                                 <br />
                                                 <br />
@@ -536,8 +530,7 @@ const AtAndBrowserDetailsModal = ({
                                                 We have automatically detected
                                                 you are using{' '}
                                                 <b>
-                                                    {uaBrowser} {uaMajor}.
-                                                    {uaMinor}.{uaPatch}
+                                                    {uaBrowser} {uaMajor}
                                                 </b>
                                                 . This version is different than
                                                 what <b>{testerName}</b> was

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -194,13 +194,23 @@ const AtAndBrowserDetailsModal = ({
                 );
         }
 
-        // Save full version even though we don't display it
-        // This will only take effect if the updatedBrowserVersion
-        // matches the found major version
-        let fullVersion = updatedBrowserVersion;
+        // Save full version even though we don't display it.
+        // Discard trailing zeros in found minor and patches.
+        // This also accounts for trailing numbers after the patch.
+        let fullVersion = '';
+        let [majorVersion, minorVersion, patch, ...rest] =
+            updatedBrowserVersion.split('.');
 
-        if (!fullVersion.includes('.') && fullVersion == uaMajor) {
-            fullVersion = `${uaMajor}.${uaMinor}.${uaPatch}`;
+        if (minorVersion === '0' && (patch === '0' || patch === undefined)) {
+            fullVersion = `${majorVersion}`;
+        } else if (patch === '0' || patch === undefined) {
+            fullVersion = `${majorVersion}.${minorVersion}`;
+        } else if (rest === undefined) {
+            fullVersion = `${majorVersion}.${minorVersion}.${patch}`;
+        } else {
+            fullVersion = `${majorVersion}.${minorVersion}.${patch}.${rest.join(
+                '.'
+            )}`;
         }
 
         handleAction(updatedAtVersion, fullVersion, updateMessage);


### PR DESCRIPTION
This PR addresses #810, which aims to only show the major browser version when confirming the user's browser version.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206550059310407