### PR TITLE
Add npm to ansible

### DIFF
--- a/deploy/roles/nodejs/tasks/main.yml
+++ b/deploy/roles/nodejs/tasks/main.yml
@@ -25,6 +25,7 @@
     name:
       - nodejs
       - yarn
+      - npm
     state: present
   become: yes
 
@@ -34,3 +35,10 @@
 
 - name: Show status of nodejs installation
   debug: msg="{{ new_node_version.stdout }}"
+
+- name: Check if npm exists
+  command: npm --version
+  register: npm_version
+
+- name: Show status of nodejs installation
+  debug: msg="{{ npm_version.stdout }}"


### PR DESCRIPTION
This PR addresses [this Asana task](https://app.asana.com/0/1206547249735190/1206719837277162), where the import tests job was failing in staging and production. NPM was not installed on provisioning of the server, which is why the import tests job was failing.