### PR TITLE
Use assertion phrase in test result table

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/queries.js
+++ b/client/components/CandidateReview/CandidateTestPlanRun/queries.js
@@ -112,24 +112,28 @@ export const CANDIDATE_REPORTS_QUERY = gql`
                         id
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }
                     mustAssertionResults: assertionResults(priority: MUST) {
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }
                     shouldAssertionResults: assertionResults(priority: SHOULD) {
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }
                     mayAssertionResults: assertionResults(priority: MAY) {
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }

--- a/client/components/Reports/queries.js
+++ b/client/components/Reports/queries.js
@@ -78,12 +78,14 @@ export const REPORT_PAGE_QUERY = gql`
                             id
                             assertion {
                                 text
+                                phrase
                             }
                             passed
                         }
                         mustAssertionResults: assertionResults(priority: MUST) {
                             assertion {
                                 text
+                                phrase
                             }
                             passed
                         }
@@ -92,12 +94,14 @@ export const REPORT_PAGE_QUERY = gql`
                         ) {
                             assertion {
                                 text
+                                phrase
                             }
                             passed
                         }
                         mayAssertionResults: assertionResults(priority: MAY) {
                             assertion {
                                 text
+                                phrase
                             }
                             passed
                         }

--- a/client/components/TestRun/queries.js
+++ b/client/components/TestRun/queries.js
@@ -204,7 +204,6 @@ export const TEST_RUN_PAGE_ANON_QUERY = gql`
                         id
                         text
                         phrase
-                        phrase
                     }
                 }
                 conflictingResults {
@@ -784,7 +783,6 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                             assertion {
                                 id
                                 text
-                                phrase
                                 phrase
                             }
                         }

--- a/client/components/TestRun/queries.js
+++ b/client/components/TestRun/queries.js
@@ -33,24 +33,28 @@ export const TEST_RUN_PAGE_QUERY = gql`
                         id
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }
                     mustAssertionResults: assertionResults(priority: MUST) {
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }
                     shouldAssertionResults: assertionResults(priority: SHOULD) {
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }
                     mayAssertionResults: assertionResults(priority: MAY) {
                         assertion {
                             text
+                            phrase
                         }
                         passed
                     }
@@ -88,6 +92,7 @@ export const TEST_RUN_PAGE_QUERY = gql`
                         assertion {
                             id
                             text
+                            phrase
                         }
                     }
                     conflictingResults {
@@ -198,6 +203,8 @@ export const TEST_RUN_PAGE_ANON_QUERY = gql`
                     assertion {
                         id
                         text
+                        phrase
+                        phrase
                     }
                 }
                 conflictingResults {
@@ -323,6 +330,7 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                                 id
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -331,6 +339,7 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -339,6 +348,7 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -347,6 +357,7 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -384,6 +395,7 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                                 assertion {
                                     id
                                     text
+                                    phrase
                                 }
                             }
                             conflictingResults {
@@ -480,6 +492,7 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                             assertion {
                                 id
                                 text
+                                phrase
                             }
                         }
                         conflictingResults {
@@ -609,6 +622,7 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                                 id
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -617,6 +631,7 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -625,6 +640,7 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -633,6 +649,7 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -670,6 +687,7 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                                 assertion {
                                     id
                                     text
+                                    phrase
                                 }
                             }
                             conflictingResults {
@@ -766,6 +784,8 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                             assertion {
                                 id
                                 text
+                                phrase
+                                phrase
                             }
                         }
                         conflictingResults {
@@ -895,6 +915,7 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                                 id
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -903,6 +924,7 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -911,6 +933,7 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -919,6 +942,7 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                             ) {
                                 assertion {
                                     text
+                                    phrase
                                 }
                                 passed
                             }
@@ -956,6 +980,7 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                                 assertion {
                                     id
                                     text
+                                    phrase
                                 }
                             }
                             conflictingResults {
@@ -1052,6 +1077,7 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                             assertion {
                                 id
                                 text
+                                phrase
                             }
                         }
                         conflictingResults {

--- a/client/components/common/TestPlanResultsTable/index.jsx
+++ b/client/components/common/TestPlanResultsTable/index.jsx
@@ -10,8 +10,11 @@ const renderAssertionRow = (assertionResult, priorityString) => {
         <tr key={`${assertionResult.id}__${nextId()}`}>
             <td>{priorityString}</td>
             <td>
-                {assertionResult.assertion.phrase ??
-                    assertionResult.assertion.text}
+                {assertionResult.assertion.phrase
+                    ? assertionResult.assertion.phrase.charAt(0).toUpperCase() +
+                      assertionResult.assertion.phrase.slice(1)
+                    : assertionResult.assertion.text.charAt(0).toUpperCase() +
+                      assertionResult.assertion.text.slice(1)}
             </td>
             <td>{assertionResult.passed ? 'Passed' : 'Failed'}</td>
         </tr>

--- a/client/components/common/TestPlanResultsTable/index.jsx
+++ b/client/components/common/TestPlanResultsTable/index.jsx
@@ -9,7 +9,10 @@ const renderAssertionRow = (assertionResult, priorityString) => {
     return (
         <tr key={`${assertionResult.id}__${nextId()}`}>
             <td>{priorityString}</td>
-            <td>{assertionResult.assertion.text}</td>
+            <td>
+                {assertionResult.assertion.phrase ??
+                    assertionResult.assertion.text}
+            </td>
             <td>{assertionResult.passed ? 'Passed' : 'Failed'}</td>
         </tr>
     );

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -565,12 +565,19 @@ const graphqlSchema = gql`
         Whether this assertion contributes to the test failing or not.
         """
         priority: AssertionPriority!
-        # TODO: consider adding a automatedAssertion field which uses regex or
-        # similar to automatically determine pass or fail.
         """
-        A human-readable version of the assertion.
+        A human-readable version of the assertion, like "Role 'radio button' is
+        conveyed".
         """
         text: String!
+        """
+        For TestPlanVersions that use the V2 test format, this field contains
+        text like "convey role 'radio button'".
+
+        See the link for more information:
+        https://github.com/w3c/aria-at/wiki/Test-Format-Definition-V2#assertionphrase
+        """
+        phrase: String
     }
 
     """

--- a/server/models/services/TestsService.js
+++ b/server/models/services/TestsService.js
@@ -50,7 +50,8 @@ const getTests = parentRecord => {
         }),
         assertions: test.assertions.map(assertion => ({
             ...assertion,
-            text: isV2 ? assertion.assertionStatement : assertion.text
+            text: isV2 ? assertion.assertionStatement : assertion.text,
+            phrase: isV2 ? assertion.assertionPhrase : null
         }))
     }));
 };

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -159,7 +159,6 @@ describe('graphql', () => {
             ['Command', 'atOperatingMode'], // TODO: Include when v2 test format CI tests are done
             ['CollectionJob', 'testPlanRun'],
             ['CollectionJob', 'externalLogsUrl'],
-            // ['Assertion', 'phrase'],
             // These interact with Response Scheduler API
             // which is mocked in other tests.
             ['Mutation', 'scheduleCollectionJob'],

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -159,6 +159,7 @@ describe('graphql', () => {
             ['Command', 'atOperatingMode'], // TODO: Include when v2 test format CI tests are done
             ['CollectionJob', 'testPlanRun'],
             ['CollectionJob', 'externalLogsUrl'],
+            ['Assertion', 'phrase'],
             // These interact with Response Scheduler API
             // which is mocked in other tests.
             ['Mutation', 'scheduleCollectionJob'],
@@ -273,6 +274,55 @@ describe('graphql', () => {
                         id
                         status
                     }
+                    # testPlan1: testPlan(id: "command-button") {
+                    #     __typename
+                    #     id
+                    #     directory
+                    #     title
+                    #     latestTestPlanVersion {
+                    #         __typename
+                    #         id
+                    #         title
+                    #         updatedAt
+                    #         gitSha
+                    #         gitMessage
+                    #         updatedAt
+                    #         testPageUrl
+                    #         metadata
+                    #         tests {
+                    #             __typename
+                    #             id
+                    #             rowNumber
+                    #             title
+                    #             ats {
+                    #                 id
+                    #             }
+                    #             scenarios {
+                    #                 __typename
+                    #                 id
+                    #                 at {
+                    #                     id
+                    #                 }
+                    #                 commands {
+                    #                     __typename
+                    #                     id
+                    #                     text
+                    #                     atOperatingMode
+                    #                 }
+                    #             }
+                    #             assertions {
+                    #                 __typename
+                    #                 id
+                    #                 priority
+                    #                 phrase
+                    #             }
+                    #             testFormatVersion
+                    #         }
+                    #     }
+                    #     testPlanVersions {
+                    #         id
+                    #     }
+                    # }
                     testPlan(id: "checkbox") {
                         __typename
                         id
@@ -967,3 +1017,7 @@ const getMutationInputs = async () => {
         browserVersionId: browserVersion.id
     };
 };
+
+/* Add the phrase to the assertion query. It will not work unless phrase is returned.
+Find a test plan version that does have a phrase (V2).
+*/

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -159,7 +159,7 @@ describe('graphql', () => {
             ['Command', 'atOperatingMode'], // TODO: Include when v2 test format CI tests are done
             ['CollectionJob', 'testPlanRun'],
             ['CollectionJob', 'externalLogsUrl'],
-            ['Assertion', 'phrase'],
+            // ['Assertion', 'phrase'],
             // These interact with Response Scheduler API
             // which is mocked in other tests.
             ['Mutation', 'scheduleCollectionJob'],
@@ -274,55 +274,18 @@ describe('graphql', () => {
                         id
                         status
                     }
-                    # testPlan1: testPlan(id: "command-button") {
-                    #     __typename
-                    #     id
-                    #     directory
-                    #     title
-                    #     latestTestPlanVersion {
-                    #         __typename
-                    #         id
-                    #         title
-                    #         updatedAt
-                    #         gitSha
-                    #         gitMessage
-                    #         updatedAt
-                    #         testPageUrl
-                    #         metadata
-                    #         tests {
-                    #             __typename
-                    #             id
-                    #             rowNumber
-                    #             title
-                    #             ats {
-                    #                 id
-                    #             }
-                    #             scenarios {
-                    #                 __typename
-                    #                 id
-                    #                 at {
-                    #                     id
-                    #                 }
-                    #                 commands {
-                    #                     __typename
-                    #                     id
-                    #                     text
-                    #                     atOperatingMode
-                    #                 }
-                    #             }
-                    #             assertions {
-                    #                 __typename
-                    #                 id
-                    #                 priority
-                    #                 phrase
-                    #             }
-                    #             testFormatVersion
-                    #         }
-                    #     }
-                    #     testPlanVersions {
-                    #         id
-                    #     }
-                    # }
+                    v2TestPlanVersion: testPlanVersion(id: 133) {
+                        __typename
+                        id
+                        metadata
+                        tests {
+                            __typename
+                            assertions {
+                                __typename
+                                phrase
+                            }
+                        }
+                    }
                     testPlan(id: "checkbox") {
                         __typename
                         id


### PR DESCRIPTION
see issue #744 

This pull request adds the assertion phrase instead of the assertion statement to the test results table.