### PR TITLE
Break out individual test commands for github actions

### DIFF
--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -41,9 +41,28 @@ jobs:
           yarn workspace server db-import-tests:test -c ${IMPORT_ARIA_AT_TESTS_COMMIT_3}
           yarn workspace server db-import-tests:test -c ${IMPORT_ARIA_AT_TESTS_COMMIT_4}
           yarn workspace server db-populate-sample-data:test
-      - name: test
-        run: yarn test
+      # yarn test would run all of these in serial, however we split this up to allow it continue
+      # in case of errors - all tests will still run even if lint fails for instance.
+      - run: yarn workspace shared prettier
+        if: always()
+      - run: yarn workspace client prettier
+        if: always()
+      - run: yarn workspace server prettier
+        if: always()
+      - run: yarn workspace shared lint
+        if: always()
+      - run: yarn workspace client lint
+        if: always()
+      - run: yarn workspace server lint
+        if: always()
+      - run: yarn workspace shared jest
+        if: always()
+      - run: yarn workspace client jest
+        if: always()
+      - run: yarn workspace server jest
+        if: always()
       - name: lighthouseci
+        if: always()
         run: |
           npm install -g @lhci/cli@0.11.0
           yarn workspace client lighthouse


### PR DESCRIPTION
This will allow all of the tests to run even if there are errors in other suites (a lint failure will still let tests run, a failure in client won't stop server from running)