### PR TITLE
Clean up incorrect database values in production

### DIFF
--- a/server/migrations/20240325205951-cleanupDuplicatesAndRegenerateHashes.js
+++ b/server/migrations/20240325205951-cleanupDuplicatesAndRegenerateHashes.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const { regenerateResultsAndRecalculateHashes } = require('./utils');
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        return queryInterface.sequelize.transaction(async transaction => {
+            // Remove unnecessarily created test plan versions for ALL 35 test
+            // plan versions for commit,
+            // https://github.com/w3c/aria-at/commit/836fb2a997f5b2844035b8c934f8fda9833cd5b2
+            // None of the following ever left R&D
+            await queryInterface.sequelize.query(
+                `delete
+                 from "TestPlanVersion"
+                 where id in
+                       (55591, 55592, 55593, 55594, 55595, 55596, 55597, 55598, 55599, 55600, 55601, 55602, 55603, 55604, 55605, 55606,
+                        55607, 55608, 55609, 55610, 55611, 55612, 55613, 55614, 55615, 55616, 55617, 55618, 55619, 55620, 55621, 55622,
+                        55623, 55624, 55625)`,
+                {
+                    transaction
+                }
+            );
+
+            // Reset the phases and remove deprecatedAt dates for versions affected by above wrongly created versions:
+            // checkbox-tri-state
+            // link-css
+            // link-img-alt
+            // main
+            // meter
+            // radiogroup-roving-tabindex
+            // slider-multithumb
+            // switch
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                 set phase          = 'RD',
+                     "deprecatedAt" = null
+                 where id in (1566, 1591, 1618, 1798, 2129, 2162, 2245, 2347)`,
+                {
+                    transaction
+                }
+            );
+
+            // Deprecate older uncaught instance of a 2nd DRAFT version
+            // Toggle Button V23.12.13 and set deprecatedAt to date of when
+            // newer Toggle Button V23.12.14 would have overwritten it,
+            // minus 2 seconds to simulate what would happen in
+            // updatePhaseResolver
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                 set phase          = 'DEPRECATED',
+                     "deprecatedAt" = '2023-12-14 21:51:35.527000 +00:00'
+                 where id = 62309`,
+                {
+                    transaction
+                }
+            );
+
+            // Update Radio Group Example Using aria-activedescendant V24.03.13 to include the tokenized assertion phrase for JAWS and NVDA
+            // because it wasn't properly handled by the import script because #942 was not yet in production when version was imported
+            const testPlanVersions = await queryInterface.sequelize.query(
+                `SELECT id, tests FROM "TestPlanVersion" WHERE directory = 'radiogroup-aria-activedescendant' AND "versionString" = 'V24.03.13'`,
+                {
+                    type: Sequelize.QueryTypes.SELECT,
+                    transaction
+                }
+            );
+            await Promise.all(
+                testPlanVersions.map(async ({ id, tests }) => {
+                    const updatedTests = JSON.stringify(
+                        tests.map(test => {
+                            const atKey = test.at.key;
+                            if (atKey === 'voiceover_macos') return test;
+
+                            test.assertions.map(assertion => {
+                                if (
+                                    assertion.assertionPhrase !==
+                                    'switch from reading mode to interaction mode'
+                                )
+                                    return assertion;
+
+                                if (atKey === 'jaws')
+                                    assertion.assertionPhrase =
+                                        'switch from virtual cursor active to PC cursor active';
+                                if (atKey === 'nvda')
+                                    assertion.assertionPhrase =
+                                        'switch from browse mode to focus mode';
+                                return assertion;
+                            });
+
+                            test.renderableContent.assertions.map(assertion => {
+                                if (
+                                    assertion.assertionPhrase !==
+                                    'switch from reading mode to interaction mode'
+                                )
+                                    return assertion;
+
+                                if (atKey === 'jaws')
+                                    assertion.assertionPhrase =
+                                        'switch from virtual cursor active to PC cursor active';
+                                if (atKey === 'nvda')
+                                    assertion.assertionPhrase =
+                                        'switch from browse mode to focus mode';
+                                return assertion;
+                            });
+
+                            return test;
+                        })
+                    );
+                    await queryInterface.sequelize.query(
+                        `UPDATE "TestPlanVersion" SET tests = ? WHERE id = ?`,
+                        { replacements: [updatedTests, id], transaction }
+                    );
+                })
+            );
+
+            // Regenerate hashes since TestPlanVersion.tests modified
+            await regenerateResultsAndRecalculateHashes(
+                queryInterface,
+                transaction,
+                { pruneOldVersions: false }
+            );
+        });
+    }
+};


### PR DESCRIPTION
Found 4 issues of varying importance while making changes to support #986:

1. There were unexpected versions included for all 35 test plans which seemed to have been created during the transition to the v2 test format and the `hashTests` function wasn't properly implemented at that time and the imports were missed. These instances are all still in RD, and so can be removed without issue.
2.  As a result of no.1, there were 8 valid instances of test plan versions which were unnecessarily deprecated so we can revert that.
3. The current [aria-at.w3.org' toggle-button page](https://aria-at.w3.org/data-management/toggle-button) has an additional version in DRAFT phase which shouldn't be possible. That is V23.12.13 should be shown as being deprecated by V23.12.14. I can only guess as to why this is but I assume this also stemmed from unexpected handling of data during the v2 test format update changes.
4. [Radio Group Example Using aria-activedescendant Test Plan V24.03.13](https://aria-at.w3.org/test-review/75322) currently shows assertion phrases which should be using replaced by intended token strings as the generic string. ie `Test 1 > JAWS > Tab (virtual cursor)`'s last assertion phrase is saying _"switch from reading mode to interaction mode"_ instead of _"switch from virtual cursor active to PC cursor active"_ and the same is true for additional JAWS and NVDA assertions where this tokenization should have happened. That's because [the PR](https://github.com/w3c/aria-at-app/pull/942) which would support this happening during the import (and only during the import) has not yet been included in production and so it warrants an update happening in place.

This PR addresses the above.