### PR TITLE
Fix console.error and update TestPlanReportStatusDialog content

### DIFF
--- a/client/tests/__mocks__/GraphQLMocks/TestPlanReportStatusDialogMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/TestPlanReportStatusDialogMock.js
@@ -376,7 +376,9 @@ export default (
                                 id: '3',
                                 name: 'Safari'
                             }
-                        ]
+                        ],
+                        candidateBrowsers: [{ id: '3' }],
+                        recommendedBrowsers: [{ id: '2' }, { id: '3' }]
                     }
                 ]
             }


### PR DESCRIPTION
This PR does the following:

1. Fixes the following error being thrown on main when running the tests:
<details>
<summary>Error Message</summary>

```bash
console.error
      Warning: Failed prop type: The prop `ats[2].candidateBrowsers` is marked as required in `TestPlanReportStatusDialog`, but its value is `undefined`.
          at testPlanVersion (/home/runner/work/aria-at-app/aria-at-app/client/components/TestPlanReportStatusDialog/index.jsx:20:5)

      23 |                 cache={new InMemoryCache({ addTypename: false })}
      24 |             >
    > 25 |                 <TestPlanReportStatusDialog {...props} />
         |                 ^
      26 |             </MockedProvider>
      27 |         </BrowserRouter>
      28 |     );
```

</details>

2. In the `TestPlanReportStatusDialog`, shows that there are reports required again to transition to `CANDIDATE` from `DRAFT` and adds contextual messages in the dialog's description based on the phase.