### PR TITLE
Revert "Force certificates to renew"

### DIFF
--- a/deploy/roles/certbot/tasks/templates/aria-at-app-cert.service.j2
+++ b/deploy/roles/certbot/tasks/templates/aria-at-app-cert.service.j2
@@ -4,7 +4,7 @@ After=nginx.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/certbot renew --no-self-upgrade --force-renewal --deploy-hook "/bin/systemctl restart nginx"
+ExecStart=/usr/bin/certbot renew --no-self-upgrade --deploy-hook "/bin/systemctl restart nginx"
 KillMode=control-group
 
 [Install]


### PR DESCRIPTION
This reverts commit 2153a0858818cc4ae9419bea0cd8e03ad808cceb.

Forced certificate renewal caused the production system to needlessly request new certificates on a daily basis. This represented a waste of resources and contributed significant noise to the log, particularly when the quota for renewals is reached:

    2024-04-03 15:08:04,536:ERROR:certbot._internal.renewal:Failed to renew certificate aria-at.w3.org with error: urn:ietf:params:acme:error:rateLimited :: There were too many requests of a given type :: Error creating new order :: too many certificates (5) already issued for this exact set of domains in the last 168 hours: aria-at.w3.org, retry after 2024-04-03T23:42:21Z: see https://letsencrypt.org/docs/duplicate-certificate-limit/

Routinely operating in this state undermines the maintainers' ability to revoke and regenerate certificates in emergency situations.

In the absence of a rationale for the introduction of `--force-renewal`, these drawbacks justify its removal.