### PR TITLE
Ensure that the In Review filter captures all test plans that have a draft review

### DIFF
--- a/client/components/DataManagement/filterSortHooks.js
+++ b/client/components/DataManagement/filterSortHooks.js
@@ -181,30 +181,23 @@ export const useDataManagementTableFiltering = (
         })`;
     }
 
-    // Find test plan versions with DRAFT advanced, even if
-    // the overall phase is not draft
-    // const testPlansWithDraft = new Map();
-    // const draftCount = testPlanVersions.reduce((acc, version) => {
-    //     if (
-    //         version.draftPhaseReachedAt !== null &&
-    //         version.phase == TEST_PLAN_VERSION_PHASES.DRAFT &&
-    //         !testPlansWithDraft.has(version.title)
-    //     ) {
-    //         acc++;
-    //         testPlansWithDraft.set(version.title, version);
-    //     }
-    //     return acc;
-    // }, 0);
-
     if (
         testPlansByPhase[TEST_PLAN_VERSION_PHASES.DRAFT].length > 0 ||
         Object.values(derivedDraftTestPlans).length > 0
     ) {
+        const allDrafts = [
+            ...Object.values(derivedDraftTestPlans),
+            ...testPlansByPhase[TEST_PLAN_VERSION_PHASES.DRAFT]
+        ];
         filterLabels[
             DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.DRAFT
         ] = `In Draft Review (${
-            Object.values(derivedDraftTestPlans).length.toString() ||
-            testPlansByPhase[TEST_PLAN_VERSION_PHASES.DRAFT].length
+            allDrafts.filter((draft, index) => {
+                return (
+                    index ===
+                    allDrafts.findIndex(testPlan => draft.id === testPlan.id)
+                );
+            }).length
         })`;
     }
 

--- a/client/components/DataManagement/filterSortHooks.js
+++ b/client/components/DataManagement/filterSortHooks.js
@@ -78,8 +78,9 @@ export const useDerivedActivePhasesByTestPlanId = (
                 // while the subsequent elements in the array are TestPlanVersions
                 // that are in other phases
                 if (derivedPhase) {
-                    let arr = activeTestPlanVersionsByPhase[testPlan.id];
-                    if (!arr) activeTestPlanVersionsByPhase[testPlan.id] = [];
+                    // Ensure the array exists or initialize it directly before pushing the new phase
+                    activeTestPlanVersionsByPhase[testPlan.id] =
+                        activeTestPlanVersionsByPhase[testPlan.id] ?? [];
                     activeTestPlanVersionsByPhase[testPlan.id].push(
                         derivedPhase
                     );

--- a/client/components/DataManagement/filterSortHooks.js
+++ b/client/components/DataManagement/filterSortHooks.js
@@ -158,7 +158,10 @@ export const useDataManagementTableFiltering = (
         if (!filter || filter === DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.ALL) {
             return testPlans;
         } else {
-            if (Object.values(derivedDraftTestPlans).length > 0) {
+            if (
+                Object.values(derivedDraftTestPlans).length > 0 &&
+                filter == DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.DRAFT
+            ) {
                 return Object.values(derivedDraftTestPlans);
             } else {
                 return testPlansByPhase[filter];
@@ -195,13 +198,13 @@ export const useDataManagementTableFiltering = (
 
     if (
         testPlansByPhase[TEST_PLAN_VERSION_PHASES.DRAFT].length > 0 ||
-        Object.keys(derivedDraftTestPlans).length > 0
+        Object.values(derivedDraftTestPlans).length > 0
     ) {
         filterLabels[
             DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.DRAFT
         ] = `In Draft Review (${
-            testPlansByPhase[TEST_PLAN_VERSION_PHASES.DRAFT].length ||
-            Object.keys(derivedDraftTestPlans).length.toString()
+            Object.values(derivedDraftTestPlans).length.toString() ||
+            testPlansByPhase[TEST_PLAN_VERSION_PHASES.DRAFT].length
         })`;
     }
 

--- a/client/tests/DataManagement.test.jsx
+++ b/client/tests/DataManagement.test.jsx
@@ -93,35 +93,30 @@ const testPlanVersions = [
     {
         phase: 'RD',
         id: '101',
-        title: 'testA',
         testPlan: { directory: 'dirA' },
         updatedAt: '2022-03-17T18:34:51.000Z'
     },
     {
         phase: 'DRAFT',
         id: '102',
-        title: 'testB',
         testPlan: { directory: 'dirB' },
         draftStatusReachedAt: '2022-05-18T20:51:40.000Z'
     },
     {
         phase: 'CANDIDATE',
         id: '103',
-        title: 'testC',
         testPlan: { directory: 'dirC' },
         candidatePhaseReachedAt: '2022-04-10T00:00:00.000Z'
     },
     {
         phase: 'RD',
         id: '104',
-        title: 'testD',
         testPlan: { directory: 'dirD' },
         updatedAt: '2022-03-18T18:34:51.000Z'
     },
     {
         phase: 'RECOMMENDED',
         id: '105',
-        title: 'testD',
         testPlan: { directory: 'dirD' },
         recommendedPhaseReachedAt: '2022-05-18T20:51:40.000Z'
     },
@@ -210,8 +205,10 @@ describe('useDataManagementTableFiltering hook', () => {
             )
         );
         expect(result.current.filteredTestPlans).toEqual([
-            testPlans[1] // DRAFT
+            testPlans[1], // DRAFT
+            testPlans[3] // DRAFT
         ]);
+        console.log(result);
         expect(
             result.current.filterLabels[
                 DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.DRAFT
@@ -276,7 +273,9 @@ describe('useDerivedTestPlanOverallPhase hook', () => {
         const { result } = renderHook(() =>
             useDerivedOverallPhaseByTestPlanId(testPlans, testPlanVersions)
         );
-        const { derivedOverallPhaseByTestPlanId } = result.current;
+        const {
+            derivedOverallPhaseByTestPlanId: { derivedOverallPhaseByTestPlanId }
+        } = result.current;
         expect(derivedOverallPhaseByTestPlanId).toEqual({
             1: 'RD',
             2: 'DRAFT',

--- a/client/tests/DataManagement.test.jsx
+++ b/client/tests/DataManagement.test.jsx
@@ -17,7 +17,7 @@ import { act } from 'react-dom/test-utils';
 import {
     useDataManagementTableFiltering,
     useDataManagementTableSorting,
-    useDerivedOverallPhaseByTestPlanId,
+    useDerivedActivePhasesByTestPlanId,
     useTestPlanVersionsByPhase,
     useTestPlansByPhase
 } from '../components/DataManagement/filterSortHooks';
@@ -270,12 +270,10 @@ describe('useTestPlanVersionsByPhase hook', () => {
 describe('useDerivedTestPlanOverallPhase hook', () => {
     it('returns an object with the active phases mapped to each test plan id', () => {
         const { result } = renderHook(() =>
-            useDerivedOverallPhaseByTestPlanId(testPlans, testPlanVersions)
+            useDerivedActivePhasesByTestPlanId(testPlans, testPlanVersions)
         );
-        const {
-            derivedOverallPhaseByTestPlanId: { activeTestPlanVersionsByPhase }
-        } = result.current;
-        expect(activeTestPlanVersionsByPhase).toEqual({
+        const { derivedActivePhasesByTestPlanId } = result.current;
+        expect(derivedActivePhasesByTestPlanId).toEqual({
             1: ['RD'],
             2: ['DRAFT'],
             3: ['CANDIDATE'],

--- a/client/tests/DataManagement.test.jsx
+++ b/client/tests/DataManagement.test.jsx
@@ -208,7 +208,6 @@ describe('useDataManagementTableFiltering hook', () => {
             testPlans[1], // DRAFT
             testPlans[3] // DRAFT
         ]);
-        console.log(result);
         expect(
             result.current.filterLabels[
                 DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.DRAFT

--- a/client/tests/DataManagement.test.jsx
+++ b/client/tests/DataManagement.test.jsx
@@ -188,11 +188,12 @@ describe('useDataManagementTableFiltering hook', () => {
             )
         );
         expect(result.current.filteredTestPlans).toEqual([
-            testPlans[0] // RD
+            testPlans[0], // RD
+            testPlans[3]
         ]);
         expect(
             result.current.filterLabels[DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.RD]
-        ).toEqual(`R&D Complete (1)`);
+        ).toEqual(`R&D Complete (2)`);
     });
 
     it('can filter by DRAFT phase', () => {
@@ -267,31 +268,31 @@ describe('useTestPlanVersionsByPhase hook', () => {
 });
 
 describe('useDerivedTestPlanOverallPhase hook', () => {
-    it('returns an object with the overall phase mapped to each test plan id', () => {
+    it('returns an object with the active phases mapped to each test plan id', () => {
         const { result } = renderHook(() =>
             useDerivedOverallPhaseByTestPlanId(testPlans, testPlanVersions)
         );
         const {
-            derivedOverallPhaseByTestPlanId: { derivedOverallPhaseByTestPlanId }
+            derivedOverallPhaseByTestPlanId: { activeTestPlanVersionsByPhase }
         } = result.current;
-        expect(derivedOverallPhaseByTestPlanId).toEqual({
-            1: 'RD',
-            2: 'DRAFT',
-            3: 'CANDIDATE',
-            4: 'RECOMMENDED'
+        expect(activeTestPlanVersionsByPhase).toEqual({
+            1: ['RD'],
+            2: ['DRAFT'],
+            3: ['CANDIDATE'],
+            4: ['RECOMMENDED', 'DRAFT', 'RD']
         });
     });
 });
 
 describe('useTestPlansByPhase hook', () => {
-    it('returns an object with test plans grouped by overall phase', () => {
+    it('returns an object with test plans with an array of active Test Plan Versions', () => {
         const { result } = renderHook(() =>
             useTestPlansByPhase(testPlans, testPlanVersions)
         );
         const { testPlansByPhase } = result.current;
         expect(testPlansByPhase).toEqual({
-            RD: [testPlans[0]],
-            DRAFT: [testPlans[1]],
+            RD: [testPlans[0], testPlans[3]],
+            DRAFT: [testPlans[1], testPlans[3]],
             CANDIDATE: [testPlans[2]],
             RECOMMENDED: [testPlans[3]]
         });

--- a/client/tests/DataManagement.test.jsx
+++ b/client/tests/DataManagement.test.jsx
@@ -123,7 +123,6 @@ const testPlanVersions = [
     {
         phase: 'DRAFT',
         id: '106',
-        title: 'testD',
         testPlan: { directory: 'dirD' },
         draftStatusReachedAt: '2024-01-08T20:51:40.000Z'
     }

--- a/client/tests/DataManagement.test.jsx
+++ b/client/tests/DataManagement.test.jsx
@@ -93,32 +93,44 @@ const testPlanVersions = [
     {
         phase: 'RD',
         id: '101',
+        title: 'testA',
         testPlan: { directory: 'dirA' },
         updatedAt: '2022-03-17T18:34:51.000Z'
     },
     {
         phase: 'DRAFT',
         id: '102',
+        title: 'testB',
         testPlan: { directory: 'dirB' },
         draftStatusReachedAt: '2022-05-18T20:51:40.000Z'
     },
     {
         phase: 'CANDIDATE',
         id: '103',
+        title: 'testC',
         testPlan: { directory: 'dirC' },
         candidatePhaseReachedAt: '2022-04-10T00:00:00.000Z'
     },
     {
         phase: 'RD',
         id: '104',
+        title: 'testD',
         testPlan: { directory: 'dirD' },
         updatedAt: '2022-03-18T18:34:51.000Z'
     },
     {
         phase: 'RECOMMENDED',
         id: '105',
+        title: 'testD',
         testPlan: { directory: 'dirD' },
         recommendedPhaseReachedAt: '2022-05-18T20:51:40.000Z'
+    },
+    {
+        phase: 'DRAFT',
+        id: '106',
+        title: 'testD',
+        testPlan: { directory: 'dirD' },
+        draftStatusReachedAt: '2024-01-08T20:51:40.000Z'
     }
 ];
 
@@ -204,7 +216,7 @@ describe('useDataManagementTableFiltering hook', () => {
             result.current.filterLabels[
                 DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.DRAFT
             ]
-        ).toEqual(`In Draft Review (1)`);
+        ).toEqual(`In Draft Review (2)`); // Test plan 106 is in DRAFT while the overall plan is RECOMMENDED
     });
 
     it('can filter by CANDIDATE phase', () => {
@@ -252,7 +264,7 @@ describe('useTestPlanVersionsByPhase hook', () => {
         const { testPlanVersionsByPhase } = result.current;
         expect(testPlanVersionsByPhase).toEqual({
             RD: [testPlanVersions[0], testPlanVersions[3]],
-            DRAFT: [testPlanVersions[1]],
+            DRAFT: [testPlanVersions[1], testPlanVersions[5]],
             CANDIDATE: [testPlanVersions[2]],
             RECOMMENDED: [testPlanVersions[4]]
         });

--- a/docs/database.md
+++ b/docs/database.md
@@ -5,7 +5,9 @@ The database migrations are managed by [Sequelize](https://sequelize.org/). To r
 ## Setting up a local database for development
 
 0. Install PostgreSQL
+
     - Mac
+
     ```
     brew install postgresql@14
     brew services start postgresql@14
@@ -94,6 +96,8 @@ yarn sequelize:test db:migrate;
 yarn sequelize:test db:seed:all;
 yarn workspace server db-import-tests:test -c 5fe7afd82fe51c185b8661276105190a59d47322;
 yarn workspace server db-import-tests:test -c 1aa3b74d24d340362e9f511eae33788d55487d12;
+yarn workspace server db-import-tests:test -c ab77d47ab19db71c635c9bb459ba5c34182e1400;
+yarn workspace server db-import-tests:test -c d34eddbb8e751f07bd28d952de15fa7fe5f07353;
 yarn workspace server db-import-tests:test;
 yarn workspace server db-populate-sample-data:test;
 ```

--- a/docs/database.md
+++ b/docs/database.md
@@ -96,8 +96,6 @@ yarn sequelize:test db:migrate;
 yarn sequelize:test db:seed:all;
 yarn workspace server db-import-tests:test -c 5fe7afd82fe51c185b8661276105190a59d47322;
 yarn workspace server db-import-tests:test -c 1aa3b74d24d340362e9f511eae33788d55487d12;
-yarn workspace server db-import-tests:test -c ab77d47ab19db71c635c9bb459ba5c34182e1400;
-yarn workspace server db-import-tests:test -c d34eddbb8e751f07bd28d952de15fa7fe5f07353;
 yarn workspace server db-import-tests:test;
 yarn workspace server db-populate-sample-data:test;
 ```


### PR DESCRIPTION
This PR addresses #884, where the app was not capturing all the test plans that contained In Draft reviews. 

Question for reviewers:

- Is this the right approach?
- Is there a better way to test other than modifying the front end test?