### PR TITLE
Fix: status for RUNNING tests updates when job status becomes finalized

### DIFF
--- a/server/resolvers/CollectionJobOperations/cancelCollectionJobResolver.js
+++ b/server/resolvers/CollectionJobOperations/cancelCollectionJobResolver.js
@@ -42,6 +42,11 @@ const cancelCollectionJobResolver = async (
             values: { status: COLLECTION_JOB_STATUS.CANCELLED },
             transaction
         });
+        await updateCollectionJobTestStatusByQuery({
+            where: { collectionJobId, status: COLLECTION_JOB_STATUS.RUNNING },
+            values: { status: COLLECTION_JOB_STATUS.CANCELLED },
+            transaction
+        });
         return updateCollectionJobById({
             id: collectionJobId,
             values: { status: COLLECTION_JOB_STATUS.CANCELLED },

--- a/server/tests/integration/automation-scheduler.test.js
+++ b/server/tests/integration/automation-scheduler.test.js
@@ -898,7 +898,7 @@ describe('Automation controller', () => {
             }
             expect(foundStatus).toEqual(true);
 
-            // Leave our test RUNNING but ERROR the job
+            // Leave our test RUNNING but COMPLETED the job
 
             response = await sessionAgent
                 .post(`/api/jobs/${job.id}`)


### PR DESCRIPTION
If a test is still marked as RUNNING when the job becomes COMPLETED, ERROR, or CANCELLED - the RUNNING test should be updated to be `ERROR` or `CANCELLED` (`COMPLETED` should become `CANCELLED` because the test results were not received)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207279995378747