### PR TITLE
Use aria-checked for AssignTesterDropdown

### DIFF
--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -145,7 +145,7 @@ const AssignTesterDropdown = ({
                             }
                             return (
                                 <Dropdown.Item
-                                    role="menuitem"
+                                    role="menuitemcheckbox"
                                     variant="secondary"
                                     as="button"
                                     key={`tpr-${testPlanReportId}-assign-tester-${username}`}
@@ -168,10 +168,7 @@ const AssignTesterDropdown = ({
                                     }}
                                 >
                                     {icon && <FontAwesomeIcon icon={icon} />}
-                                    <span
-                                        aria-hidden="true"
-                                        className={classname}
-                                    >
+                                    <span className={classname}>
                                         {`${tester.username}`}
                                     </span>
                                 </Dropdown.Item>

--- a/client/components/TestQueue/AssignTesterDropdown/index.jsx
+++ b/client/components/TestQueue/AssignTesterDropdown/index.jsx
@@ -149,6 +149,9 @@ const AssignTesterDropdown = ({
                                     variant="secondary"
                                     as="button"
                                     key={`tpr-${testPlanReportId}-assign-tester-${username}`}
+                                    aria-checked={
+                                        testerIsAssigned ? true : false
+                                    }
                                     onClick={async () => {
                                         const updatedIsAssigned =
                                             !testerIsAssigned;
@@ -165,11 +168,6 @@ const AssignTesterDropdown = ({
                                     }}
                                 >
                                     {icon && <FontAwesomeIcon icon={icon} />}
-                                    <span className="sr-only">{`${username} ${
-                                        testerIsAssigned
-                                            ? 'checked'
-                                            : 'unchecked'
-                                    }`}</span>
                                     <span
                                         aria-hidden="true"
                                         className={classname}

--- a/client/tests/AssignTesterDropdown.test.jsx
+++ b/client/tests/AssignTesterDropdown.test.jsx
@@ -179,7 +179,7 @@ describe('AssignTesterDropdown', () => {
         fireEvent.click(button);
 
         const items = await screen.findAllByText(/bee/);
-        expect(items.length).toBe(2); // One for display, one for sr-only
+        expect(items.length).toBe(1);
         fireEvent.click(items[0]);
 
         await waitFor(async () => {
@@ -205,7 +205,7 @@ describe('AssignTesterDropdown', () => {
         fireEvent.click(button);
 
         const items = await screen.findAllByText(/NVDA Bot/);
-        expect(items.length).toBe(2); // One for display, one for sr-only
+        expect(items.length).toBe(1);
         fireEvent.click(items[0]);
 
         await waitFor(() => {


### PR DESCRIPTION
This PR addresses #977. It removes the screen reader `div` in favor of `aria-checked` for the `AssignTesterDropdown`.