### PR TITLE
Move CollectionJob mutations into CollectionJobOperations where appropriate

### DIFF
--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1349,6 +1349,19 @@ const graphqlSchema = gql`
         Delete a CollectionJob
         """
         deleteCollectionJob: NoResponse!
+        """
+        Update a CollectionJob
+        """
+        updateCollectionJob(
+            """
+            The status of the CollectionJob.
+            """
+            status: CollectionJobStatus
+            """
+            The external logs url of the CollectionJob.
+            """
+            externalLogsUrl: String
+        ): CollectionJob
     }
 
     """
@@ -1449,23 +1462,6 @@ const graphqlSchema = gql`
             """
             testPlanReportId: ID
         ): CollectionJob!
-        """
-        Update a CollectionJob
-        """
-        updateCollectionJob(
-            """
-            The CollectionJob to update.
-            """
-            id: ID!
-            """
-            The status of the CollectionJob.
-            """
-            status: CollectionJobStatus
-            """
-            The external logs url of the CollectionJob.
-            """
-            externalLogsUrl: String
-        ): CollectionJob
     }
 `;
 

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1342,6 +1342,10 @@ const graphqlSchema = gql`
         """
         retryCanceledCollections: CollectionJob!
         """
+        Restart a CollectionJob by way of the Response Scheduler
+        """
+        restartCollectionJob: CollectionJob
+        """
         Delete a CollectionJob
         """
         deleteCollectionJob: NoResponse!
@@ -1461,15 +1465,6 @@ const graphqlSchema = gql`
             The external logs url of the CollectionJob.
             """
             externalLogsUrl: String
-        ): CollectionJob
-        """
-        Restart a CollectionJob by way of the Response Scheduler
-        """
-        restartCollectionJob(
-            """
-            The CollectionJob to restart.
-            """
-            id: ID!
         ): CollectionJob
     }
 `;

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1341,6 +1341,10 @@ const graphqlSchema = gql`
         Retry the 'cancelled' tests of a CollectionJob.
         """
         retryCanceledCollections: CollectionJob!
+        """
+        Delete a CollectionJob
+        """
+        deleteCollectionJob: NoResponse!
     }
 
     """
@@ -1467,10 +1471,6 @@ const graphqlSchema = gql`
             """
             id: ID!
         ): CollectionJob
-        """
-        Delete a CollectionJob
-        """
-        deleteCollectionJob(id: ID!): NoResponse!
     }
 `;
 

--- a/server/resolvers/CollectionJobOperations/deleteCollectionJobResolver.js
+++ b/server/resolvers/CollectionJobOperations/deleteCollectionJobResolver.js
@@ -1,14 +1,17 @@
 const { AuthenticationError } = require('apollo-server-core');
 const {
     deleteCollectionJob
-} = require('../models/services/CollectionJobService');
+} = require('../../models/services/CollectionJobService');
 
-const deleteCollectionJobResolver = async (_, { id }, context) => {
-    const { user } = context;
+const deleteCollectionJobResolver = async (
+    { parentContext: { id: collectionJobId } },
+    _,
+    { user }
+) => {
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
         throw new AuthenticationError();
     }
-    return deleteCollectionJob(id);
+    return deleteCollectionJob(collectionJobId);
 };
 
 module.exports = deleteCollectionJobResolver;

--- a/server/resolvers/CollectionJobOperations/index.js
+++ b/server/resolvers/CollectionJobOperations/index.js
@@ -1,8 +1,10 @@
 const cancelCollectionJob = require('./cancelCollectionJobResolver');
 const retryCanceledCollections = require('./retryCanceledCollectionsResolver');
 const deleteCollectionJob = require('./deleteCollectionJobResolver');
+const restartCollectionJob = require('./restartCollectionJobResolver');
 module.exports = {
     cancelCollectionJob,
     retryCanceledCollections,
-    deleteCollectionJob
+    deleteCollectionJob,
+    restartCollectionJob
 };

--- a/server/resolvers/CollectionJobOperations/index.js
+++ b/server/resolvers/CollectionJobOperations/index.js
@@ -1,3 +1,8 @@
 const cancelCollectionJob = require('./cancelCollectionJobResolver');
 const retryCanceledCollections = require('./retryCanceledCollectionsResolver');
-module.exports = { cancelCollectionJob, retryCanceledCollections };
+const deleteCollectionJob = require('./deleteCollectionJobResolver');
+module.exports = {
+    cancelCollectionJob,
+    retryCanceledCollections,
+    deleteCollectionJob
+};

--- a/server/resolvers/CollectionJobOperations/index.js
+++ b/server/resolvers/CollectionJobOperations/index.js
@@ -2,9 +2,11 @@ const cancelCollectionJob = require('./cancelCollectionJobResolver');
 const retryCanceledCollections = require('./retryCanceledCollectionsResolver');
 const deleteCollectionJob = require('./deleteCollectionJobResolver');
 const restartCollectionJob = require('./restartCollectionJobResolver');
+const updateCollectionJob = require('./updateCollectionJobResolver');
 module.exports = {
     cancelCollectionJob,
     retryCanceledCollections,
     deleteCollectionJob,
-    restartCollectionJob
+    restartCollectionJob,
+    updateCollectionJob
 };

--- a/server/resolvers/CollectionJobOperations/restartCollectionJobResolver.js
+++ b/server/resolvers/CollectionJobOperations/restartCollectionJobResolver.js
@@ -1,16 +1,18 @@
 const { AuthenticationError } = require('apollo-server-core');
 const {
     restartCollectionJob
-} = require('../models/services/CollectionJobService');
+} = require('../../models/services/CollectionJobService');
 
-const restartCollectionJobResolver = async (_, { id }, context) => {
-    const { user } = context;
-
+const restartCollectionJobResolver = async (
+    { parentContext: { id: collectionJobId } },
+    _,
+    { user }
+) => {
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
         throw new AuthenticationError();
     }
 
-    return restartCollectionJob({ id });
+    return restartCollectionJob({ id: collectionJobId });
 };
 
 module.exports = restartCollectionJobResolver;

--- a/server/resolvers/CollectionJobOperations/updateCollectionJobResolver.js
+++ b/server/resolvers/CollectionJobOperations/updateCollectionJobResolver.js
@@ -1,14 +1,13 @@
 const { AuthenticationError } = require('apollo-server-core');
 const {
     updateCollectionJob
-} = require('../models/services/CollectionJobService');
+} = require('../../models/services/CollectionJobService');
 
 const updateCollectionJobResolver = async (
-    _,
-    { id, status, externalLogsUrl },
-    context
+    { parentContext: { id: collectionJobId } },
+    { status, externalLogsUrl },
+    { user }
 ) => {
-    const { user } = context;
     if (!user?.roles.find(role => role.name === 'ADMIN')) {
         throw new AuthenticationError();
     }
@@ -18,9 +17,12 @@ const updateCollectionJobResolver = async (
         ...(externalLogsUrl && { externalLogsUrl })
     };
 
-    const collectionJobs = await updateCollectionJob(id, updateParams);
+    const collectionJob = await updateCollectionJob(
+        collectionJobId,
+        updateParams
+    );
 
-    return collectionJobs;
+    return collectionJob;
 };
 
 module.exports = updateCollectionJobResolver;

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -26,7 +26,6 @@ const collectionJob = require('./collectionJobResolver');
 const collectionJobs = require('./collectionJobsResolver');
 const findOrCreateCollectionJob = require('./findOrCreateCollectionJobResolver');
 const updateCollectionJob = require('./updateCollectionJobResolver');
-const deleteCollectionJob = require('./deleteCollectionJobResolver');
 const scheduleCollectionJob = require('./scheduleCollectionJobResolver');
 const restartCollectionJob = require('./restartCollectionJobResolver');
 const collectionJobByTestPlanRunId = require('./collectionJobByTestPlanRunIdResolver');
@@ -79,7 +78,6 @@ const resolvers = {
         addViewer,
         findOrCreateCollectionJob,
         updateCollectionJob,
-        deleteCollectionJob,
         scheduleCollectionJob,
         restartCollectionJob
     },

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -27,7 +27,6 @@ const collectionJobs = require('./collectionJobsResolver');
 const findOrCreateCollectionJob = require('./findOrCreateCollectionJobResolver');
 const updateCollectionJob = require('./updateCollectionJobResolver');
 const scheduleCollectionJob = require('./scheduleCollectionJobResolver');
-const restartCollectionJob = require('./restartCollectionJobResolver');
 const collectionJobByTestPlanRunId = require('./collectionJobByTestPlanRunIdResolver');
 const User = require('./User');
 const AtOperations = require('./AtOperations');
@@ -78,8 +77,7 @@ const resolvers = {
         addViewer,
         findOrCreateCollectionJob,
         updateCollectionJob,
-        scheduleCollectionJob,
-        restartCollectionJob
+        scheduleCollectionJob
     },
     AtOperations,
     AtVersionOperations,

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -25,7 +25,6 @@ const populateData = require('./populateDataResolver');
 const collectionJob = require('./collectionJobResolver');
 const collectionJobs = require('./collectionJobsResolver');
 const findOrCreateCollectionJob = require('./findOrCreateCollectionJobResolver');
-const updateCollectionJob = require('./updateCollectionJobResolver');
 const scheduleCollectionJob = require('./scheduleCollectionJobResolver');
 const collectionJobByTestPlanRunId = require('./collectionJobByTestPlanRunIdResolver');
 const User = require('./User');
@@ -76,7 +75,6 @@ const resolvers = {
         updateMe,
         addViewer,
         findOrCreateCollectionJob,
-        updateCollectionJob,
         scheduleCollectionJob
     },
     AtOperations,

--- a/server/tests/integration/automation-scheduler.test.js
+++ b/server/tests/integration/automation-scheduler.test.js
@@ -159,9 +159,11 @@ const scheduleCollectionJobByMutation = async () =>
 const restartCollectionJobByMutation = async () =>
     await mutate(`
         mutation {
-            restartCollectionJob(id: "${jobId}") {
-                id
-                status
+            collectionJob(id: "${jobId}") {
+                restartCollectionJob {
+                    id
+                    status
+                }
             }
         }
     `);
@@ -290,12 +292,13 @@ describe('Automation controller', () => {
     it('should restart a job', async () => {
         await dbCleaner(async () => {
             await scheduleCollectionJobByMutation();
-            const { restartCollectionJob: collectionJob } =
-                await restartCollectionJobByMutation();
+            const { collectionJob } = await restartCollectionJobByMutation();
             expect(collectionJob).not.toBe(undefined);
             expect(collectionJob).toEqual({
-                id: jobId,
-                status: 'QUEUED'
+                restartCollectionJob: {
+                    id: jobId,
+                    status: 'QUEUED'
+                }
             });
             const { collectionJob: storedCollectionJob } =
                 await getTestCollectionJob();
@@ -305,9 +308,10 @@ describe('Automation controller', () => {
     });
 
     it('should gracefully reject restarting a job that does not exist', async () => {
-        const { restartCollectionJob: res } =
-            await restartCollectionJobByMutation();
-        expect(res).toEqual(null);
+        const { collectionJob } = await restartCollectionJobByMutation();
+        expect(collectionJob).toEqual({
+            restartCollectionJob: null
+        });
     });
 
     it('should not update a job status without verification', async () => {

--- a/server/tests/integration/automation-scheduler.test.js
+++ b/server/tests/integration/automation-scheduler.test.js
@@ -181,7 +181,9 @@ const cancelCollectionJobByMutation = async () =>
 const deleteCollectionJobByMutation = async () =>
     await mutate(`
         mutation {
-            deleteCollectionJob(id: "${jobId}") 
+            collectionJob(id: "${jobId}") {
+                deleteCollectionJob
+            }
         }
     `);
 
@@ -616,7 +618,9 @@ describe('Automation controller', () => {
 
             const res = await deleteCollectionJobByMutation();
             expect(res).toEqual({
-                deleteCollectionJob: true
+                collectionJob: {
+                    deleteCollectionJob: true
+                }
             });
 
             const { collectionJob: deletedCollectionJob } =

--- a/server/tests/integration/automation-scheduler.test.js
+++ b/server/tests/integration/automation-scheduler.test.js
@@ -189,6 +189,19 @@ const deleteCollectionJobByMutation = async () =>
         }
     `);
 
+const updateCollectionJobByMutation = async (status, externalLogsUrl) =>
+    await mutate(`
+        mutation {
+            collectionJob(id: "${jobId}") {
+                updateCollectionJob(status: ${status}, externalLogsUrl: ${externalLogsUrl}) {
+                    id
+                    status
+                    externalLogsUrl
+                }
+            }
+        }
+    `);
+
 describe('Automation controller', () => {
     it('should schedule a new job', async () => {
         await dbCleaner(async () => {
@@ -324,6 +337,18 @@ describe('Automation controller', () => {
             expect(response.body).toEqual({
                 error: 'Unauthorized'
             });
+        });
+    });
+
+    it('should successfully update a job through graphql', async () => {
+        await dbCleaner(async () => {
+            await scheduleCollectionJobByMutation();
+            const {
+                collectionJob: { updateCollectionJob }
+            } = await updateCollectionJobByMutation('RUNNING', null);
+            expect(updateCollectionJob.id).toEqual(jobId);
+            expect(updateCollectionJob.status).toEqual('RUNNING');
+            expect(updateCollectionJob.externalLogsUrl).toEqual(null);
         });
     });
 

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -756,13 +756,6 @@ describe('graphql', () => {
                                 id
                             }
                         }
-                        collectionJob(id: 333) {
-                            __typename
-                            cancelCollectionJob {
-                                id
-                                status
-                            }
-                        }
                         updateCollectionJob(id: 333, status: COMPLETED) {
                             id
                             status
@@ -770,7 +763,14 @@ describe('graphql', () => {
                                 id
                             }
                         }
-                        deleteCollectionJob(id: 333)
+                        collectionJob(id: 333) {
+                            __typename
+                            cancelCollectionJob {
+                                id
+                                status
+                            }
+                            deleteCollectionJob
+                        }
                     }
                 `,
                 {

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -161,7 +161,7 @@ describe('graphql', () => {
             // These interact with Response Scheduler API
             // which is mocked in other tests.
             ['Mutation', 'scheduleCollectionJob'],
-            ['Mutation', 'restartCollectionJob'],
+            ['CollectionJobOperations', 'restartCollectionJob'],
             ['CollectionJobOperations', 'retryCanceledCollections']
         ];
         ({

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -756,19 +756,22 @@ describe('graphql', () => {
                                 id
                             }
                         }
-                        updateCollectionJob(id: 333, status: COMPLETED) {
-                            id
-                            status
-                            testPlanRun {
-                                id
-                            }
-                        }
-                        collectionJob(id: 333) {
+                        cancelCollectionJob: collectionJob(id: 333) {
                             __typename
                             cancelCollectionJob {
                                 id
                                 status
                             }
+                        }
+                        updateCollectionJob: collectionJob(id: 333) {
+                            __typename
+                            updateCollectionJob(status: QUEUED) {
+                                id
+                                status
+                            }
+                        }
+                        collectionJob(id: 333) {
+                            __typename
                             deleteCollectionJob
                         }
                     }


### PR DESCRIPTION
This PR moves all of the mutation resolvers that are contextual to an existing `CollectionJob` into `CollectionJobOperations`.

These are :
- `deleteCollectionJob`
- `restartCollectionJob`
- `updateCollectionJob`

These changes make are intended to make the GraphQL interface for `CollectionJob`s more organized and clear.