### PR TITLE
Make draft report links show in status dialog

### DIFF
--- a/client/components/TestPlanReportStatusDialog/index.jsx
+++ b/client/components/TestPlanReportStatusDialog/index.jsx
@@ -80,11 +80,7 @@ const TestPlanReportStatusDialog = ({
     const renderReportStatus = ({ report, at, browser }) => {
         if (report) {
             const { markedFinalAt } = report;
-            const { phase } = testPlanVersion;
-            if (
-                markedFinalAt &&
-                (phase === 'CANDIDATE' || phase === 'RECOMMENDED')
-            ) {
+            if (markedFinalAt) {
                 return renderCompleteReportStatus(report);
             } else {
                 return renderPartialCompleteReportStatus(report);


### PR DESCRIPTION
See https://github.com/w3c/aria-at-app/issues/799, namely the comment from Matt:

> Per my prior comment, I think this issue is not yet resolved because links to reports on draft test plans are still not available from the report status dialog.

In other words, when the test plan version is in the draft phase, the report status dialog on the data management page is not showing links to completed reports, instead it shows text like "100% complete by [alflennik](https://github.com/alflennik) with 0 conflicts" even after being marked final. What it should show is "Report completed on Mar 26, 2024" which is a link to the completed report. Note that this feature does work for candidate and recommended test plan versions already.

I found in the code that we were intentionally not showing the links to reports that were still in draft, and I removed that bit of logic.