### PR TITLE
Include the latest w3c/aria-at data imports in tests and update sample data

### DIFF
--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -36,12 +36,10 @@ jobs:
           sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE ${PGDATABASE} to ${PGUSER};"
           yarn sequelize:test db:migrate
           yarn sequelize:test db:seed:all
-          yarn workspace server db-import-tests:test -c ${IMPORT_ARIA_AT_TESTS_COMMIT_1}
-          yarn workspace server db-import-tests:test -c ${IMPORT_ARIA_AT_TESTS_COMMIT_2}
-          yarn workspace server db-import-tests:test -c ${IMPORT_ARIA_AT_TESTS_COMMIT_3}
-          yarn workspace server db-import-tests:test -c ${IMPORT_ARIA_AT_TESTS_COMMIT_4}
+          yarn workspace server db-import-tests:test -c "${IMPORT_ARIA_AT_TESTS_COMMIT_1} ${IMPORT_ARIA_AT_TESTS_COMMIT_2} ${IMPORT_ARIA_AT_TESTS_COMMIT_3} ${IMPORT_ARIA_AT_TESTS_COMMIT_4}"
+          yarn workspace server db-import-tests:test
           yarn workspace server db-populate-sample-data:test
-      # yarn test would run all of these in serial, however we split this up to allow it continue
+      # yarn test would run all of these in serial, however we split this up to allow it to continue
       # in case of errors - all tests will still run even if lint fails for instance.
       - run: yarn workspace shared prettier
         if: always()

--- a/docs/database.md
+++ b/docs/database.md
@@ -95,6 +95,7 @@ yarn db-init:test;
 yarn sequelize:test db:migrate;
 yarn sequelize:test db:seed:all;
 yarn workspace server db-import-tests:test -c "5fe7afd82fe51c185b8661276105190a59d47322 1aa3b74d24d340362e9f511eae33788d55487d12 ab77d47ab19db71c635c9bb459ba5c34182e1400 d34eddbb8e751f07bd28d952de15fa7fe5f07353";
+yarn workspace server db-import-tests:test;
 yarn workspace server db-populate-sample-data:test;
 ```
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -35,10 +35,7 @@ The database migrations are managed by [Sequelize](https://sequelize.org/). The 
     ```
 4. Import the most recent tests from the [aria-at repository](https://github.com/w3c/aria-at):
     ```
-    yarn db-import-tests:dev -c 5fe7afd82fe51c185b8661276105190a59d47322;
-    yarn db-import-tests:dev -c 1aa3b74d24d340362e9f511eae33788d55487d12;
-    yarn db-import-tests:dev -c ab77d47ab19db71c635c9bb459ba5c34182e1400;
-    yarn db-import-tests:dev -c d34eddbb8e751f07bd28d952de15fa7fe5f07353;
+    yarn db-import-tests:dev -c "5fe7afd82fe51c185b8661276105190a59d47322 1aa3b74d24d340362e9f511eae33788d55487d12 ab77d47ab19db71c635c9bb459ba5c34182e1400 d34eddbb8e751f07bd28d952de15fa7fe5f07353";
     yarn db-import-tests:dev;
     ```
 
@@ -54,10 +51,7 @@ fi;
 
 yarn sequelize db:migrate;
 yarn sequelize db:seed:all;
-yarn db-import-tests:dev -c 5fe7afd82fe51c185b8661276105190a59d47322;
-yarn db-import-tests:dev -c 1aa3b74d24d340362e9f511eae33788d55487d12;
-yarn db-import-tests:dev -c ab77d47ab19db71c635c9bb459ba5c34182e1400;
-yarn db-import-tests:dev -c d34eddbb8e751f07bd28d952de15fa7fe5f07353;
+yarn db-import-tests:dev -c "5fe7afd82fe51c185b8661276105190a59d47322 1aa3b74d24d340362e9f511eae33788d55487d12 ab77d47ab19db71c635c9bb459ba5c34182e1400 d34eddbb8e751f07bd28d952de15fa7fe5f07353";
 yarn db-import-tests:dev;
 ```
 
@@ -100,10 +94,7 @@ The instructions are similar for the test database, with one extra step:
 yarn db-init:test;
 yarn sequelize:test db:migrate;
 yarn sequelize:test db:seed:all;
-yarn workspace server db-import-tests:test -c 5fe7afd82fe51c185b8661276105190a59d47322;
-yarn workspace server db-import-tests:test -c 1aa3b74d24d340362e9f511eae33788d55487d12;
-yarn workspace server db-import-tests:test -c ab77d47ab19db71c635c9bb459ba5c34182e1400;
-yarn workspace server db-import-tests:test -c d34eddbb8e751f07bd28d952de15fa7fe5f07353;
+yarn workspace server db-import-tests:test -c "5fe7afd82fe51c185b8661276105190a59d47322 1aa3b74d24d340362e9f511eae33788d55487d12 ab77d47ab19db71c635c9bb459ba5c34182e1400 d34eddbb8e751f07bd28d952de15fa7fe5f07353";
 yarn workspace server db-populate-sample-data:test;
 ```
 

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -170,9 +170,7 @@ const getTestByRowNumber = async ({ testPlanRun, testRowNumber, context }) => {
         null,
         context
     );
-    return tests.find(
-        test => String(test.rowNumber) === String(testRowNumber)
-    );
+    return tests.find(test => String(test.rowNumber) === String(testRowNumber));
 };
 
 const updateOrCreateTestResultWithResponses = async ({

--- a/server/handlebars/embed/public/style.css
+++ b/server/handlebars/embed/public/style.css
@@ -52,8 +52,8 @@ details summary::after {
 }
 
 details > summary.recommended::after {
-  background-color: #115b11;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='6.861' viewBox='0 0 12 6.861'%3E%3Cpath id='Icon_ionic-ios-arrow-down' data-name='Icon ionic-ios-arrow-down' d='M12.19,16.039,16.727,11.5a.854.854,0,0,1,1.211,0,.865.865,0,0,1,0,1.215L12.8,17.858a.856.856,0,0,1-1.183.025L6.438,12.717A.858.858,0,1,1,7.649,11.5Z' transform='translate(18.188 18.108) rotate(180)' fill='rgb(233, 251, 233)'/%3E%3C/svg%3E%0A");
+    background-color: #115b11;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='6.861' viewBox='0 0 12 6.861'%3E%3Cpath id='Icon_ionic-ios-arrow-down' data-name='Icon ionic-ios-arrow-down' d='M12.19,16.039,16.727,11.5a.854.854,0,0,1,1.211,0,.865.865,0,0,1,0,1.215L12.8,17.858a.856.856,0,0,1-1.183.025L6.438,12.717A.858.858,0,1,1,7.649,11.5Z' transform='translate(18.188 18.108) rotate(180)' fill='rgb(233, 251, 233)'/%3E%3C/svg%3E%0A");
 }
 
 details[open] summary::after {
@@ -73,8 +73,8 @@ details > summary {
 }
 
 details > summary.recommended {
-  border: 1.5px solid #7ac498;
-  background-color: #e9fbe9;
+    border: 1.5px solid #7ac498;
+    background-color: #e9fbe9;
 }
 
 details > summary > ::before {
@@ -90,26 +90,26 @@ details > summary > ::before {
 }
 
 details > summary.recommended ::before {
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNS4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjQgRm9udGljb25zLCBJbmMuLS0+CiAgPHBhdGgKICBmaWxsPSIjMTE1YjExIgogICAgZD0iTTI1NiA1MTJBMjU2IDI1NiAwIDEgMCAyNTYgMGEyNTYgMjU2IDAgMSAwIDAgNTEyek0yMTYgMzM2aDI0VjI3MkgyMTZjLTEzLjMgMC0yNC0xMC43LTI0LTI0czEwLjctMjQgMjQtMjRoNDhjMTMuMyAwIDI0IDEwLjcgMjQgMjR2ODhoOGMxMy4zIDAgMjQgMTAuNyAyNCAyNHMtMTAuNyAyNC0yNCAyNEgyMTZjLTEzLjMgMC0yNC0xMC43LTI0LTI0czEwLjctMjQgMjQtMjR6bTQwLTIwOGEzMiAzMiAwIDEgMSAwIDY0IDMyIDMyIDAgMSAxIDAtNjR6IgogIC8+Cjwvc3ZnPgo=');
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KICA8IS0tIUZvbnQgQXdlc29tZSBGcmVlIDYuNS4yIGJ5IEBmb250YXdlc29tZSAtIGh0dHBzOi8vZm9udGF3ZXNvbWUuY29tIExpY2Vuc2UgLSBodHRwczovL2ZvbnRhd2Vzb21lLmNvbS9saWNlbnNlL2ZyZWUgQ29weXJpZ2h0IDIwMjQgRm9udGljb25zLCBJbmMuLS0+CiAgPHBhdGgKICBmaWxsPSIjMTE1YjExIgogICAgZD0iTTI1NiA1MTJBMjU2IDI1NiAwIDEgMCAyNTYgMGEyNTYgMjU2IDAgMSAwIDAgNTEyek0yMTYgMzM2aDI0VjI3MkgyMTZjLTEzLjMgMC0yNC0xMC43LTI0LTI0czEwLjctMjQgMjQtMjRoNDhjMTMuMyAwIDI0IDEwLjcgMjQgMjR2ODhoOGMxMy4zIDAgMjQgMTAuNyAyNCAyNHMtMTAuNyAyNC0yNCAyNEgyMTZjLTEzLjMgMC0yNC0xMC43LTI0LTI0czEwLjctMjQgMjQtMjR6bTQwLTIwOGEzMiAzMiAwIDEgMSAwIDY0IDMyIDMyIDAgMSAxIDAtNjR6IgogIC8+Cjwvc3ZnPgo=');
 }
 
 details > summary > h4 {
-  position: relative;
-  padding-left: var(--left-right-padding);
-  padding-right: var(--left-right-padding);
+    position: relative;
+    padding-left: var(--left-right-padding);
+    padding-right: var(--left-right-padding);
 
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 1em;
-  color: #60470c;
-  display: inline-block;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1em;
+    color: #60470c;
+    display: inline-block;
 }
 
 details > summary.recommended > h4 {
-  color: #384338;
+    color: #384338;
 }
 
 details summary::-webkit-details-marker {
-  display: none;
+    display: none;
 }
 
 .content-container {
@@ -130,11 +130,11 @@ details summary::-webkit-details-marker {
 }
 
 div.recommended {
-  border-bottom: 1.5px solid #7ac498;
-  border-left: 1.5px solid #7ac498;
-  border-right: 1.5px solid #7ac498;
-  background-color: #e9fbe9;
-  color: #384338;
+    border-bottom: 1.5px solid #7ac498;
+    border-left: 1.5px solid #7ac498;
+    border-right: 1.5px solid #7ac498;
+    background-color: #e9fbe9;
+    color: #384338;
 }
 
 .no-data-cell {

--- a/server/scripts/import-tests/index.js
+++ b/server/scripts/import-tests/index.js
@@ -60,7 +60,26 @@ const gitRun = (args, cwd = gitCloneDirectory) => {
 };
 
 const importTestPlanVersions = async transaction => {
-    const { gitCommitDate } = await readRepo();
+    await cloneRepo();
+
+    // Get list of commits when multiple passed in as
+    // `<import_cmd> -c "commit1 commit2 commitN ..."`
+    const commits = args.commit
+        ? args.commit
+              .trim()
+              .split(' ')
+              .filter(el => !!el)
+        : [];
+
+    if (commits.length) {
+        for (const commit of commits) {
+            await buildTestsAndCreateTestPlanVersions(commit, { transaction });
+        }
+    } else await buildTestsAndCreateTestPlanVersions(null, { transaction });
+};
+
+const buildTestsAndCreateTestPlanVersions = async (commit, { transaction }) => {
+    const { gitCommitDate } = await readCommit(commit);
 
     console.log('Running `npm install` ...\n');
     const installOutput = spawn.sync('npm', ['install'], {
@@ -227,17 +246,26 @@ const importTestPlanVersions = async transaction => {
             transaction
         });
     }
+
+    // To ensure build folder is clean when multiple commits are being processed
+    // to prevent `EPERM` errors
+    console.log('Running `npm run cleanup` ...\n');
+    const cleanupOutput = spawn.sync('npm', ['run', 'cleanup'], {
+        cwd: gitCloneDirectory
+    });
+    console.log('`npm run cleanup` output', cleanupOutput.stdout.toString());
 };
 
-const readRepo = async () => {
+const cloneRepo = async () => {
     fse.ensureDirSync(gitCloneDirectory);
 
     console.info('Cloning aria-at repo ...');
     spawn.sync('git', ['clone', ariaAtRepo, gitCloneDirectory]);
     console.info('Cloning aria-at repo complete.');
+};
 
-    gitRun(`checkout ${args.commit ?? ariaAtDefaultBranch}`);
-
+const readCommit = async commit => {
+    gitRun(`checkout ${commit ?? ariaAtDefaultBranch}`);
     const gitCommitDate = new Date(gitRun(`log --format=%aI -n 1`));
 
     return { gitCommitDate };

--- a/server/scripts/populate-test-data/index.js
+++ b/server/scripts/populate-test-data/index.js
@@ -227,6 +227,14 @@ const populateTestDatabase = async transaction => {
         transaction
     });
 
+    await populateFakeTestResults(
+        19,
+        new Array(12).fill('completeAndPassing'),
+        {
+            transaction
+        }
+    );
+
     console.info(
         'Successfully populated. Please wait a moment for the process to close.'
     );

--- a/server/scripts/populate-test-data/pg_dump_test_data.sql
+++ b/server/scripts/populate-test-data/pg_dump_test_data.sql
@@ -78,6 +78,7 @@ INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "markedFinal
 INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "markedFinalAt", "atId", "browserId", "vendorReviewStatus") VALUES (16, get_test_plan_version_id(text 'Command Button Example', '2'), '2023-12-13 14:18:23.602-05', '2023-12-14', 1, 2, 'READY');
 INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "markedFinalAt", "atId", "browserId", "vendorReviewStatus") VALUES (17, get_test_plan_version_id(text 'Command Button Example', '2'), '2023-12-13 14:18:23.602-05', '2023-12-14', 2, 2, 'READY');
 INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "markedFinalAt", "atId", "browserId", "vendorReviewStatus") VALUES (18, get_test_plan_version_id(text 'Command Button Example', '2'), '2023-12-13 14:18:23.602-05', '2023-12-14', 3, 3, 'READY');
+INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "atId", "browserId", "vendorReviewStatus") VALUES (19, get_test_plan_version_id(text 'Modal Dialog Example', '2'), '2024-05-14 14:18:23.602-05', 2, 2, 'READY');
 
 --
 -- Data for Name: TestPlanVersion; Type: TABLE DATA; Schema: public; Owner: atr
@@ -89,6 +90,7 @@ UPDATE "TestPlanVersion" SET "phase" = 'CANDIDATE', "draftPhaseReachedAt" = '202
 UPDATE "TestPlanVersion" SET "phase" = 'RECOMMENDED', "candidatePhaseReachedAt" = '2022-07-06', "recommendedPhaseTargetDate" = '2023-01-02', "recommendedPhaseReachedAt" = '2023-01-03' WHERE id = get_test_plan_version_id(text 'Checkbox Example (Mixed-State)', '1');
 UPDATE "TestPlanVersion" SET "phase" = 'DRAFT', "draftPhaseReachedAt" = '2022-07-06' WHERE id = get_test_plan_version_id(text 'Alert Example', '1');
 UPDATE "TestPlanVersion" SET "phase" = 'DRAFT', "draftPhaseReachedAt" = '2023-12-14' WHERE id = get_test_plan_version_id(text 'Command Button Example', '2');
+UPDATE "TestPlanVersion" SET "phase" = 'DRAFT', "draftPhaseReachedAt" = '2024-05-14' WHERE id = get_test_plan_version_id(text 'Modal Dialog Example', '2');
 
 --
 -- Data for Name: User; Type: TABLE DATA; Schema: public; Owner: atr
@@ -126,6 +128,7 @@ INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults"
 INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (16, 1, 16, '[]');
 INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (17, 1, 17, '[]');
 INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (18, 1, 18, '[]');
+INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (19, 1, 19, '[]');
 
 --
 -- Data for Name: CollectionJob; Type: TABLE DATA; Schema: public; Owner: atr


### PR DESCRIPTION
Address #1107 by doing the following:
1. Allowing the most recent commits from w3c/aria-at to be imported when importing data from w3c/aria-at again.
2. This also updates the sample data population script to include a modal-dialog example to test [tests which has decimal value `presentationNumber`s](https://github.com/w3c/aria-at/blob/master/tests/modal-dialog/data/tests.csv).

Also took the opportunity in this PR to make the `yarn db-import-tests:*` process multiple commits at once, with `-c "commit_1 commit_2"`. This saves ~30s for me.