### PR TITLE
Assign tester dropdown focus 

### DIFF
--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -115,7 +115,7 @@ const AssignTesterDropdown = ({
     };
     return (
         <LoadingStatus message={loadingMessage}>
-            <Dropdown aria-label="Assign testers menu">
+            <Dropdown focusFirstItemOnShow aria-label="Assign testers menu">
                 <Dropdown.Toggle
                     ref={dropdownAssignTesterButtonRef}
                     aria-label="Assign testers"

--- a/client/components/TestQueueRow/index.jsx
+++ b/client/components/TestQueueRow/index.jsx
@@ -228,7 +228,7 @@ const TestQueueRow = ({
 
     const renderOpenAsDropdown = () => {
         return (
-            <Dropdown className="open-run-as">
+            <Dropdown className="open-run-as" focusFirstItemOnShow>
                 <Dropdown.Toggle
                     id={nextId()}
                     variant="secondary"
@@ -265,7 +265,10 @@ const TestQueueRow = ({
         if (testPlanRunsWithResults.length) {
             return (
                 <>
-                    <Dropdown aria-label="Delete results menu">
+                    <Dropdown
+                        aria-label="Delete results menu"
+                        focusFirstItemOnShow
+                    >
                         <Dropdown.Toggle
                             ref={dropdownDeleteTesterResultsButtonRef}
                             variant="danger"


### PR DESCRIPTION
see issue #992 

This pull request adds focus to the first menu option in the dropdown for assigning a tester on the test queue page.