### PR TITLE
Update Test Plan Report Status dialog completion percentage calculation

### DIFF
--- a/client/components/TestPlanReportStatusDialog/calculateTestPlanReportCompletionPercentage.js
+++ b/client/components/TestPlanReportStatusDialog/calculateTestPlanReportCompletionPercentage.js
@@ -7,7 +7,9 @@ export const calculateTestPlanReportCompletionPercentage = ({
     const totalTestsPossible = metrics.testsCount * assignedUserCount;
     let totalTestsCompleted = 0;
     draftTestPlanRuns.forEach(draftTestPlanRun => {
-        totalTestsCompleted += draftTestPlanRun.testResults.length;
+        totalTestsCompleted += draftTestPlanRun.testResults.filter(
+            ({ completedAt }) => !!completedAt
+        ).length;
     });
     const percentage = (totalTestsCompleted / totalTestsPossible) * 100;
     if (isNaN(percentage) || !isFinite(percentage)) return 0;


### PR DESCRIPTION
Currently being shown on aria-at.w3.org for the Toggle Button V24.03.12 Test Plan Report Status Dialog is that all the current reports in the Test Queue are 100% complete:

<img width="1051" alt="Screenshot showing 100% complete status across JAWS, NVDA and VoiceOver reports currently in the Test Queue" src="https://github.com/w3c/aria-at-app/assets/7191577/4d5d7518-80ab-4137-a16d-aa96c04a69b1">

But the Test Queue shows that only 2 of 8 tests are complete for each listed tester:

<img width="952" alt="Screenshot showing 2 of 8 tests complete for both testers assigned to JAWS and Chrome" src="https://github.com/w3c/aria-at-app/assets/7191577/18ecc741-2ed5-486e-87aa-cd65f0f73ee5">

That's because the percentage is being calculated against whether the test result for a test exists (which is created once you navigate to the test within the Test Run page) vs checking if the test has actually been completed by the tester.