### PR TITLE
Fix: correctly support rowNumbers like 14.1 with automation

### DIFF
--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -158,7 +158,7 @@ const getTestByRowNumber = async ({ testPlanRun, testRowNumber, context }) => {
         context
     );
     return tests.find(
-        test => parseInt(test.rowNumber, 10) === parseInt(testRowNumber, 10)
+        test => String(test.rowNumber) === String(testRowNumber)
     );
 };
 


### PR DESCRIPTION
This is a simple fix to support the `14.1` row numbers correctly.  This is the reason for the empty results in the modal dialog tests (w3c/aria-at#1070)

@howard-e I was having some trouble trying to figure out if I could add a test for this in automation-scheduler.test.js but the test report it's running against doesn't have a "decimal" row number, and I'm unsure where the data that it's querying is coming from to add 