### PR TITLE
Remove AT and browser alert banner

### DIFF
--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -76,6 +76,22 @@ const TestRun = () => {
             variables: { testPlanRunId, testPlanReportId }
         }
     );
+    /* HOMEWORK
+        *try changing or turning off the fetchPolicy so that loading won't be false
+            and to see the behavior.
+        *You are trying to catch the page loading so the if statement will run.
+            Use whatever catches the page load as if statement conditional.
+    */
+    //    section:
+    // console.log('performance', performance.navigation.TYPE_RELOAD);
+    // console.log('loading', loading);
+    // console.log('updateMessageComponent', updateMessageComponent);
+    // useEffect(() => {
+    //     if (performance.navigation.TYPE_RELOAD) {
+    //         console.log('IT RAN')
+    //         // setUpdateMessageComponent(null);
+    //     }
+    // }, [performance.navigation.TYPE_RELOAD]);
 
     const { data: collectionJobQuery } = useQuery(
         COLLECTION_JOB_STATUS_BY_TEST_PLAN_RUN_ID_QUERY,
@@ -94,6 +110,7 @@ const TestRun = () => {
         FIND_OR_CREATE_BROWSER_VERSION_MUTATION
     );
 
+    const [isRunning, setIsRunning] = useState(false);
     const [isRendererReady, setIsRendererReady] = useState(false);
     const [isSavingForm, setIsSavingForm] = useState(false);
     const [isTestSubmitClicked, setIsTestSubmitClicked] = useState(false);
@@ -114,6 +131,12 @@ const TestRun = () => {
     const [isEditAtBrowserDetailsModalClick, setIsEditAtBrowserDetailsClicked] =
         useState(false);
     const [updateMessageComponent, setUpdateMessageComponent] = useState(null);
+    // section:
+    if (isRunning) {
+        if (updateMessageComponent) {
+            setUpdateMessageComponent(null);
+        }
+    }
 
     // Queried State Values
     const [testPlanRun, setTestPlanRun] = useState({});
@@ -497,6 +520,7 @@ const TestRun = () => {
             forceSave = false,
             forceEdit = false
         ) => {
+            setIsRunning(true);
             try {
                 if (forceEdit) setIsTestEditClicked(true);
                 else setIsTestEditClicked(false);
@@ -532,6 +556,7 @@ const TestRun = () => {
                 console.error('save.error', e);
                 setIsSavingForm(false);
             }
+            setIsRunning(false);
         };
 
         switch (action) {
@@ -1390,6 +1415,7 @@ const TestRun = () => {
                         )}
                         patternName={testPlanVersion.title}
                         testerName={tester.username}
+                        // section:
                         handleAction={handleAtAndBrowserDetailsModalAction}
                         handleClose={handleAtAndBrowserDetailsModalCloseAction}
                     />

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -110,7 +110,6 @@ const TestRun = () => {
         FIND_OR_CREATE_BROWSER_VERSION_MUTATION
     );
 
-    const [isRunning, setIsRunning] = useState(false);
     const [isRendererReady, setIsRendererReady] = useState(false);
     const [isSavingForm, setIsSavingForm] = useState(false);
     const [isTestSubmitClicked, setIsTestSubmitClicked] = useState(false);
@@ -131,12 +130,6 @@ const TestRun = () => {
     const [isEditAtBrowserDetailsModalClick, setIsEditAtBrowserDetailsClicked] =
         useState(false);
     const [updateMessageComponent, setUpdateMessageComponent] = useState(null);
-    // section:
-    if (isRunning) {
-        if (updateMessageComponent) {
-            setUpdateMessageComponent(null);
-        }
-    }
 
     // Queried State Values
     const [testPlanRun, setTestPlanRun] = useState({});
@@ -520,7 +513,9 @@ const TestRun = () => {
             forceSave = false,
             forceEdit = false
         ) => {
-            setIsRunning(true);
+            if (updateMessageComponent) {
+                setUpdateMessageComponent(null);
+            }
             try {
                 if (forceEdit) setIsTestEditClicked(true);
                 else setIsTestEditClicked(false);
@@ -556,7 +551,6 @@ const TestRun = () => {
                 console.error('save.error', e);
                 setIsSavingForm(false);
             }
-            setIsRunning(false);
         };
 
         switch (action) {

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -76,22 +76,6 @@ const TestRun = () => {
             variables: { testPlanRunId, testPlanReportId }
         }
     );
-    /* HOMEWORK
-        *try changing or turning off the fetchPolicy so that loading won't be false
-            and to see the behavior.
-        *You are trying to catch the page loading so the if statement will run.
-            Use whatever catches the page load as if statement conditional.
-    */
-    //    section:
-    // console.log('performance', performance.navigation.TYPE_RELOAD);
-    // console.log('loading', loading);
-    // console.log('updateMessageComponent', updateMessageComponent);
-    // useEffect(() => {
-    //     if (performance.navigation.TYPE_RELOAD) {
-    //         console.log('IT RAN')
-    //         // setUpdateMessageComponent(null);
-    //     }
-    // }, [performance.navigation.TYPE_RELOAD]);
 
     const { data: collectionJobQuery } = useQuery(
         COLLECTION_JOB_STATUS_BY_TEST_PLAN_RUN_ID_QUERY,
@@ -1409,7 +1393,6 @@ const TestRun = () => {
                         )}
                         patternName={testPlanVersion.title}
                         testerName={tester.username}
-                        // section:
                         handleAction={handleAtAndBrowserDetailsModalAction}
                         handleClose={handleAtAndBrowserDetailsModalCloseAction}
                     />


### PR DESCRIPTION
see issue #797 

This pull request removes the green alert banner from the top of the test run page after saving data and reloading the page.