### PR TITLE
Adjust connection pooling limit

### DIFF
--- a/server/models/index.js
+++ b/server/models/index.js
@@ -18,7 +18,7 @@ sequelize = new Sequelize(
             native: true
         },
         pool: {
-            max: 100
+            max: 80
         },
         logging: false // console.log // eslint-disable-line
     }


### PR DESCRIPTION
Increasing the connection limit fixed the issue we were seeing about too many simultaneous connections but whenever the pooling function is needed it immediately errors without timing out with a complaint about exceeding the number of superuser connections. The solution was to lower the connection count slightly so that connection pooling can work again. That way we keep the increased number of simultaneous transactions while also keeping the ability to use connection pooling during intense workloads like the tests.