### PR TITLE
Add type-ahead to assign tester dropdown

### DIFF
--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -123,7 +123,7 @@ const AssignTesterDropdown = ({
                     return menuItem.innerText
                         .trim()
                         .toLowerCase()
-                        .startsWith(key);
+                        .startsWith(key.toLowerCase());
                 }
             );
 

--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -116,7 +116,7 @@ const AssignTesterDropdown = ({
 
     const handleKeyDown = event => {
         const { key } = event;
-        if (key.match(/[a-z]/)) {
+        if (key.match(/[0-9a-zA-Z]/)) {
             const container = event.target.closest('[role=menu]');
             const matchingMenuItem = Array.from(container.children).find(
                 menuItem => {

--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -113,9 +113,33 @@ const AssignTesterDropdown = ({
     const clearAriaLiveRegion = () => {
         setAlertMessage('');
     };
+
+    const handleKeyDown = event => {
+        const { key } = event;
+        if (key.match(/[a-z]/)) {
+            const container = event.target.closest('[role=menu]');
+            const matchingMenuItem = Array.from(container.children).find(
+                menuItem => {
+                    return menuItem.innerText
+                        .trim()
+                        .toLowerCase()
+                        .startsWith(key);
+                }
+            );
+
+            if (matchingMenuItem) {
+                matchingMenuItem.focus();
+            }
+        }
+    };
+
     return (
         <LoadingStatus message={loadingMessage}>
-            <Dropdown focusFirstItemOnShow aria-label="Assign testers menu">
+            <Dropdown
+                focusFirstItemOnShow
+                aria-label="Assign testers menu"
+                onKeyDown={handleKeyDown}
+            >
                 <Dropdown.Toggle
                     ref={dropdownAssignTesterButtonRef}
                     aria-label="Assign testers"


### PR DESCRIPTION
see issue #991 

This pull request updates the assign tester menu to support type-ahead.