### PR TITLE
Fix initial state of "Mark as finished" button

### DIFF
--- a/client/components/ManageBotRunDialog/MarkBotRunFinishedButton/index.jsx
+++ b/client/components/ManageBotRunDialog/MarkBotRunFinishedButton/index.jsx
@@ -52,6 +52,11 @@ const MarkBotRunFinishedButton = ({ testPlanRun, onClick = () => {} }) => {
         await onClick();
     };
 
+    const buttonDisabled =
+        totalPossibleAssertions === 0 ||
+        totalValidatedAssertions < totalPossibleAssertions ||
+        runIsFinished;
+
     return (
         <LoadingStatus message={loadingMessage}>
             <BasicModal
@@ -72,10 +77,7 @@ const MarkBotRunFinishedButton = ({ testPlanRun, onClick = () => {} }) => {
             <Button
                 variant="secondary"
                 onClick={() => setShowConfirmation(true)}
-                disabled={
-                    totalValidatedAssertions < totalPossibleAssertions ||
-                    runIsFinished
-                }
+                disabled={buttonDisabled}
             >
                 Mark as finished
             </Button>


### PR DESCRIPTION
totalPossibleAssertions of 0 means the data isnt available yet, might as well wait to enable the button until we have the data.

Fixes #875 