### PR TITLE
feat: Restructure APG Support Tables

### DIFF
--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -220,7 +220,7 @@ const getLatestReportsForPattern = ({ allTestPlanReports, pattern }) => {
         latestReports
     };
 };
-const priorities = ['MUST', 'SHOULD'];
+const priorities = ['"Must" Assertion Priority', '"Should" Assertion Priority'];
 const renderEmbed = ({
     ats,
     allTestPlanReports,

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -30,16 +30,40 @@ app.set('views', path.resolve(handlebarsPath, 'views'));
 // stale data for however long it takes for the query to complete.
 const millisecondsUntilStale = 5000;
 
-const queryReports = async () => {
+const queryReports = async testPlanDirectory => {
     const { data, errors } = await apolloServer.executeOperation({
         query: gql`
-            query {
+            query TestPlanQuery($testPlanDirectory: ID!) {
                 ats {
                     id
                     name
                     browsers {
                         id
                         name
+                    }
+                }
+                testPlan(id: $testPlanDirectory) {
+                    testPlanVersions {
+                        id
+                        title
+                        phase
+                        testPlanReports(isFinal: true) {
+                            id
+                            metrics
+                            at {
+                                id
+                                name
+                            }
+                            browser {
+                                id
+                                name
+                            }
+                            latestAtVersionReleasedAt {
+                                id
+                                name
+                                releasedAt
+                            }
+                        }
                     }
                 }
                 testPlanReports(
@@ -72,7 +96,8 @@ const queryReports = async () => {
                     }
                 }
             }
-        `
+        `,
+        variables: { testPlanDirectory }
     });
 
     if (errors) {

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -92,12 +92,29 @@ const renderEmbed = async ({
         );
     }
 
+    // const allAtsAlphabetical = Array.from(allAts).sort((a, b) =>
+    //     a.localeCompare(b)
+    // );
+    // allAtsAlphabetical.forEach(at => {
+    //     reportsByAt[at] = latestReports
+    //         .filter(report => report.at.name === at)
+    //         .sort((a, b) => a.browser.name.localeCompare(b.browser.name));
+    // });
+    const testPlanReports = (testPlanVersion?.testPlanReports ?? []).sort(
+        (a, b) => {
+            if (a.at.name !== b.at.name) {
+                return a.at.name.localeCompare(b.at.name);
+            }
+            return a.browser.name.localeCompare(b.browser.name);
+        }
+    );
+
     return hbs.renderView(path.resolve(handlebarsPath, 'views/main.hbs'), {
         layout: 'index',
         dataEmpty: !testPlanVersion?.testPlanReports.length,
         title: queryTitle || testPlanVersion.title || 'Pattern Not Found',
         phase: testPlanVersion.phase,
-        testPlanReports: testPlanVersion?.testPlanReports ?? [],
+        testPlanReports,
         completeReportLink: `${protocol}${host}/report/${testPlanVersion?.id}`,
         embedLink: `${protocol}${host}/embed/reports/${testPlanDirectory}`
     });

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -92,14 +92,6 @@ const renderEmbed = async ({
         );
     }
 
-    // const allAtsAlphabetical = Array.from(allAts).sort((a, b) =>
-    //     a.localeCompare(b)
-    // );
-    // allAtsAlphabetical.forEach(at => {
-    //     reportsByAt[at] = latestReports
-    //         .filter(report => report.at.name === at)
-    //         .sort((a, b) => a.browser.name.localeCompare(b.browser.name));
-    // });
     const testPlanReports = (testPlanVersion?.testPlanReports ?? []).sort(
         (a, b) => {
             if (a.at.name !== b.at.name) {

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -80,13 +80,13 @@ const renderEmbed = async ({
 
     let testPlanVersion;
 
-    const recommendedTestPlanVersion = data.testPlan.testPlanVersions.find(
+    const recommendedTestPlanVersion = data.testPlan?.testPlanVersions.find(
         testPlanVersion => testPlanVersion.phase === 'RECOMMENDED'
     );
 
-    if (recommendedTestPlanVersion) {
+    if (data.testPlan && recommendedTestPlanVersion) {
         testPlanVersion = recommendedTestPlanVersion;
-    } else {
+    } else if (data.testPlan) {
         testPlanVersion = data.testPlan.testPlanVersions.find(
             testPlanVersion => testPlanVersion.phase === 'CANDIDATE'
         );
@@ -104,8 +104,8 @@ const renderEmbed = async ({
     return hbs.renderView(path.resolve(handlebarsPath, 'views/main.hbs'), {
         layout: 'index',
         dataEmpty: !testPlanVersion?.testPlanReports.length,
-        title: queryTitle || testPlanVersion.title || 'Pattern Not Found',
-        phase: testPlanVersion.phase,
+        title: queryTitle || testPlanVersion?.title || 'Pattern Not Found',
+        phase: testPlanVersion?.phase,
         testPlanReports,
         completeReportLink: `${protocol}${host}/report/${testPlanVersion?.id}`,
         embedLink: `${protocol}${host}/embed/reports/${testPlanDirectory}`

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -66,35 +66,35 @@ const queryReports = async testPlanDirectory => {
                         }
                     }
                 }
-                # testPlanReports(
-                #     testPlanVersionPhases: [CANDIDATE, RECOMMENDED]
-                #     isFinal: true
-                # ) {
-                #     id
-                #     metrics
-                #     at {
-                #         id
-                #         name
-                #     }
-                #     browser {
-                #         id
-                #         name
-                #     }
-                #     latestAtVersionReleasedAt {
-                #         id
-                #         name
-                #         releasedAt
-                #     }
-                #     testPlanVersion {
-                #         id
-                #         title
-                #         phase
-                #         updatedAt
-                #         testPlan {
-                #             id
-                #         }
-                #     }
-                # }
+                testPlanReports(
+                    testPlanVersionPhases: [CANDIDATE, RECOMMENDED]
+                    isFinal: true
+                ) {
+                    id
+                    metrics
+                    at {
+                        id
+                        name
+                    }
+                    browser {
+                        id
+                        name
+                    }
+                    latestAtVersionReleasedAt {
+                        id
+                        name
+                        releasedAt
+                    }
+                    testPlanVersion {
+                        id
+                        title
+                        phase
+                        updatedAt
+                        testPlan {
+                            id
+                        }
+                    }
+                }
             }
         `,
         variables: { testPlanDirectory }
@@ -104,11 +104,11 @@ const queryReports = async testPlanDirectory => {
         throw new Error(errors);
     }
 
-    // const reportsHashed = hash(data.testPlanReports);
+    const reportsHashed = hash(data.testPlanReports);
 
     return {
         allTestPlanReports: data.testPlanReports,
-        // reportsHashed,
+        reportsHashed,
         ats: data.ats
     };
 };
@@ -182,11 +182,12 @@ const getLatestReportsForPattern = ({ allTestPlanReports, pattern }) => {
             latestReports.push(group.pop());
         } else {
             const latestReport = group
-                .sort(
-                    (a, b) =>
+                .sort((a, b) => {
+                    return (
                         new Date(a.latestAtVersionReleasedAt.releasedAt) -
                         new Date(b.latestAtVersionReleasedAt.releasedAt)
-                )
+                    );
+                })
                 .pop();
 
             latestReports.push(latestReport);
@@ -217,10 +218,21 @@ const getLatestReportsForPattern = ({ allTestPlanReports, pattern }) => {
         testPlanVersionIds,
         phase,
         reportsByAt,
-        latestReports
+        latestReports: latestReports.sort((a, b) => {
+            if (a.at.name !== b.at.name) {
+                return a.at.name.localeCompare(b.at.name);
+            }
+            if (a.browser.name !== b.browser.name) {
+                return a.browser.name.localeCompare(b.browser.name);
+            }
+            return (
+                new Date(b.latestAtVersionReleasedAt.releasedAt) -
+                new Date(a.latestAtVersionReleasedAt.releasedAt)
+            );
+        })
     };
 };
-const priorities = ['"Must" Assertion Priority', '"Should" Assertion Priority'];
+const priorities = ['MUST HAVE Behaviors', 'SHOULD HAVE Behaviors'];
 const renderEmbed = ({
     ats,
     allTestPlanReports,

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -106,7 +106,10 @@ const renderEmbed = async ({
         dataEmpty: !testPlanVersion?.testPlanReports.length,
         title: queryTitle || testPlanVersion?.title || 'Pattern Not Found',
         phase: testPlanVersion?.phase,
+        testPlanVersionId: testPlanVersion?.id,
         testPlanReports,
+        protocol,
+        host,
         completeReportLink: `${protocol}${host}/report/${testPlanVersion?.id}`,
         embedLink: `${protocol}${host}/embed/reports/${testPlanDirectory}`
     });

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -66,35 +66,35 @@ const queryReports = async testPlanDirectory => {
                         }
                     }
                 }
-                testPlanReports(
-                    testPlanVersionPhases: [CANDIDATE, RECOMMENDED]
-                    isFinal: true
-                ) {
-                    id
-                    metrics
-                    at {
-                        id
-                        name
-                    }
-                    browser {
-                        id
-                        name
-                    }
-                    latestAtVersionReleasedAt {
-                        id
-                        name
-                        releasedAt
-                    }
-                    testPlanVersion {
-                        id
-                        title
-                        phase
-                        updatedAt
-                        testPlan {
-                            id
-                        }
-                    }
-                }
+                # testPlanReports(
+                #     testPlanVersionPhases: [CANDIDATE, RECOMMENDED]
+                #     isFinal: true
+                # ) {
+                #     id
+                #     metrics
+                #     at {
+                #         id
+                #         name
+                #     }
+                #     browser {
+                #         id
+                #         name
+                #     }
+                #     latestAtVersionReleasedAt {
+                #         id
+                #         name
+                #         releasedAt
+                #     }
+                #     testPlanVersion {
+                #         id
+                #         title
+                #         phase
+                #         updatedAt
+                #         testPlan {
+                #             id
+                #         }
+                #     }
+                # }
             }
         `,
         variables: { testPlanDirectory }
@@ -104,11 +104,11 @@ const queryReports = async testPlanDirectory => {
         throw new Error(errors);
     }
 
-    const reportsHashed = hash(data.testPlanReports);
+    // const reportsHashed = hash(data.testPlanReports);
 
     return {
         allTestPlanReports: data.testPlanReports,
-        reportsHashed,
+        // reportsHashed,
         ats: data.ats
     };
 };

--- a/server/apps/embed.js
+++ b/server/apps/embed.js
@@ -69,12 +69,6 @@ const queryReports = async () => {
                         testPlan {
                             id
                         }
-                        tests {
-                            ats {
-                                id
-                                name
-                            }
-                        }
                     }
                 }
             }
@@ -118,7 +112,7 @@ const getLatestReportsForPattern = ({ allTestPlanReports, pattern }) => {
     let testPlanVersionIds = new Set();
     const uniqueReports = [];
     let latestReports = [];
-
+    // section:
     testPlanReports.forEach(report => {
         allAts.add(report.at.name);
         allBrowsers.add(report.browser.name);
@@ -156,7 +150,14 @@ const getLatestReportsForPattern = ({ allTestPlanReports, pattern }) => {
 
         testPlanVersionIds.add(report.testPlanVersion.id);
     });
-
+    // section:
+    // const numberArray = allAts.map((at) => {
+    //     return allBrowsers.map((browser) => {
+    //         return {at, browser}
+    //     })
+    // })
+    // const numberArray =
+    // console.log(numberArray);
     uniqueReports.forEach(group => {
         if (group.length <= 1) {
             latestReports.push(group.pop());
@@ -170,6 +171,7 @@ const getLatestReportsForPattern = ({ allTestPlanReports, pattern }) => {
                 .pop();
 
             latestReports.push(latestReport);
+            // use latest reports for the loop for the table
         }
     });
 
@@ -197,6 +199,7 @@ const getLatestReportsForPattern = ({ allTestPlanReports, pattern }) => {
         testPlanVersionIds,
         phase,
         reportsByAt
+        // numberArray
     };
 };
 
@@ -215,6 +218,7 @@ const renderEmbed = ({
         testPlanVersionIds,
         phase,
         reportsByAt
+        // numberArray
     } = getLatestReportsForPattern({ pattern, allTestPlanReports });
     const allAtBrowserCombinations = Object.fromEntries(
         ats.map(at => {
@@ -235,6 +239,8 @@ const renderEmbed = ({
         pattern,
         phase,
         allBrowsers,
+        // section:
+        // numberArray: numberArray,
         allAtVersionsByAt,
         reportsByAt,
         completeReportLink: `${protocol}${host}/report/${testPlanVersionIds.join(

--- a/server/handlebars/embed/helpers/index.js
+++ b/server/handlebars/embed/helpers/index.js
@@ -20,6 +20,12 @@ module.exports = {
                 100
         );
     },
+    isMustAssertionPriority: function (object) {
+        return object.metrics.mustAssertionsCount > 0;
+    },
+    isShouldAssertionPriority: function (object) {
+        return object.metrics.shouldAssertionsCount > 0;
+    },
     getShouldSupportData: function (object) {
         return Math.trunc(
             (object.metrics.shouldAssertionsPassedCount /

--- a/server/handlebars/embed/helpers/index.js
+++ b/server/handlebars/embed/helpers/index.js
@@ -11,13 +11,22 @@ module.exports = {
         return value === 'CANDIDATE';
     },
     getAtVersion: function (object, key) {
-        // return object.allAtVersionsByAt[key].name;
         return object.allAtVersionsByAt[key].name;
     },
-    // getAtBrowserCombo: function (object, key) {
-    //     // console.log(object.allBrowsers);
-    //     return object[0].at.id;
-    // },
+    getMustSupportData: function (object) {
+        return Math.trunc(
+            (object.metrics.mustAssertionsPassedCount /
+                object.metrics.mustAssertionsCount) *
+                100
+        );
+    },
+    getShouldSupportData: function (object) {
+        return Math.trunc(
+            (object.metrics.shouldAssertionsPassedCount /
+                object.metrics.shouldAssertionsCount) *
+                100
+        );
+    },
     combinationExists: function (object, atName, browserName) {
         if (object.allAtBrowserCombinations[atName].includes(browserName)) {
             return true;

--- a/server/handlebars/embed/helpers/index.js
+++ b/server/handlebars/embed/helpers/index.js
@@ -1,17 +1,6 @@
-let map = {};
-
 module.exports = {
-    isBrowser: function (a, b) {
-        return a === b;
-    },
-    isInAllBrowsers: function (value, object) {
-        return object.allBrowsers.includes(value);
-    },
     isCandidate: function (value) {
         return value === 'CANDIDATE';
-    },
-    getAtVersion: function (object, key) {
-        return object.allAtVersionsByAt[key].name;
     },
     getMustSupportData: function (object) {
         return Math.trunc(
@@ -32,49 +21,5 @@ module.exports = {
                 object.metrics.shouldAssertionsCount) *
                 100
         );
-    },
-    combinationExists: function (object, atName, browserName) {
-        if (object.allAtBrowserCombinations[atName].includes(browserName)) {
-            return true;
-        }
-        return false;
-    },
-    elementExists: function (parentObject, childObject, at, key, last) {
-        const atBrowsers = childObject.map(o => o.browser.name);
-
-        if (!map[parentObject.pattern]) {
-            map[parentObject.pattern] = {};
-        }
-
-        if (!(at in map[parentObject.pattern])) {
-            map[parentObject.pattern][at] = {};
-        }
-
-        const moreThanOneColumn = Object.values(childObject).length > 1;
-
-        const conditional =
-            moreThanOneColumn &&
-            (key in map[parentObject.pattern][at] || atBrowsers.includes(key));
-
-        // Cache columns that don't have data
-        if (
-            !(key in map[parentObject.pattern][at]) &&
-            !atBrowsers.includes(key)
-        ) {
-            map[parentObject.pattern][at][key] = true;
-        }
-
-        // Don't write to the Safari column unless it's the last element
-        if (!last && key === 'Safari' && !atBrowsers.includes(key)) {
-            return true;
-        } else if (last && key === 'Safari' && !atBrowsers.includes(key)) {
-            return false;
-        }
-
-        return conditional;
-    },
-    resetMap: function () {
-        map = {};
-        return;
     }
 };

--- a/server/handlebars/embed/helpers/index.js
+++ b/server/handlebars/embed/helpers/index.js
@@ -1,4 +1,8 @@
 module.exports = {
+    dataEmpty: function (object) {
+        return object.length === 0;
+    },
+
     isCandidate: function (value) {
         return value === 'CANDIDATE';
     },

--- a/server/handlebars/embed/helpers/index.js
+++ b/server/handlebars/embed/helpers/index.js
@@ -11,8 +11,13 @@ module.exports = {
         return value === 'CANDIDATE';
     },
     getAtVersion: function (object, key) {
+        // return object.allAtVersionsByAt[key].name;
         return object.allAtVersionsByAt[key].name;
     },
+    // getAtBrowserCombo: function (object, key) {
+    //     // console.log(object.allBrowsers);
+    //     return object[0].at.id;
+    // },
     combinationExists: function (object, atName, browserName) {
         if (object.allAtBrowserCombinations[atName].includes(browserName)) {
             return true;

--- a/server/handlebars/embed/public/script.js
+++ b/server/handlebars/embed/public/script.js
@@ -31,8 +31,6 @@ const announceCopied = link => {
 };
 
 const postHeightAndClass = () => {
-    console.log('posting height', document.body.scrollHeight);
-    console.log('iframeClass', iframeClass);
     window.parent.postMessage(
         { height: document.body.scrollHeight, iframe: iframeClass },
         '*'

--- a/server/handlebars/embed/public/script.js
+++ b/server/handlebars/embed/public/script.js
@@ -1,6 +1,6 @@
-const iframeClass = `support-levels-${document
-    .querySelector('script[pattern]')
-    .getAttribute('pattern')}`;
+const iframeClass = `support-levels-${
+    document.location.href.match(/([^/]+)\/?$/)?.[1]
+}`;
 
 const iframeCode = link =>
     `<iframe
@@ -30,11 +30,14 @@ const announceCopied = link => {
     }, 5000);
 };
 
-const postHeightAndClass = () =>
+const postHeightAndClass = () => {
+    console.log('posting height', document.body.scrollHeight);
+    console.log('iframeClass', iframeClass);
     window.parent.postMessage(
         { height: document.body.scrollHeight, iframe: iframeClass },
         '*'
     );
+};
 
 window.onresize = postHeightAndClass;
 document

--- a/server/handlebars/embed/public/style.css
+++ b/server/handlebars/embed/public/style.css
@@ -15,22 +15,6 @@ a:focus-visible {
     outline: 2px solid #3a86d1;
 }
 
-h3#report-title {
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 18px;
-}
-
-#copied-message {
-    align-self: center;
-}
-
-#at-version {
-    font-weight: lighter;
-}
-
 #no-data-content-container {
     border-left: 1.5px solid #c0c0c0;
     border-right: 1.5px solid #c0c0c0;
@@ -43,55 +27,114 @@ h3#report-title {
     text-align: center;
 }
 
-#embed-report-phase-container {
+details {
     margin-bottom: 1em;
 }
-#embed-report-phase-container summary:focus-visible {
+details summary:focus-visible {
     outline-offset: -2px;
     outline: 2px solid #3a86d1;
 }
 
-#candidate-title {
-    border: 1.5px solid #ffc4a2;
+details summary::after {
+    width: 30px;
+    height: 30px;
+    border-radius: 3px;
+    display: block;
+    content: '';
+    background-position: center center;
+    background-repeat: no-repeat;
+    position: absolute;
+    right: 0.5em;
+    top: 1.5em;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='6.861' viewBox='0 0 12 6.861'%3E%3Cpath id='Icon_ionic-ios-arrow-down' data-name='Icon ionic-ios-arrow-down' d='M12.19,16.039,16.727,11.5a.854.854,0,0,1,1.211,0,.865.865,0,0,1,0,1.215L12.8,17.858a.856.856,0,0,1-1.183.025L6.438,12.717A.858.858,0,1,1,7.649,11.5Z' transform='translate(18.188 18.108) rotate(180)' fill='%2360470c'/%3E%3C/svg%3E%0A");
+    background-color: #fce1a4;
+    transform: rotate(180deg);
+}
+
+details > summary.recommended::after {
+  background-color: #115b11;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='6.861' viewBox='0 0 12 6.861'%3E%3Cpath id='Icon_ionic-ios-arrow-down' data-name='Icon ionic-ios-arrow-down' d='M12.19,16.039,16.727,11.5a.854.854,0,0,1,1.211,0,.865.865,0,0,1,0,1.215L12.8,17.858a.856.856,0,0,1-1.183.025L6.438,12.717A.858.858,0,1,1,7.649,11.5Z' transform='translate(18.188 18.108) rotate(180)' fill='rgb(233, 251, 233)'/%3E%3C/svg%3E%0A");
+}
+
+details[open] summary::after {
+    transform: rotate(0deg);
+}
+
+details > summary {
+    background-color: #fcebc3;
+    border: 1.5px solid #fce1a4;
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
-    background-color: #ffd8c1;
     padding: 0.5em 0.5em 0.5em 1em;
     cursor: pointer;
+    --space-between-elements: 1em;
+    --left-right-padding: 55px;
+    display: block;
 }
 
-#candidate-title > span {
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 12px;
-    font-weight: bold;
-    color: white;
-    background-color: #c25401;
-    padding: 8px 14px;
-    border-radius: 15px;
-    display: inline-block;
+details > summary.recommended {
+  border: 1.5px solid #7ac498;
+  background-color: #e9fbe9;
 }
 
-#candidate-title.recommended {
-    border: 1.5px solid #7ac498;
-    background-color: #e9fbe9;
-}
-#candidate-title.recommended > span {
-    background-color: #115b11;
+details > summary > ::before {
+    width: 32px;
+    height: 32px;
+    display: block;
+    content: '';
+    background-repeat: no-repeat;
+    position: absolute;
+    left: 5px;
+    top: -7px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='31' viewBox='0 0 30 31'%3E%3Cg id='Group_1' data-name='Group 1' transform='translate(-11 -292)'%3E%3Cellipse id='Ellipse_1' data-name='Ellipse 1' cx='15' cy='15.5' rx='15' ry='15.5' transform='translate(11 292)' fill='%23d9ae4d'/%3E%3Cpath id='Path_3' data-name='Path 3' d='M4.524-17.368a4.507,4.507,0,0,0-1.56.312.278.278,0,0,0-.13.286V-14.9c0,2.184.416,8.294.468,9.022a.172.172,0,0,0,.182.156h2.08c.156,0,.182-.078.182-.156.078-.78.52-6.916.52-9.1v-1.872a.326.326,0,0,0-.156-.286A5.112,5.112,0,0,0,4.524-17.368Zm0,17.576A1.7,1.7,0,0,0,6.4-1.534,1.741,1.741,0,0,0,4.524-3.328,1.77,1.77,0,0,0,2.652-1.534,1.7,1.7,0,0,0,4.524.208Z' transform='translate(22 316)' fill='%23fff'/%3E%3C/g%3E%3C/svg%3E%0A");
 }
 
-#candidate-content-container {
-    border-left: 1.5px solid #c0c0c0;
-    border-right: 1.5px solid #c0c0c0;
-    border-bottom: 1.5px solid #c0c0c0;
+details > summary.recommended ::before {
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNS4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjQgRm9udGljb25zLCBJbmMuLS0+CiAgPHBhdGgKICBmaWxsPSIjMTE1YjExIgogICAgZD0iTTI1NiA1MTJBMjU2IDI1NiAwIDEgMCAyNTYgMGEyNTYgMjU2IDAgMSAwIDAgNTEyek0yMTYgMzM2aDI0VjI3MkgyMTZjLTEzLjMgMC0yNC0xMC43LTI0LTI0czEwLjctMjQgMjQtMjRoNDhjMTMuMyAwIDI0IDEwLjcgMjQgMjR2ODhoOGMxMy4zIDAgMjQgMTAuNyAyNCAyNHMtMTAuNyAyNC0yNCAyNEgyMTZjLTEzLjMgMC0yNC0xMC43LTI0LTI0czEwLjctMjQgMjQtMjR6bTQwLTIwOGEzMiAzMiAwIDEgMSAwIDY0IDMyIDMyIDAgMSAxIDAtNjR6IgogIC8+Cjwvc3ZnPgo=');
+}
+
+details > summary > h4 {
+  position: relative;
+  padding-left: var(--left-right-padding);
+  padding-right: var(--left-right-padding);
+
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 1em;
+  color: #60470c;
+  display: inline-block;
+}
+
+details > summary.recommended > h4 {
+  color: #384338;
+}
+
+details summary::-webkit-details-marker {
+  display: none;
+}
+
+.content-container {
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
     padding: 1em 0.5em 0.5em 1em;
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 14px;
+    font-family: Noto Sans, Trebuchet MS, Helvetica Neue, Arial, sans-serif;
+    font-size: 1rem;
+    color: #60470c;
+    background-color: #fdefce;
+    border-left: 1px solid #fce1a4;
+    border-right: 1px solid #fce1a4;
+    border-bottom: 1px solid #fce1a4;
 }
 
-#candidate-content-container > ol > li:not(:last-child) {
+.content-container > ol > li:not(:last-child) {
     margin-bottom: 3px;
+}
+
+div.recommended {
+  border-bottom: 1.5px solid #7ac498;
+  border-left: 1.5px solid #7ac498;
+  border-right: 1.5px solid #7ac498;
+  background-color: #e9fbe9;
+  color: #384338;
 }
 
 .no-data-cell {
@@ -232,6 +275,7 @@ table tbody tr td {
 }
 
 #copied-message {
+    align-self: center;
     font-family: Arial, Helvetica, sans-serif;
     margin: 5px;
     display: inline-block;

--- a/server/handlebars/embed/public/style.css
+++ b/server/handlebars/embed/public/style.css
@@ -1,233 +1,238 @@
 body {
-  margin: 0;
-  /* Parent should use the posted message and set an explicit height */
-  overflow: hidden;
+    margin: 0;
+    /* Parent should use the posted message and set an explicit height */
+    overflow: hidden;
 }
 
 #main {
-  width: 100%;
+    width: 100%;
 }
 
 a {
-  color: #036;
+    color: #036;
 }
 a:focus-visible {
-  outline: 2px solid #3a86d1;
+    outline: 2px solid #3a86d1;
 }
 
 h3#report-title {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
 
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 18px;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 18px;
 }
 
 #copied-message {
-  align-self: center;
+    align-self: center;
 }
 
 #at-version {
-  font-weight: lighter;
+    font-weight: lighter;
 }
 
 #no-data-content-container {
-  border-left: 1.5px solid #c0c0c0;
-  border-right: 1.5px solid #c0c0c0;
-  border-bottom: 1.5px solid #c0c0c0;
-  background-color: #c0c0c0;
-  padding: 1em 0.5em 0.5em 1em;
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 14px;
-  margin-bottom: 1em;
-  text-align: center;
+    border-left: 1.5px solid #c0c0c0;
+    border-right: 1.5px solid #c0c0c0;
+    border-bottom: 1.5px solid #c0c0c0;
+    background-color: #c0c0c0;
+    padding: 1em 0.5em 0.5em 1em;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 14px;
+    margin-bottom: 1em;
+    text-align: center;
 }
 
 #embed-report-phase-container {
-  margin-bottom: 1em;
+    margin-bottom: 1em;
 }
 #embed-report-phase-container summary:focus-visible {
-  outline-offset: -2px;
-  outline: 2px solid #3a86d1;
+    outline-offset: -2px;
+    outline: 2px solid #3a86d1;
 }
 
 #candidate-title {
-  border: 1.5px solid #ffc4a2;
-  border-top-left-radius: 3px;
-  border-top-right-radius: 3px;
-  background-color: #ffd8c1;
-  padding: 0.5em 0.5em 0.5em 1em;
-  cursor: pointer;
+    border: 1.5px solid #ffc4a2;
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+    background-color: #ffd8c1;
+    padding: 0.5em 0.5em 0.5em 1em;
+    cursor: pointer;
 }
 
 #candidate-title > span {
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 12px;
-  font-weight: bold;
-  color: white;
-  background-color: #c25401;
-  padding: 8px 14px;
-  border-radius: 15px;
-  display: inline-block;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 12px;
+    font-weight: bold;
+    color: white;
+    background-color: #c25401;
+    padding: 8px 14px;
+    border-radius: 15px;
+    display: inline-block;
 }
 
 #candidate-title.recommended {
-  border: 1.5px solid #7ac498;
-  background-color: #e9fbe9;
+    border: 1.5px solid #7ac498;
+    background-color: #e9fbe9;
 }
 #candidate-title.recommended > span {
-  background-color: #115b11;
+    background-color: #115b11;
 }
 
 #candidate-content-container {
-  border-left: 1.5px solid #c0c0c0;
-  border-right: 1.5px solid #c0c0c0;
-  border-bottom: 1.5px solid #c0c0c0;
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
-  padding: 1em 0.5em 0.5em 1em;
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 14px;
+    border-left: 1.5px solid #c0c0c0;
+    border-right: 1.5px solid #c0c0c0;
+    border-bottom: 1.5px solid #c0c0c0;
+    border-bottom-left-radius: 3px;
+    border-bottom-right-radius: 3px;
+    padding: 1em 0.5em 0.5em 1em;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 14px;
 }
 
 #candidate-content-container > ol > li:not(:last-child) {
-  margin-bottom: 3px;
+    margin-bottom: 3px;
 }
 
 .no-data-cell {
-  display: block;
-  color: #72777f;
-  font-style: italic;
-  text-align: center;
+    display: block;
+    color: #72777f;
+    font-style: italic;
+    text-align: center;
 }
 
 .responsive-table {
-  overflow-x: auto;
-  width: 100%;
-  margin-bottom: 1em;
+    overflow-x: auto;
+    width: 100%;
+    margin-bottom: 1em;
 }
 
 table {
-  border-collapse: collapse;
-  border-top: 1.5px solid #c0c0c0;
-  width: 100%;
+    border-collapse: collapse;
+    border-top: 1.5px solid #c0c0c0;
+    width: 100%;
 }
 
 table td,
 th {
-  padding: 1rem;
-  border: 1.5px solid #c0c0c0;
+    padding: 1rem;
+    border: 1.5px solid #c0c0c0;
 }
 
 th,
 td {
-  font-family: Arial, Helvetica, sans-serif;
-  padding: 15px;
-  border: 1.5px solid #c0c0c0;
+    font-family: Arial, Helvetica, sans-serif;
+    padding: 15px;
+    border: 1.5px solid #c0c0c0;
 }
 
 th {
-  background-color: #f2f2f2;
+    background-color: #f2f2f2;
+}
+
+th a {
+    text-decoration: none;
+    color: black;
 }
 
 table tbody tr th {
-  text-align: left;
+    text-align: left;
 }
 
 table tbody tr td {
-  padding: 20px;
-  text-align: center;
+    padding: 20px;
+    text-align: center;
 }
 
 .meter-container {
-  gap: 0.5em;
-  display: flex;
+    gap: 0.5em;
+    display: flex;
 }
 
 .meter {
-  flex-grow: 1;
-  box-sizing: content-box;
-  height: 15px; /* Can be anything */
-  position: relative;
-  background: #c0c0c0;
-  border-radius: 25px;
-  margin-bottom: 10px;
-  overflow: hidden;
+    flex-grow: 1;
+    box-sizing: content-box;
+    height: 15px; /* Can be anything */
+    position: relative;
+    background: #c0c0c0;
+    border-radius: 25px;
+    margin-bottom: 10px;
+    overflow: hidden;
 }
 
 .meter > span {
-  display: block;
-  height: 100%;
-  float: left;
-  background-color: #175a6a;
-  border-radius: 25px;
-  position: relative;
+    display: block;
+    height: 100%;
+    float: left;
+    background-color: #175a6a;
+    border-radius: 25px;
+    position: relative;
 }
 
 .meter-container > b {
-  position: relative;
-  bottom: 2px;
+    position: relative;
+    bottom: 2px;
 }
 
 .button {
-  border: none;
-  padding: 10px 20px;
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 14px;
-  font-weight: bold;
-  cursor: pointer;
-  border-radius: 3px;
-  border: 3px solid #175a6a;
+    border: none;
+    padding: 10px 20px;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    cursor: pointer;
+    border-radius: 3px;
+    border: 3px solid #175a6a;
 }
 
 #view-report-button {
-  color: white;
-  background-color: #175a6a;
-  margin-right: 6px;
+    color: white;
+    background-color: #175a6a;
+    margin-right: 6px;
 }
 #view-report-button:hover {
-  background-color: #024e5c;
-  border-color: #024e5c;
+    background-color: #024e5c;
+    border-color: #024e5c;
 }
 #view-report-button:focus-visible {
-  margin-left: 4px;
-  padding: 0 8px 0 12px;
+    margin-left: 4px;
+    padding: 0 8px 0 12px;
 }
 #embed-button {
-  color: #175a6a;
-  background-color: white;
-  margin-left: 4px;
+    color: #175a6a;
+    background-color: white;
+    margin-left: 4px;
 }
 #embed-button:hover {
-  background-color: #f4f4f4;
+    background-color: #f4f4f4;
 }
 
 #view-report-button,
 #embed-button {
-  margin-bottom: 1em;
-  padding: 0 12px;
-  line-height: 36px;
+    margin-bottom: 1em;
+    padding: 0 12px;
+    line-height: 36px;
 }
 #view-report-button:focus-visible,
 #embed-button:focus-visible {
-  outline-offset: 2px;
-  outline: 2px solid #3a86d1;
+    outline-offset: 2px;
+    outline: 2px solid #3a86d1;
 }
 #view-report-button svg,
 #embed-button svg {
-  width: 24px;
-  margin-right: 8px;
-  float: left;
-  position: relative;
-  top: 6px;
+    width: 24px;
+    margin-right: 8px;
+    float: left;
+    position: relative;
+    top: 6px;
 }
 
 #embed-button-wrap {
-  display: inline-block;
+    display: inline-block;
 }
 
 #copied-message {
-  font-family: Arial, Helvetica, sans-serif;
-  margin: 5px;
-  display: inline-block;
+    font-family: Arial, Helvetica, sans-serif;
+    margin: 5px;
+    display: inline-block;
 }

--- a/server/handlebars/embed/public/style.css
+++ b/server/handlebars/embed/public/style.css
@@ -139,7 +139,13 @@ table tbody tr td {
     text-align: center;
 }
 
+.meter-container {
+    gap: 0.5em;
+    display: flex;
+}
+
 .meter {
+    flex-grow: 1;
     box-sizing: content-box;
     height: 15px; /* Can be anything */
     position: relative;
@@ -156,6 +162,11 @@ table tbody tr td {
     background-color: #175a6a;
     border-radius: 25px;
     position: relative;
+}
+
+.meter-container > b {
+    position: relative;
+    bottom: 2px;
 }
 
 .button {

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -9,7 +9,7 @@
     {{#unless dataEmpty}}
         {{#if (isCandidate phase)}}
         <details id="embed-report-phase-container">
-            <summary id="candidate-title"><span><span>Warning! Unapproved Report</span></span></summary>
+            <summary id="candidate-title"><span>Warning! Unapproved Report</span></summary>
             <div id="candidate-content-container">
                 The information in this report is generated from candidate tests developed and run by the <a href="http://aria-at.w3.org">ARIA-AT Project</a>.
                 Candidate ARIA-AT tests are in review by assistive technology developers and lack consensus regarding:

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -46,7 +46,7 @@
                     {{log latestReports}}
                     {{#each latestReports}}
                         <tr>
-                            <th><b>{{this.at.name}} / {{this.browser.name}}</b></th>
+                            <th><b>{{this.at.name}}</b> <span style="font-weight: normal;">{{this.latestAtVersionReleasedAt.name}}</span> - <b>{{this.browser.name}}</b></th>
                             {{!-- {{#if (isApplicable this.metrics.mustFormatted)}} --}}
                             {{#if this.metrics.mustFormatted}}
                            <td>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -45,9 +45,9 @@
             >
                 <thead>
                     <tr>
-                        <th>Assistive Technology / Browser</th>
-                        <th>Must Have Behaviors</th>
-                        <th>Should Have Behaviors</th>
+                        <th>Assistive Technology - Browser</th>
+                        <th>Must-Have Behaviors</th>
+                        <th>Should-Have Behaviors</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -37,13 +37,12 @@
                 <thead>
                     <tr>
                         <td></td>
-                        {{#each priorities}}
-                        <th>{{this}}</th>
-                        {{/each}}
+                        <th>MUST HAVE Behaviors</th>
+                        <th>SHOULD HAVE Behaviors</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {{#each latestReports}}
+                    {{#each testPlanReports}}
                         <tr>
                             <th><b>{{this.at.name}}</b> <span style="font-weight: normal;">{{this.latestAtVersionReleasedAt.name}}</span> - <b>{{this.browser.name}}</b></th>
                             {{#if (isMustAssertionPriority this)}}

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -37,78 +37,35 @@
                 <thead>
                     <tr>
                         <td></td>
-                        {{#each allBrowsers}}
+                        {{#each priorities}}
                         <th>{{this}}</th>
                         {{/each}}
                     </tr>
                 </thead>
                 <tbody>
-                    {{#each reportsByAt}}
+                    {{#each latestReports}}
                         <tr>
-                            <th><b>{{@key}}</b> <span id="at-version">{{getAtVersion @../this @key}}</span></th>
-                            {{#each this}}
-                                {{#if (isBrowser "Chrome" this.browser.name)}}
-                                    {{#if (isInAllBrowsers "Chrome" @../../this) }}
-                                            <td>
-                                                <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
+                            <th><b>{{this.at.name}}</b> <span style="font-weight: normal;">{{this.latestAtVersionReleasedAt.name}}</span> - <b>{{this.browser.name}}</b></th>
+                            {{#if (isMustAssertionPriority this)}}
+                           <td>
+                               <div class="meter" aria-hidden="true">
+                                                    <span style="width: {{getMustSupportData this}}%;"></span>
                                                 </div>
-                                                <b>{{this.metrics.supportPercent}}%</b> supported
-                                            </td>
-                                    {{/if}}
-                                {{else}}
-                                    {{#if (isInAllBrowsers "Chrome" @../../this) }}
-                                        {{#unless (elementExists @../../this @../this this.at.name "Chrome" @last)}}
-                                            {{#if (combinationExists @../../this this.at.name "Chrome")}}
-                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
-                                            {{else}}
-                                                <td><span class="no-data-cell">Not Applicable</span></td>
-                                            {{/if}}
-                                        {{/unless}}
-                                    {{/if}}
-                                {{/if}}
-                                {{#if (isBrowser "Firefox" this.browser.name)}}
-                                    {{#if (isInAllBrowsers "Firefox" @../../this) }}
-                                            <td>
-                                                <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
+                                                <b>{{getMustSupportData this}}%</b> supported
+                            </td>
+                            {{else}}
+                                <td><span class="no-data-cell">Not Applicable</span></td>
+                            {{/if}}
+                            {{#if (isShouldAssertionPriority this)}}
+                           <td>
+                               <div class="meter" aria-hidden="true">
+                                                    <span style="width: {{getShouldSupportData this}}%;"></span>
                                                 </div>
-                                                <b>{{this.metrics.supportPercent}}%</b> supported
-                                            </td>
-                                    {{/if}}
-                                {{else}}
-                                    {{#if (isInAllBrowsers "Firefox" @../../this) }}
-                                        {{#unless (elementExists @../../this @../this this.at.name "Firefox" @last)}}
-                                            {{#if (combinationExists @../../this this.at.name "Firefox")}}
-                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
-                                            {{else}}
-                                                <td><span class="no-data-cell">Not Applicable</span></td>
-                                            {{/if}}
-                                        {{/unless}}
-                                    {{/if}}
-                                {{/if}}
-                                {{#if (isBrowser "Safari" this.browser.name)}}
-                                    {{#if (isInAllBrowsers "Safari" @../../this) }}
-                                            <td>
-                                                <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
-                                                </div>
-                                                <b>{{this.metrics.supportPercent}}%</b> supported
-                                            </td>
-                                    {{/if}}
-                                {{else}}
-                                    {{#if (isInAllBrowsers "Safari" @../../this) }}
-                                        {{#unless (elementExists @../../this @../this this.at.name "Safari" @last)}}
-                                            {{#if (combinationExists @../../this this.at.name "Safari")}}
-                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
-                                            {{else}}
-                                                <td><span class="no-data-cell">Not Applicable</span></td>
-                                            {{/if}}
-                                        {{/unless}}
-                                    {{/if}}
-                                {{/if}}
-                            {{/each}}
-                            {{resetMap}}
+                                                <b>{{getShouldSupportData this}}%</b> supported
+                            </td>
+                            {{else}}
+                                <td><span class="no-data-cell">Not Applicable</span></td>
+                            {{/if}}
                         </tr>
                     {{/each}}
                 </tbody>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -47,8 +47,7 @@
                     {{#each latestReports}}
                         <tr>
                             <th><b>{{this.at.name}}</b> <span style="font-weight: normal;">{{this.latestAtVersionReleasedAt.name}}</span> - <b>{{this.browser.name}}</b></th>
-                            {{!-- {{#if (isApplicable this.metrics.mustFormatted)}} --}}
-                            {{#if this.metrics.mustFormatted}}
+                            {{#if (isMustAssertionPriority this)}}
                            <td>
                                <div class="meter" aria-hidden="true">
                                                     <span style="width: {{getMustSupportData this}}%;"></span>
@@ -58,7 +57,7 @@
                             {{else}}
                                 <td><span class="no-data-cell">Not Applicable</span></td>
                             {{/if}}
-                            {{#if this.metrics.shouldFormatted}}
+                            {{#if (isShouldAssertionPriority this)}}
                            <td>
                                <div class="meter" aria-hidden="true">
                                                     <span style="width: {{getShouldSupportData this}}%;"></span>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -53,12 +53,22 @@
                 <tbody>
                     {{#each testPlanReports}}
                         <tr>
-                            <th><b>{{this.at.name}}</b>
-                                <span
-                                    style='font-weight: normal;'
-                                >{{this.latestAtVersionReleasedAt.name}}</span>
-                                -
-                                <b>{{this.browser.name}}</b></th>
+                            <th>
+                                <a
+                                    href="{{../protocol}}{{../host}}/report/{{../testPlanVersionId}}/targets/{{this.id}}" 
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    <b>{{this.at.name}}</b>
+                                    <span
+                                        style='font-weight: normal;'
+                                    >
+                                        {{this.latestAtVersionReleasedAt.name}}
+                                    </span>
+                                    -
+                                    <b>{{this.browser.name}}</b>
+                                </a>
+                            </th>
                             {{#if (isMustAssertionPriority this)}}
                                 <td>
                                     <div class='meter-container'>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -43,7 +43,8 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {{#each reportsByAt}}
+                    {{!-- {{#each reportsByAt}}
+                    {{log this}}
                         <tr>
                             <th><b>{{@key}}</b> <span id="at-version">{{getAtVersion @../this @key}}</span></th>
                             {{#each this}}
@@ -110,6 +111,13 @@
                             {{/each}}
                             {{resetMap}}
                         </tr>
+                    {{/each}} --}}
+                    
+                    {{#each reportsByAt}}
+                    
+                    <tr>
+                        <th><b>{{@key}}</b>
+                    </tr>
                     {{/each}}
                 </tbody>
             </table>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -9,7 +9,7 @@
     {{#unless dataEmpty}}
         {{#if (isCandidate phase)}}
         <details id="embed-report-phase-container">
-            <summary id="candidate-title"><span>Warning! Unapproved Report</span></summary>
+            <summary id="candidate-title"><span><span>Warning! Unapproved Report</span></span></summary>
             <div id="candidate-content-container">
                 The information in this report is generated from candidate tests developed and run by the <a href="http://aria-at.w3.org">ARIA-AT Project</a>.
                 Candidate ARIA-AT tests are in review by assistive technology developers and lack consensus regarding:
@@ -37,36 +37,78 @@
                 <thead>
                     <tr>
                         <td></td>
-                        {{#each priorities}}
+                        {{#each allBrowsers}}
                         <th>{{this}}</th>
                         {{/each}}
                     </tr>
                 </thead>
                 <tbody>
-                    {{log latestReports}}
-                    {{#each latestReports}}
+                    {{#each reportsByAt}}
                         <tr>
-                            <th><b>{{this.at.name}}</b> <span style="font-weight: normal;">{{this.latestAtVersionReleasedAt.name}}</span> - <b>{{this.browser.name}}</b></th>
-                            {{#if (isMustAssertionPriority this)}}
-                           <td>
-                               <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{getMustSupportData this}}%;"></span>
+                            <th><b>{{@key}}</b> <span id="at-version">{{getAtVersion @../this @key}}</span></th>
+                            {{#each this}}
+                                {{#if (isBrowser "Chrome" this.browser.name)}}
+                                    {{#if (isInAllBrowsers "Chrome" @../../this) }}
+                                            <td>
+                                                <div class="meter" aria-hidden="true">
+                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
                                                 </div>
-                                                <b>{{getMustSupportData this}}%</b> supported
-                            </td>
-                            {{else}}
-                                <td><span class="no-data-cell">Not Applicable</span></td>
-                            {{/if}}
-                            {{#if (isShouldAssertionPriority this)}}
-                           <td>
-                               <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{getShouldSupportData this}}%;"></span>
+                                                <b>{{this.metrics.supportPercent}}%</b> supported
+                                            </td>
+                                    {{/if}}
+                                {{else}}
+                                    {{#if (isInAllBrowsers "Chrome" @../../this) }}
+                                        {{#unless (elementExists @../../this @../this this.at.name "Chrome" @last)}}
+                                            {{#if (combinationExists @../../this this.at.name "Chrome")}}
+                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
+                                            {{else}}
+                                                <td><span class="no-data-cell">Not Applicable</span></td>
+                                            {{/if}}
+                                        {{/unless}}
+                                    {{/if}}
+                                {{/if}}
+                                {{#if (isBrowser "Firefox" this.browser.name)}}
+                                    {{#if (isInAllBrowsers "Firefox" @../../this) }}
+                                            <td>
+                                                <div class="meter" aria-hidden="true">
+                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
                                                 </div>
-                                                <b>{{getShouldSupportData this}}%</b> supported
-                            </td>
-                            {{else}}
-                                <td><span class="no-data-cell">Not Applicable</span></td>
-                            {{/if}}
+                                                <b>{{this.metrics.supportPercent}}%</b> supported
+                                            </td>
+                                    {{/if}}
+                                {{else}}
+                                    {{#if (isInAllBrowsers "Firefox" @../../this) }}
+                                        {{#unless (elementExists @../../this @../this this.at.name "Firefox" @last)}}
+                                            {{#if (combinationExists @../../this this.at.name "Firefox")}}
+                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
+                                            {{else}}
+                                                <td><span class="no-data-cell">Not Applicable</span></td>
+                                            {{/if}}
+                                        {{/unless}}
+                                    {{/if}}
+                                {{/if}}
+                                {{#if (isBrowser "Safari" this.browser.name)}}
+                                    {{#if (isInAllBrowsers "Safari" @../../this) }}
+                                            <td>
+                                                <div class="meter" aria-hidden="true">
+                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
+                                                </div>
+                                                <b>{{this.metrics.supportPercent}}%</b> supported
+                                            </td>
+                                    {{/if}}
+                                {{else}}
+                                    {{#if (isInAllBrowsers "Safari" @../../this) }}
+                                        {{#unless (elementExists @../../this @../this this.at.name "Safari" @last)}}
+                                            {{#if (combinationExists @../../this this.at.name "Safari")}}
+                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
+                                            {{else}}
+                                                <td><span class="no-data-cell">Not Applicable</span></td>
+                                            {{/if}}
+                                        {{/unless}}
+                                    {{/if}}
+                                {{/if}}
+                            {{/each}}
+                            {{resetMap}}
                         </tr>
                     {{/each}}
                 </tbody>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -1,69 +1,95 @@
-<div id="main">
+<div id='main'>
     {{#if dataEmpty}}
-        <div id="no-data-container">
-            <div id="no-data-content-container">
-                 There is no data for this pattern.
+        <div id='no-data-container'>
+            <div id='no-data-content-container'>
+                There is no data for this pattern.
             </div>
         </div>
     {{/if}}
     {{#unless dataEmpty}}
         {{#if (isCandidate phase)}}
-        <details id="embed-report-phase-container">
-            <summary id="candidate-title"><span>Warning! Unapproved Report</span></summary>
-            <div id="candidate-content-container">
-                The information in this report is generated from candidate tests developed and run by the <a href="http://aria-at.w3.org">ARIA-AT Project</a>.
-                Candidate ARIA-AT tests are in review by assistive technology developers and lack consensus regarding:
-                <ol>
-                    <li>applicability and validity of the tests, and</li>
-                    <li>accuracy of test results.</li>
-                </ol>
-            </div>
-        </details>
+            <details id='embed-report-phase-container'>
+                <summary id='candidate-title'><span>Warning! Unapproved Report</span></summary>
+                <div id='candidate-content-container'>
+                    The information in this report is generated from candidate
+                    tests developed and run by the
+                    <a href='http://aria-at.w3.org'>ARIA-AT Project</a>.
+                    Candidate ARIA-AT tests are in review by assistive
+                    technology developers and lack consensus regarding:
+                    <ol>
+                        <li>applicability and validity of the tests, and</li>
+                        <li>accuracy of test results.</li>
+                    </ol>
+                </div>
+            </details>
         {{else}}
-        <details id="embed-report-phase-container">
-            <summary id="candidate-title" class="recommended"><span>Recommended Report</span></summary>
-            <div id="candidate-content-container">
-                The information in this report is generated from recommended tests.
-                Recommended ARIA-AT tests have been reviewed by assistive technology developers and represent consensus regarding:
-                <ol>
-                    <li>applicability and validity of the tests, and</li>
-                    <li>accuracy of test results.</li>
-                </ol>
-            </div>
-        </details>
+            <details id='embed-report-phase-container'>
+                <summary id='candidate-title' class='recommended'><span
+                    >Recommended Report</span></summary>
+                <div id='candidate-content-container'>
+                    The information in this report is generated from recommended
+                    tests. Recommended ARIA-AT tests have been reviewed by
+                    assistive technology developers and represent consensus
+                    regarding:
+                    <ol>
+                        <li>applicability and validity of the tests, and</li>
+                        <li>accuracy of test results.</li>
+                    </ol>
+                </div>
+            </details>
         {{/if}}
-        <div class="responsive-table">
-            <table id="embed-report-table" aria-label="Assistive Technology Support for {{title}}">
+        <div class='responsive-table'>
+            <table
+                id='embed-report-table'
+                aria-label='Assistive Technology Support for {{title}}'
+            >
                 <thead>
                     <tr>
-                        <td></td>
-                        <th>MUST HAVE Behaviors</th>
-                        <th>SHOULD HAVE Behaviors</th>
+                        <th>Assistive Technology / Browser</th>
+                        <th>Must Have Behaviors</th>
+                        <th>Should Have Behaviors</th>
                     </tr>
                 </thead>
                 <tbody>
                     {{#each testPlanReports}}
                         <tr>
-                            <th><b>{{this.at.name}}</b> <span style="font-weight: normal;">{{this.latestAtVersionReleasedAt.name}}</span> - <b>{{this.browser.name}}</b></th>
+                            <th><b>{{this.at.name}}</b>
+                                <span
+                                    style='font-weight: normal;'
+                                >{{this.latestAtVersionReleasedAt.name}}</span>
+                                -
+                                <b>{{this.browser.name}}</b></th>
                             {{#if (isMustAssertionPriority this)}}
-                           <td>
-                               <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{getMustSupportData this}}%;"></span>
-                                                </div>
-                                                <b>{{getMustSupportData this}}%</b> supported
-                            </td>
+                                <td>
+                                    <div class='meter-container'>
+                                        <div class='meter' aria-hidden='true'>
+                                            <span
+                                                style='width: {{getMustSupportData
+                                                    this
+                                                }}%;'
+                                            ></span>
+                                        </div>
+                                        <b>{{getMustSupportData this}}%</b>
+                                    </div>
+                                </td>
                             {{else}}
-                                <td><span class="no-data-cell">Not Applicable</span></td>
+                                <td><span class='no-data-cell'>Not Applicable</span></td>
                             {{/if}}
                             {{#if (isShouldAssertionPriority this)}}
-                           <td>
-                               <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{getShouldSupportData this}}%;"></span>
-                                                </div>
-                                                <b>{{getShouldSupportData this}}%</b> supported
-                            </td>
+                                <td>
+                                    <div class='meter-container'>
+                                        <div class='meter' aria-hidden='true'>
+                                            <span
+                                                style='width: {{getShouldSupportData
+                                                    this
+                                                }}%;'
+                                            ></span>
+                                        </div>
+                                        <b>{{getShouldSupportData this}}%</b>
+                                    </div>
+                                </td>
                             {{else}}
-                                <td><span class="no-data-cell">Not Applicable</span></td>
+                                <td><span class='no-data-cell'>Not Applicable</span></td>
                             {{/if}}
                         </tr>
                     {{/each}}
@@ -71,17 +97,40 @@
             </table>
         </div>
 
-        <div id="button-row">
-            <button id="view-report-button" class="button" onclick="window.open('{{completeReportLink}}', '_blank')" aria-label="View Complete Report in New Window">
-                <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="white" d="M22,12v9a1,1,0,0,1-1,1H3a1,1,0,0,1-1-1V3A1,1,0,0,1,3,2h9a1,1,0,0,1,0,2H4V20H20V12a1,1,0,0,1,2,0Zm-.618-9.923A.991.991,0,0,0,21,2H16a1,1,0,0,0,0,2h2.586l-7.293,7.293a1,1,0,1,0,1.414,1.414L20,5.414V8a1,1,0,0,0,2,0V3a1.01,1.01,0,0,0-.077-.382A1,1,0,0,0,21.382,2.077Z"/></svg>
+        <div id='button-row'>
+            <button
+                id='view-report-button'
+                class='button'
+                onclick="window.open('{{completeReportLink}}', '_blank')"
+                aria-label='View Complete Report in New Window'
+            >
+                <svg
+                    aria-hidden='true'
+                    xmlns='http://www.w3.org/2000/svg'
+                    viewBox='0 0 24 24'
+                ><path
+                        fill='white'
+                        d='M22,12v9a1,1,0,0,1-1,1H3a1,1,0,0,1-1-1V3A1,1,0,0,1,3,2h9a1,1,0,0,1,0,2H4V20H20V12a1,1,0,0,1,2,0Zm-.618-9.923A.991.991,0,0,0,21,2H16a1,1,0,0,0,0,2h2.586l-7.293,7.293a1,1,0,1,0,1.414,1.414L20,5.414V8a1,1,0,0,0,2,0V3a1.01,1.01,0,0,0-.077-.382A1,1,0,0,0,21.382,2.077Z'
+                    /></svg>
                 View Complete Report
             </button>
-            <div id="embed-button-wrap">
-                <button id="embed-button" class="button" onclick="announceCopied('{{embedLink}}')">
-                    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#175a6a" d="M1.293,11.293l4-4A1,1,0,1,1,6.707,8.707L3.414,12l3.293,3.293a1,1,0,1,1-1.414,1.414l-4-4A1,1,0,0,1,1.293,11.293Zm17.414-4a1,1,0,1,0-1.414,1.414L20.586,12l-3.293,3.293a1,1,0,1,0,1.414,1.414l4-4a1,1,0,0,0,0-1.414ZM13.039,4.726l-4,14a1,1,0,0,0,.686,1.236A1.053,1.053,0,0,0,10,20a1,1,0,0,0,.961-.726l4-14a1,1,0,1,0-1.922-.548Z"/></svg>
+            <div id='embed-button-wrap'>
+                <button
+                    id='embed-button'
+                    class='button'
+                    onclick="announceCopied('{{embedLink}}')"
+                >
+                    <svg
+                        aria-hidden='true'
+                        xmlns='http://www.w3.org/2000/svg'
+                        viewBox='0 0 24 24'
+                    ><path
+                            fill='#175a6a'
+                            d='M1.293,11.293l4-4A1,1,0,1,1,6.707,8.707L3.414,12l3.293,3.293a1,1,0,1,1-1.414,1.414l-4-4A1,1,0,0,1,1.293,11.293Zm17.414-4a1,1,0,1,0-1.414,1.414L20.586,12l-3.293,3.293a1,1,0,1,0,1.414,1.414l4-4a1,1,0,0,0,0-1.414ZM13.039,4.726l-4,14a1,1,0,0,0,.686,1.236A1.053,1.053,0,0,0,10,20a1,1,0,0,0,.961-.726l4-14a1,1,0,1,0-1.922-.548Z'
+                        /></svg>
                     Copy Embed Code
                 </button>
-                <div id="copied-message"></div>
+                <div id='copied-message'></div>
             </div>
         </div>
     {{/unless}}

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -8,9 +8,9 @@
     {{/if}}
     {{#unless (dataEmpty testPlanReports)}}
         {{#if (isCandidate phase)}}
-            <details id='embed-report-phase-container'>
-                <summary id='candidate-title'><span>Warning! Unapproved Report</span></summary>
-                <div id='candidate-content-container'>
+            <details>
+                <summary><h4>Warning! Unapproved Report</h4></summary>
+                <div class='content-container'>
                     The information in this report is generated from candidate
                     tests developed and run by the
                     <a href='http://aria-at.w3.org'>ARIA-AT Project</a>.
@@ -23,20 +23,17 @@
                 </div>
             </details>
         {{else}}
-            <details id='embed-report-phase-container'>
-                <summary id='candidate-title' class='recommended'><span
-                    >Recommended Report</span></summary>
-                <div id='candidate-content-container'>
-                    The information in this report is generated from recommended
-                    tests. Recommended ARIA-AT tests have been reviewed by
-                    assistive technology developers and represent consensus
-                    regarding:
-                    <ol>
-                        <li>applicability and validity of the tests, and</li>
-                        <li>accuracy of test results.</li>
-                    </ol>
-                </div>
-            </details>
+            <details>
+            <summary class="recommended"><h4>Recommended Report</h4></summary>
+            <div class="content-container recommended">
+                The information in this report is generated from recommended tests.
+                Recommended ARIA-AT tests have been reviewed by assistive technology developers and represent consensus regarding:
+                <ol>
+                    <li>applicability and validity of the tests, and</li>
+                    <li>accuracy of test results.</li>
+                </ol>
+            </div>
+        </details>
         {{/if}}
         <div class='responsive-table'>
             <table

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -1,12 +1,13 @@
 <div id='main'>
-    {{#if dataEmpty}}
+    {{!-- {{log testPlanReports}} --}}
+    {{#if (dataEmpty testPlanReports)}}
         <div id='no-data-container'>
             <div id='no-data-content-container'>
                 There is no data for this pattern.
             </div>
         </div>
     {{/if}}
-    {{#unless dataEmpty}}
+    {{#unless (dataEmpty testPlanReports)}}
         {{#if (isCandidate phase)}}
             <details id='embed-report-phase-container'>
                 <summary id='candidate-title'><span>Warning! Unapproved Report</span></summary>

--- a/server/handlebars/embed/views/main.hbs
+++ b/server/handlebars/embed/views/main.hbs
@@ -37,87 +37,38 @@
                 <thead>
                     <tr>
                         <td></td>
-                        {{#each allBrowsers}}
+                        {{#each priorities}}
                         <th>{{this}}</th>
                         {{/each}}
                     </tr>
                 </thead>
                 <tbody>
-                    {{!-- {{#each reportsByAt}}
-                    {{log this}}
+                    {{log latestReports}}
+                    {{#each latestReports}}
                         <tr>
-                            <th><b>{{@key}}</b> <span id="at-version">{{getAtVersion @../this @key}}</span></th>
-                            {{#each this}}
-                                {{#if (isBrowser "Chrome" this.browser.name)}}
-                                    {{#if (isInAllBrowsers "Chrome" @../../this) }}
-                                            <td>
-                                                <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
+                            <th><b>{{this.at.name}} / {{this.browser.name}}</b></th>
+                            {{!-- {{#if (isApplicable this.metrics.mustFormatted)}} --}}
+                            {{#if this.metrics.mustFormatted}}
+                           <td>
+                               <div class="meter" aria-hidden="true">
+                                                    <span style="width: {{getMustSupportData this}}%;"></span>
                                                 </div>
-                                                <b>{{this.metrics.supportPercent}}%</b> supported
-                                            </td>
-                                    {{/if}}
-                                {{else}}
-                                    {{#if (isInAllBrowsers "Chrome" @../../this) }}
-                                        {{#unless (elementExists @../../this @../this this.at.name "Chrome" @last)}}
-                                            {{#if (combinationExists @../../this this.at.name "Chrome")}}
-                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
-                                            {{else}}
-                                                <td><span class="no-data-cell">Not Applicable</span></td>
-                                            {{/if}}
-                                        {{/unless}}
-                                    {{/if}}
-                                {{/if}}
-                                {{#if (isBrowser "Firefox" this.browser.name)}}
-                                    {{#if (isInAllBrowsers "Firefox" @../../this) }}
-                                            <td>
-                                                <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
+                                                <b>{{getMustSupportData this}}%</b> supported
+                            </td>
+                            {{else}}
+                                <td><span class="no-data-cell">Not Applicable</span></td>
+                            {{/if}}
+                            {{#if this.metrics.shouldFormatted}}
+                           <td>
+                               <div class="meter" aria-hidden="true">
+                                                    <span style="width: {{getShouldSupportData this}}%;"></span>
                                                 </div>
-                                                <b>{{this.metrics.supportPercent}}%</b> supported
-                                            </td>
-                                    {{/if}}
-                                {{else}}
-                                    {{#if (isInAllBrowsers "Firefox" @../../this) }}
-                                        {{#unless (elementExists @../../this @../this this.at.name "Firefox" @last)}}
-                                            {{#if (combinationExists @../../this this.at.name "Firefox")}}
-                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
-                                            {{else}}
-                                                <td><span class="no-data-cell">Not Applicable</span></td>
-                                            {{/if}}
-                                        {{/unless}}
-                                    {{/if}}
-                                {{/if}}
-                                {{#if (isBrowser "Safari" this.browser.name)}}
-                                    {{#if (isInAllBrowsers "Safari" @../../this) }}
-                                            <td>
-                                                <div class="meter" aria-hidden="true">
-                                                    <span style="width: {{this.metrics.supportPercent}}%;"></span>
-                                                </div>
-                                                <b>{{this.metrics.supportPercent}}%</b> supported
-                                            </td>
-                                    {{/if}}
-                                {{else}}
-                                    {{#if (isInAllBrowsers "Safari" @../../this) }}
-                                        {{#unless (elementExists @../../this @../this this.at.name "Safari" @last)}}
-                                            {{#if (combinationExists @../../this this.at.name "Safari")}}
-                                                <td><span class="no-data-cell">Data Not Yet Available</span></td>
-                                            {{else}}
-                                                <td><span class="no-data-cell">Not Applicable</span></td>
-                                            {{/if}}
-                                        {{/unless}}
-                                    {{/if}}
-                                {{/if}}
-                            {{/each}}
-                            {{resetMap}}
+                                                <b>{{getShouldSupportData this}}%</b> supported
+                            </td>
+                            {{else}}
+                                <td><span class="no-data-cell">Not Applicable</span></td>
+                            {{/if}}
                         </tr>
-                    {{/each}} --}}
-                    
-                    {{#each reportsByAt}}
-                    
-                    <tr>
-                        <th><b>{{@key}}</b>
-                    </tr>
                     {{/each}}
                 </tbody>
             </table>

--- a/server/resolvers/testPlanResolver.js
+++ b/server/resolvers/testPlanResolver.js
@@ -1,14 +1,17 @@
 const { getTestPlans } = require('../models/services/TestPlanService');
 
 const testPlanResolver = async (_, { id }, context) => {
+    // console.log(1)
     const { transaction } = context;
-
+    // console.log(2)
     const testPlans = await getTestPlans({
         where: { directory: id },
         includeLatestTestPlanVersion: true,
         transaction
     });
-    return testPlans[0].dataValues;
+    // console.log(3)
+    // console.log("testPlan Value", testPlans[0].dataValues)
+    return testPlans[0]?.dataValues;
 };
 
 module.exports = testPlanResolver;

--- a/server/resolvers/testPlanResolver.js
+++ b/server/resolvers/testPlanResolver.js
@@ -1,16 +1,12 @@
 const { getTestPlans } = require('../models/services/TestPlanService');
 
 const testPlanResolver = async (_, { id }, context) => {
-    // console.log(1)
     const { transaction } = context;
-    // console.log(2)
     const testPlans = await getTestPlans({
         where: { directory: id },
         includeLatestTestPlanVersion: true,
         transaction
     });
-    // console.log(3)
-    // console.log("testPlan Value", testPlans[0].dataValues)
     return testPlans[0]?.dataValues;
 };
 

--- a/server/resources/ats.json
+++ b/server/resources/ats.json
@@ -6,8 +6,9 @@
         "defaultConfigurationInstructionsHTML": "Configure JAWS with default settings. For help, read &lt;a href=&quot;https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing&quot;&gt;Configuring Screen Readers for Testing&lt;/a&gt;.",
         "assertionTokens": {
             "screenReader": "JAWS",
+            "interactionMode": "PC cursor active",
             "readingMode": "virtual cursor active",
-            "interactionMode": "PC cursor active"
+            "readingCursor": "virtual cursor"
         },
         "settings": {
             "virtualCursor": {
@@ -33,8 +34,9 @@
         "defaultConfigurationInstructionsHTML": "Configure NVDA with default settings. For help, read &lt;a href=&quot;https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing&quot;&gt;Configuring Screen Readers for Testing&lt;/a&gt;.",
         "assertionTokens": {
             "screenReader": "NVDA",
+            "interactionMode": "focus mode",
             "readingMode": "browse mode",
-            "interactionMode": "focus mode"
+            "readingCursor": "browse mode caret"
         },
         "settings": {
             "browseMode": {
@@ -58,6 +60,10 @@
         "name": "VoiceOver for macOS",
         "key": "voiceover_macos",
         "defaultConfigurationInstructionsHTML": "Configure VoiceOver with default settings. For help, read &lt;a href=&quot;https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing&quot;&gt;Configuring Screen Readers for Testing&lt;/a&gt;.",
+        "assertionTokens": {
+            "screenReader": "VoiceOver",
+            "readingCursor": "VoiceOver cursor"
+        },
         "settings": {
             "quickNavOn": {
                 "screenText": "quick nav on",

--- a/server/tests/integration/embed.test.js
+++ b/server/tests/integration/embed.test.js
@@ -60,7 +60,7 @@ describe('embed', () => {
         const copyEmbedButtonOnClick = copyEmbedButton.getAttribute('onclick');
         const table = document.querySelector('table');
         const cellWithData = Array.from(table.querySelectorAll('td')).find(td =>
-            td.innerHTML.match(/<b>\s*\d+%\s*<\/b>\s*supported/)
+            td.innerHTML.match(/<b>\s*\d+%\s*<\/b>/)
         );
 
         expect(res.text).toEqual(res2.text);

--- a/server/tests/integration/embed.test.js
+++ b/server/tests/integration/embed.test.js
@@ -44,11 +44,6 @@ describe('embed', () => {
 
         const nonWarning = screen.queryByText('Recommended Report');
         const warning = screen.queryByText('Warning! Unapproved Report');
-        const unsupportedAtBrowserCombination =
-            screen.queryAllByText('Not Applicable');
-        const futureSupportedAtBrowserCombination = screen.queryAllByText(
-            'Data Not Yet Available'
-        );
 
         const nonWarningContents = screen.queryByText(
             'The information in this report is generated from candidate tests',
@@ -73,8 +68,6 @@ describe('embed', () => {
         expect(initialLoadTime / 10).toBeGreaterThan(cachedTime);
         expect(nonWarning || warning).toBeTruthy();
         expect(nonWarningContents || warningContents).toBeTruthy();
-        expect(unsupportedAtBrowserCombination.length).not.toBe(0);
-        expect(futureSupportedAtBrowserCombination.length).not.toBe(0);
         expect(viewReportButton).toBeTruthy();
         expect(viewReportButtonOnClick).toMatch(
             // Onclick should be like the following:


### PR DESCRIPTION
see issue #https://github.com/w3c/aria-practices/issues/2971

This pull request changes the structure of the support tables. The rows are now AT and browser combinations and the columns are now "MUST" and "SHOULD" assertions. The support percentage now represents the degree of support for "MUST" assertions and "SHOULD" assertions.