### PR TITLE
Preserve `candidatePhaseReachedAt` and `recommendedPhaseTargetDate` dates when updating a TestPlanVersion to CANDIDATE and an older version exists

### DIFF
--- a/server/migrations/20240319190618-updateCandidatePhaseReachedDates.js
+++ b/server/migrations/20240319190618-updateCandidatePhaseReachedDates.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        return queryInterface.sequelize.transaction(async transaction => {
+            const testPlanVersions = await queryInterface.sequelize.query(
+                `select id, "candidatePhaseReachedAt", "recommendedPhaseTargetDate", directory
+                     from "TestPlanVersion"
+                     where "candidatePhaseReachedAt" is not null
+                     order by "candidatePhaseReachedAt"`,
+                {
+                    type: Sequelize.QueryTypes.SELECT,
+                    transaction
+                }
+            );
+
+            const testPlanVersionsByDirectory = {};
+            for (const testPlanVersion of testPlanVersions) {
+                const { directory } = testPlanVersion;
+
+                if (!testPlanVersionsByDirectory[directory])
+                    testPlanVersionsByDirectory[directory] = [testPlanVersion];
+                else
+                    testPlanVersionsByDirectory[directory].push(
+                        testPlanVersion
+                    );
+            }
+
+            for (const directory of Object.keys(testPlanVersionsByDirectory)) {
+                // No need to update since only that TestPlanVersion exists in CANDIDATE
+                if (directory.length === 1) continue;
+
+                // Already pre sorted to have the earliest candidatePhaseStart date; works because
+                // no RECOMMENDED TestPlanVersions currently exist
+                const [firstTestPlanVersion, ...rest] =
+                    testPlanVersionsByDirectory[directory];
+
+                for (const restTestPlanVersion of rest) {
+                    await queryInterface.sequelize.query(
+                        `update "TestPlanVersion"
+                                set "candidatePhaseReachedAt" = ?,
+                                    "recommendedPhaseTargetDate" = ?
+                                where id = ?`,
+                        {
+                            replacements: [
+                                firstTestPlanVersion.candidatePhaseReachedAt,
+                                firstTestPlanVersion.recommendedPhaseTargetDate,
+                                restTestPlanVersion.id
+                            ],
+                            transaction
+                        }
+                    );
+                }
+            }
+        });
+    }
+};

--- a/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
+++ b/server/resolvers/TestPlanVersionOperations/updatePhaseResolver.js
@@ -55,7 +55,7 @@ const updatePhaseResolver = async (
         transaction
     });
 
-    const { newTestPlanReportIds, updatedTestPlanReports } =
+    const { oldTestPlanVersion, newTestPlanReportIds, updatedTestPlanReports } =
         await processCopiedReports({
             oldTestPlanVersionId: testPlanVersionDataToIncludeId,
             newTestPlanVersionId: testPlanVersionId,
@@ -279,9 +279,19 @@ const updatePhaseResolver = async (
             deprecatedAt: null
         };
     else if (phase === 'CANDIDATE') {
+        // Preserve candidate phase related dates from older TestPlanVersion since not yet gone to
+        // recommended
+        const {
+            candidatePhaseReachedAt: oldCandidatePhaseReachedAtDate,
+            recommendedPhaseTargetDate: oldRecommendedPhaseTargetDate
+        } = oldTestPlanVersion || {};
+
         const candidatePhaseReachedAtValue =
-            candidatePhaseReachedAt || new Date();
+            oldCandidatePhaseReachedAtDate ||
+            candidatePhaseReachedAt ||
+            new Date();
         const recommendedPhaseTargetDateValue =
+            oldRecommendedPhaseTargetDate ||
             recommendedPhaseTargetDate ||
             recommendedPhaseTargetDateResolver(
                 { candidatePhaseReachedAt: candidatePhaseReachedAtValue },

--- a/server/resolvers/helpers/processCopiedReports.js
+++ b/server/resolvers/helpers/processCopiedReports.js
@@ -66,6 +66,7 @@ const processCopiedReports = async ({
     // There is no older test plan reports to process
     if (!oldTestPlanReports.length) {
         return {
+            oldTestPlanVersion,
             newTestPlanReportIds,
             updatedTestPlanReports
         };
@@ -382,6 +383,7 @@ const processCopiedReports = async ({
     });
 
     return {
+        oldTestPlanVersion,
         newTestPlanReportIds,
         updatedTestPlanReports
     };


### PR DESCRIPTION
This PR addresses https://github.com/w3c/aria-at-app/issues/966#issuecomment-2008053768.