### PR TITLE
Use uniquely created ids for `aria-labelledby` referenced in `InstructionsRenderer`

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/InstructionsRenderer.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/InstructionsRenderer.jsx
@@ -224,21 +224,23 @@ const InstructionsRenderer = ({
                         `${settingsScreenTextFormatted}: ${mustCount} MUST, ` +
                         `${shouldCount} SHOULD, ${mayCount} MAY Assertions`;
 
+                    const scenarioId =
+                        `${at.name}-test${test.rowNumber}-${id}-cmd${i}`.replaceAll(
+                            /[,+\s]+/g,
+                            '_'
+                        );
+
                     if (isV2) {
                         return (
                             <React.Fragment key={`command-${id}-${i}`}>
-                                <Heading
-                                    id={renderableContent.commands[i].keystroke}
-                                >
+                                <Heading id={scenarioId}>
                                     {scenarioTitle}
                                 </Heading>
                                 <Table
                                     key={`${id}-${i}`}
                                     bordered
                                     responsive
-                                    aria-labelledby={
-                                        renderableContent.commands[i].keystroke
-                                    }
+                                    aria-labelledby={scenarioId}
                                 >
                                     <thead>
                                         <tr>
@@ -275,12 +277,14 @@ const InstructionsRenderer = ({
                     } else {
                         return (
                             <React.Fragment key={`command-${id}-${i}`}>
-                                <Heading>{scenarioTitle}</Heading>
+                                <Heading id={scenarioId}>
+                                    {scenarioTitle}
+                                </Heading>
                                 <Table
                                     key={`${id}-${i}`}
                                     bordered
                                     responsive
-                                    aria-label={`Results for test ${test.title}`}
+                                    aria-labelledby={scenarioId}
                                 >
                                     <thead>
                                         <tr>


### PR DESCRIPTION
Follow up for #944.

Fixes issue where non-unique ids were being used for `aria-labelledby` with the assertions table in the `InstructionsRenderer` component. This can be tested on the Test Review and Candidate Test Plan Run pages.

Addresses:
* https://github.com/w3c/aria-at-app/pull/944#issuecomment-1981463867
* https://github.com/w3c/aria-at-app/pull/944#issuecomment-1981481738