### PR TITLE
Address date inconsistencies for candidate phase TestPlanVersions

### DIFF
--- a/client/components/CandidateReview/TestPlans/index.jsx
+++ b/client/components/CandidateReview/TestPlans/index.jsx
@@ -438,9 +438,7 @@ const TestPlans = ({ testPlanVersions }) => {
                         <thead>
                             <tr>
                                 <th>Candidate Test Plans</th>
-                                <CenteredTh>
-                                    Candidate Phase Start Date
-                                </CenteredTh>
+                                <CenteredTh>Plan Last Updated</CenteredTh>
                                 <CenteredTh>Target Completion Date</CenteredTh>
                                 <CenteredTh>Review Status</CenteredTh>
                                 <CenteredTh>Results Summary</CenteredTh>

--- a/client/components/CandidateReview/TestPlans/index.jsx
+++ b/client/components/CandidateReview/TestPlans/index.jsx
@@ -438,7 +438,7 @@ const TestPlans = ({ testPlanVersions }) => {
                         <thead>
                             <tr>
                                 <th>Candidate Test Plans</th>
-                                <CenteredTh>Plan Last Updated</CenteredTh>
+                                <CenteredTh>Last Updated</CenteredTh>
                                 <CenteredTh>Target Completion Date</CenteredTh>
                                 <CenteredTh>Review Status</CenteredTh>
                                 <CenteredTh>Results Summary</CenteredTh>

--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -432,7 +432,7 @@ const DataManagementRow = ({
          * @param {"RECOMMENDED"|"CANDIDATE"|"DRAFT"} phase
          * @returns {TestPlanVersion[]}
          */
-        const deriveVersionsByDates = phase => {
+        const getVersionsThatReachedPhase = phase => {
             switch (phase) {
                 case 'RECOMMENDED':
                     return testPlanVersions.filter(
@@ -462,13 +462,15 @@ const DataManagementRow = ({
             }
         };
 
-        const derivedRecommendedVersions = deriveVersionsByDates('RECOMMENDED');
-        const derivedCandidateVersions = deriveVersionsByDates('CANDIDATE');
-        const derivedDraftVersions = deriveVersionsByDates('DRAFT');
+        const versionsThatReachedRecommended =
+            getVersionsThatReachedPhase('RECOMMENDED');
+        const versionsThatReachedCandidate =
+            getVersionsThatReachedPhase('CANDIDATE');
+        const versionsThatReachedDraft = getVersionsThatReachedPhase('DRAFT');
 
-        if (derivedRecommendedVersions.length) {
+        if (versionsThatReachedRecommended.length) {
             const { earliestVersionDate } = getVersionData(
-                derivedRecommendedVersions,
+                versionsThatReachedRecommended,
                 'recommendedPhaseReachedAt'
             );
             const phase = 'RECOMMENDED';
@@ -482,9 +484,9 @@ const DataManagementRow = ({
             );
         }
 
-        if (derivedCandidateVersions.length) {
+        if (versionsThatReachedCandidate.length) {
             const { earliestVersionDate } = getVersionData(
-                derivedCandidateVersions,
+                versionsThatReachedCandidate,
                 'candidatePhaseReachedAt'
             );
             const phase = 'CANDIDATE';
@@ -501,9 +503,9 @@ const DataManagementRow = ({
             );
         }
 
-        if (derivedDraftVersions.length) {
+        if (versionsThatReachedDraft.length) {
             const { earliestVersionDate } = getVersionData(
-                derivedDraftVersions,
+                versionsThatReachedDraft,
                 'draftPhaseReachedAt'
             );
             const phase = 'DRAFT';

--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -152,7 +152,6 @@ const DataManagementRow = ({
     testPlan,
     testPlanVersions,
     setTestPlanVersions,
-    deprecatedTestPlanVersions,
     tableRowIndex
 }) => {
     const { triggerLoad, loadingMessage } = useTriggerLoad();
@@ -426,72 +425,46 @@ const DataManagementRow = ({
             return otherVersionsInProgress.length;
         };
 
-        const getDeprecatedVersionsByDatePhase = phase => {
+        const deriveVersionsByDates = phase => {
             switch (phase) {
                 case 'RECOMMENDED':
-                    return deprecatedTestPlanVersions
-                        .filter(
-                            ({ recommendedPhaseReachedAt }) =>
-                                !!recommendedPhaseReachedAt
-                        )
-                        .map(testPlanVersion => ({
-                            ...testPlanVersion,
-                            phase: 'RECOMMENDED'
-                        }));
+                    return testPlanVersions.filter(
+                        ({ recommendedPhaseReachedAt }) =>
+                            !!recommendedPhaseReachedAt
+                    );
                 case 'CANDIDATE':
-                    return deprecatedTestPlanVersions
-                        .filter(
-                            ({
-                                candidatePhaseReachedAt,
-                                recommendedPhaseReachedAt
-                            }) =>
-                                !!candidatePhaseReachedAt &&
-                                !recommendedPhaseReachedAt
-                        )
-                        .map(testPlanVersion => ({
-                            ...testPlanVersion,
-                            phase: 'CANDIDATE'
-                        }));
+                    return testPlanVersions.filter(
+                        ({
+                            candidatePhaseReachedAt,
+                            recommendedPhaseReachedAt
+                        }) =>
+                            !!candidatePhaseReachedAt &&
+                            !recommendedPhaseReachedAt
+                    );
                 case 'DRAFT':
-                    return deprecatedTestPlanVersions
-                        .filter(
-                            ({
-                                draftPhaseReachedAt,
-                                candidatePhaseReachedAt,
-                                recommendedPhaseReachedAt
-                            }) =>
-                                !!draftPhaseReachedAt &&
-                                !candidatePhaseReachedAt &&
-                                !recommendedPhaseReachedAt
-                        )
-                        .map(testPlanVersion => ({
-                            ...testPlanVersion,
-                            phase: 'DRAFT'
-                        }));
+                    return testPlanVersions.filter(
+                        ({
+                            draftPhaseReachedAt,
+                            candidatePhaseReachedAt,
+                            recommendedPhaseReachedAt
+                        }) =>
+                            !!draftPhaseReachedAt &&
+                            !candidatePhaseReachedAt &&
+                            !recommendedPhaseReachedAt
+                    );
             }
         };
 
-        let recommendedWithDeprecatedTestPlanVersions = [
-            ...recommendedTestPlanVersions,
-            ...getDeprecatedVersionsByDatePhase('RECOMMENDED')
-        ];
+        const derivedRecommendedVersions = deriveVersionsByDates('RECOMMENDED');
+        const derivedCandidateVersions = deriveVersionsByDates('CANDIDATE');
+        const derivedDraftVersions = deriveVersionsByDates('DRAFT');
 
-        let candidateWithDeprecatedTestPlanVersions = [
-            ...candidateTestPlanVersions,
-            ...getDeprecatedVersionsByDatePhase('CANDIDATE')
-        ];
-
-        let draftWithDeprecatedTestPlanVersions = [
-            ...draftTestPlanVersions,
-            ...getDeprecatedVersionsByDatePhase('DRAFT')
-        ];
-
-        if (recommendedWithDeprecatedTestPlanVersions.length) {
-            const { earliestVersion, earliestVersionDate } = getVersionData(
-                recommendedWithDeprecatedTestPlanVersions,
+        if (derivedRecommendedVersions.length) {
+            const { earliestVersionDate } = getVersionData(
+                derivedRecommendedVersions,
                 'recommendedPhaseReachedAt'
             );
-            const { phase } = earliestVersion;
+            const phase = 'RECOMMENDED';
             const versionsInProgressCount = otherVersionsInProgressCount(phase);
 
             return (
@@ -502,13 +475,12 @@ const DataManagementRow = ({
             );
         }
 
-        if (candidateWithDeprecatedTestPlanVersions.length) {
-            const { earliestVersion, earliestVersionDate } = getVersionData(
-                candidateWithDeprecatedTestPlanVersions,
+        if (derivedCandidateVersions.length) {
+            const { earliestVersionDate } = getVersionData(
+                derivedCandidateVersions,
                 'candidatePhaseReachedAt'
             );
-            const { phase } = earliestVersion;
-
+            const phase = 'CANDIDATE';
             const versionsInProgressCount = otherVersionsInProgressCount(
                 phase,
                 ['RECOMMENDED']
@@ -522,13 +494,12 @@ const DataManagementRow = ({
             );
         }
 
-        if (draftWithDeprecatedTestPlanVersions.length) {
-            const { earliestVersion, earliestVersionDate } = getVersionData(
-                draftWithDeprecatedTestPlanVersions,
+        if (derivedDraftVersions.length) {
+            const { earliestVersionDate } = getVersionData(
+                derivedDraftVersions,
                 'draftPhaseReachedAt'
             );
-            const { phase } = earliestVersion;
-
+            const phase = 'DRAFT';
             const versionsInProgressCount = otherVersionsInProgressCount(
                 phase,
                 ['RECOMMENDED', 'CANDIDATE']

--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -425,6 +425,13 @@ const DataManagementRow = ({
             return otherVersionsInProgress.length;
         };
 
+        /**
+         * Uses the truthy state of defined dates for a TestPlanVersion to
+         * determine if the version was ever in that phase at any given point.
+         * Useful if the phase of the TestPlanVersion is currently DEPRECATED.
+         * @param {RECOMMENDED|CANDIDATE|DRAFT} phase
+         * @returns {TestPlanVersion[]}
+         */
         const deriveVersionsByDates = phase => {
             switch (phase) {
                 case 'RECOMMENDED':

--- a/client/components/DataManagement/DataManagementRow/index.jsx
+++ b/client/components/DataManagement/DataManagementRow/index.jsx
@@ -429,7 +429,7 @@ const DataManagementRow = ({
          * Uses the truthy state of defined dates for a TestPlanVersion to
          * determine if the version was ever in that phase at any given point.
          * Useful if the phase of the TestPlanVersion is currently DEPRECATED.
-         * @param {RECOMMENDED|CANDIDATE|DRAFT} phase
+         * @param {"RECOMMENDED"|"CANDIDATE"|"DRAFT"} phase
          * @returns {TestPlanVersion[]}
          */
         const deriveVersionsByDates = phase => {

--- a/client/components/DataManagement/index.jsx
+++ b/client/components/DataManagement/index.jsx
@@ -31,6 +31,8 @@ const DataManagement = () => {
     const [ats, setAts] = useState([]);
     const [testPlans, setTestPlans] = useState([]);
     const [testPlanVersions, setTestPlanVersions] = useState([]);
+    const [deprecatedTestPlanVersions, setDeprecatedTestPlanVersions] =
+        useState([]);
     const [filter, setFilter] = useState(
         DATA_MANAGEMENT_TABLE_FILTER_OPTIONS.ALL
     );
@@ -40,10 +42,16 @@ const DataManagement = () => {
 
     useEffect(() => {
         if (data) {
-            const { ats = [], testPlanVersions = [], testPlans = [] } = data;
+            const {
+                ats = [],
+                testPlanVersions = [],
+                deprecatedTestPlanVersions = [],
+                testPlans = []
+            } = data;
             setAts(ats);
             setTestPlans(testPlans);
             setTestPlanVersions(testPlanVersions);
+            setDeprecatedTestPlanVersions(deprecatedTestPlanVersions);
             setPageReady(true);
         }
     }, [data]);
@@ -213,6 +221,11 @@ const DataManagement = () => {
                                 ats={ats}
                                 testPlan={testPlan}
                                 testPlanVersions={testPlanVersions.filter(
+                                    testPlanVersion =>
+                                        testPlanVersion.testPlan.directory ===
+                                        testPlan.directory
+                                )}
+                                deprecatedTestPlanVersions={deprecatedTestPlanVersions.filter(
                                     testPlanVersion =>
                                         testPlanVersion.testPlan.directory ===
                                         testPlan.directory

--- a/client/components/DataManagement/index.jsx
+++ b/client/components/DataManagement/index.jsx
@@ -220,12 +220,10 @@ const DataManagement = () => {
                                 isAdmin={isAdmin}
                                 ats={ats}
                                 testPlan={testPlan}
-                                testPlanVersions={testPlanVersions.filter(
-                                    testPlanVersion =>
-                                        testPlanVersion.testPlan.directory ===
-                                        testPlan.directory
-                                )}
-                                deprecatedTestPlanVersions={deprecatedTestPlanVersions.filter(
+                                testPlanVersions={[
+                                    ...deprecatedTestPlanVersions,
+                                    ...testPlanVersions
+                                ].filter(
                                     testPlanVersion =>
                                         testPlanVersion.testPlan.directory ===
                                         testPlan.directory

--- a/client/components/DataManagement/queries.js
+++ b/client/components/DataManagement/queries.js
@@ -31,6 +31,19 @@ export const DATA_MANAGEMENT_PAGE_QUERY = gql`
             directory
             title
         }
+        deprecatedTestPlanVersions: testPlanVersions(phases: [DEPRECATED]) {
+            id
+            phase
+            updatedAt
+            draftPhaseReachedAt
+            candidatePhaseReachedAt
+            recommendedPhaseTargetDate
+            recommendedPhaseReachedAt
+            deprecatedAt
+            testPlan {
+                directory
+            }
+        }
         testPlanVersions(phases: [RD, DRAFT, CANDIDATE, RECOMMENDED]) {
             id
             title

--- a/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
+++ b/client/tests/__mocks__/GraphQLMocks/DataManagementPagePopulatedMock.js
@@ -280,6 +280,7 @@ export default (
                         title: 'Banner Landmark'
                     }
                 ],
+                deprecatedTestPlanVersions: [],
                 testPlanVersions: [
                     {
                         id: '28',

--- a/server/migrations/20240401203810-fixCommandButtonPhaseChangeDate.js
+++ b/server/migrations/20240401203810-fixCommandButtonPhaseChangeDate.js
@@ -18,7 +18,7 @@ module.exports = {
             );
 
             // Update deprecation date for Command Button V23.12.06 to be a
-            // second before it's current time. It was the same time Command
+            // second before its current time. It was the same time Command
             // Button V23.12.13 was updated to draft which isn't functionally
             // possible
             await queryInterface.sequelize.query(

--- a/server/migrations/20240401203810-fixCommandButtonPhaseChangeDate.js
+++ b/server/migrations/20240401203810-fixCommandButtonPhaseChangeDate.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface) {
+        return queryInterface.sequelize.transaction(async transaction => {
+            // Update date for Command Button V23.12.13 to be the time V22.04.04
+            // was deprecated (+1 second)
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                 set "candidatePhaseReachedAt" = '2024-01-24 02:06:55.460000 +00:00'
+                 where id = 62353
+                   and "gitSha" = '565a87b4111acebdb883d187b581e82c42a73844'
+                   and directory = 'command-button'`,
+                {
+                    transaction
+                }
+            );
+
+            // Update deprecation date for Command Button V23.12.06 to be a
+            // second before it's current time. It was the same time Command
+            // Button V23.12.13 was updated to draft which isn't functionally
+            // possible
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                 set "deprecatedAt" = '2023-12-13 22:18:04.298000 +00:00'
+                 where id = 56298
+                   and "gitSha" = 'd9a19f815d0f21194023b1c5919eb3b04d5c1ab7'
+                   and directory = 'command-button'`,
+                {
+                    transaction
+                }
+            );
+        });
+    },
+    async down() {}
+};

--- a/server/migrations/20240401203810-fixCommandButtonPhaseChangeDate.js
+++ b/server/migrations/20240401203810-fixCommandButtonPhaseChangeDate.js
@@ -33,5 +33,29 @@ module.exports = {
             );
         });
     },
-    async down() {}
+    async down(queryInterface) {
+        return queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                 set "candidatePhaseReachedAt" = '2022-05-05 21:34:31.000000 +00:00'
+                 where id = 62353
+                   and "gitSha" = '565a87b4111acebdb883d187b581e82c42a73844'
+                   and directory = 'command-button'`,
+                {
+                    transaction
+                }
+            );
+
+            await queryInterface.sequelize.query(
+                `update "TestPlanVersion"
+                 set "deprecatedAt" = '2023-12-13 22:19:04.298000 +00:00'
+                 where id = 56298
+                   and "gitSha" = 'd9a19f815d0f21194023b1c5919eb3b04d5c1ab7'
+                   and directory = 'command-button'`,
+                {
+                    transaction
+                }
+            );
+        });
+    }
 };


### PR DESCRIPTION
Addressing latest comments of https://github.com/w3c/aria-at-app/issues/973#issuecomment-2028893100:

**Data Management Overall Status Column date being incorrect**

The Data Management page never kept track of the deprecated versions, so the earliest version date could not have been presented if the version it belonged to was now deprecated. This PR now includes deprecated versions in that date calculation.

**Incorrect phase change date recorded on Command Button versions page for V23.12.13**

This issue isn't related to this PR because it is also [on production](https://aria-at.w3.org/data-management/command-button). I figure something odd happened around this time and this is a one-off situation. There was also an oddity observed for [Toggle Button](https://aria-at.w3.org/data-management/toggle-button) on the same date, with there being a 2nd DRAFT version (but this will be resolved once #987 is deployed to production).

I think fixing this could be a simple SQL update. Using V22.05.04 deprecation date + 1 second, as the guide for the "correct" phase change date as it was the version deprecated in CANDIDATE by V23.12.13, the statement should be:

```sql
update "TestPlanVersion"
set "candidatePhaseReachedAt" = '2024-01-24 02:06:55.460000 +00:00'
where id = 62353
  and "gitSha" = '565a87b4111acebdb883d187b581e82c42a73844'
  and directory = 'command-button';
```

Reviewers, would you rather there be a migration for this change or it be performed on the deployed environment and noted? I have tested this locally on a copy of the production data and found no issues.

**Candidate review page**

This PR makes use of option 2

> Change the column title and leave the data as is.

And updates the `Candidate Phase Start Date` title to `Plan Last Updated`