### PR TITLE
fix: use correct test number sequence for raising github issues

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -465,7 +465,7 @@ const CandidateTestPlanRun = () => {
                                     testPlanTitle: testPlanVersion.title,
                                     versionString:
                                         testPlanVersion.versionString,
-                                    testRowNumber: currentTest.rowNumber
+                                    testSequenceNumber: currentTest.seq
                                 })}
                             />
                         );

--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -317,6 +317,7 @@ const CandidateTestPlanRun = () => {
         versionString: testPlanVersion.versionString,
         testTitle: currentTest.title,
         testRowNumber: currentTest.rowNumber,
+        testSequenceNumber: currentTest.seq,
         testRenderedUrl: currentTest.renderedUrl,
         atName: testPlanReport.at.name
     };

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -186,6 +186,7 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
                     versionString: testPlanVersion.versionString,
                     testTitle: test.title,
                     testRowNumber: test.rowNumber,
+                    testSequenceNumber: test.seq,
                     testRenderedUrl: test.renderedUrl,
                     atName: testPlanReport.at.name,
                     atVersionName: testResult.atVersion.name,

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -186,7 +186,7 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
                     versionString: testPlanVersion.versionString,
                     testTitle: test.title,
                     testRowNumber: test.rowNumber,
-                    testSequenceNumber: test.seq,
+                    testSequenceNumber: index + 1,
                     testRenderedUrl: test.renderedUrl,
                     atName: testPlanReport.at.name,
                     atVersionName: testResult.atVersion.name,

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -367,7 +367,7 @@ const TestRun = () => {
                 'YY.MM.DD'
             )}`,
             testTitle: currentTest.title,
-            testRowNumber: currentTest.rowNumber,
+            testSequenceNumber: currentTest.seq,
             testRenderedUrl: currentTest.renderedUrl,
             atName: testPlanReport.at.name,
             browserName: testPlanReport.browser.name,

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -367,6 +367,7 @@ const TestRun = () => {
                 'YY.MM.DD'
             )}`,
             testTitle: currentTest.title,
+            testRowNumber: currentTest.rowNumber,
             testSequenceNumber: currentTest.seq,
             testRenderedUrl: currentTest.renderedUrl,
             atName: testPlanReport.at.name,

--- a/client/utils/createIssueLink.js
+++ b/client/utils/createIssueLink.js
@@ -9,6 +9,28 @@ const atLabelMap = {
     NVDA: 'nvda'
 };
 
+/**
+ * Creates a link to open a new issue on the GitHub repository.
+ *
+ * @param {Object} options - Options for creating the issue link
+ * @param {boolean} [options.isCandidateReview=false] - Whether this is a candidate review
+ * @param {boolean} [options.isCandidateReviewChangesRequested=false] - Whether changes are requested for a candidate review
+ * @param {string} [options.testPlanDirectory] - The directory of the test plan
+ * @param {string} [options.testPlanTitle] - The title of the test plan
+ * @param {string} [options.versionString] - The version string
+ * @param {string|null} [options.testTitle=null] - The title of the test
+ * @param {number|null} [options.testSequenceNumber=null] - The sequence number of the test. This is the number displayed to test runners
+ * @param {number|null} [options.testRowNumber=null] - The row number of the test in aria-at
+ * @param {string|null} [options.testRenderedUrl=null] - The rendered URL of the test
+ * @param {string} options.atName - The name of the assistive technology
+ * @param {string|null} [options.atVersionName=null] - The version name of the assistive technology
+ * @param {string|null} [options.browserName=null] - The name of the browser
+ * @param {string|null} [options.browserVersionName=null] - The version name of the browser
+ * @param {string|null} [options.conflictMarkdown=null] - The conflict markdown
+ * @param {string|null} [options.reportLink=null] - The link to the report
+ * @returns {string} The URL for creating a new issue on the GitHub repository
+ * @throws {Error} If required parameters are missing
+ */
 const createIssueLink = ({
     isCandidateReview = false,
     isCandidateReviewChangesRequested = false,
@@ -128,6 +150,19 @@ const createIssueLink = ({
     );
 };
 
+/**
+ * Returns a link to search for existing issues on the GitHub repository based on the provided parameters.
+ *
+ * @param {Object} options - Options for generating the issue search link
+ * @param {boolean} [options.isCandidateReview=false] - Whether this is a candidate review
+ * @param {boolean} [options.isCandidateReviewChangesRequested=false] - Whether changes are requested for a candidate review
+ * @param {string|null} [options.username=null] - The username of the author
+ * @param {string} options.atName - The name of the assistive technology
+ * @param {string} options.testPlanTitle - The title of the test plan
+ * @param {string} options.versionString - The version string
+ * @param {number|null} [options.testSequenceNumber=null] - The sequence number of the test, this is the test number displayed to test runners
+ * @returns {string} The URL for searching issues on the GitHub repository
+ */
 export const getIssueSearchLink = ({
     isCandidateReview = false,
     isCandidateReviewChangesRequested = false,

--- a/client/utils/createIssueLink.js
+++ b/client/utils/createIssueLink.js
@@ -135,7 +135,7 @@ export const getIssueSearchLink = ({
     atName,
     testPlanTitle,
     versionString,
-    testRowNumber = null
+    testSequenceNumber = null
 }) => {
     let atKey;
     if (atName === 'JAWS' || atName === 'NVDA') {
@@ -153,7 +153,7 @@ export const getIssueSearchLink = ({
         username ? `author:${username}` : '',
         `label:${atKey}`,
         `"${testPlanTitle}"`,
-        testRowNumber ? `Test ${testRowNumber}` : '',
+        testSequenceNumber ? `Test ${testSequenceNumber}` : '',
         versionString
     ]
         .filter(str => str)

--- a/client/utils/createIssueLink.js
+++ b/client/utils/createIssueLink.js
@@ -16,6 +16,7 @@ const createIssueLink = ({
     testPlanTitle,
     versionString,
     testTitle = null,
+    testSequenceNumber = null,
     testRowNumber = null,
     testRenderedUrl = null,
     atName,
@@ -29,7 +30,12 @@ const createIssueLink = ({
         throw new Error('Cannot create issue link due to missing parameters');
     }
 
-    const hasTest = !!(testTitle && testRowNumber && testRenderedUrl);
+    const hasTest = !!(
+        testTitle &&
+        testSequenceNumber &&
+        testRowNumber &&
+        testRenderedUrl
+    );
 
     let title;
     if (hasTest) {
@@ -44,7 +50,7 @@ const createIssueLink = ({
 
         title =
             `${titleStart}: "${testTitle}" (${testPlanTitle}, ` +
-            `Test ${testRowNumber}, ${versionString})`;
+            `Test ${testSequenceNumber}, ${versionString})`;
     } else {
         title = `${atName} General Feedback: ${testPlanTitle} ${versionString}`;
     }
@@ -99,6 +105,7 @@ const createIssueLink = ({
         atName,
         browserName,
         testRowNumber,
+        testSequenceNumber,
         isCandidateReview,
         isCandidateReviewChangesRequested
     });


### PR DESCRIPTION
This PR modifies `createIssueLink()` so that it accepts a new property in the options param, `testSequenceNumber`. In all instances where this function is used, the generated number used for rendering the test number ("Test X:") is passed. This handles confusion about which test is referenced when creating issues. The test row number which is now decoupled from the specific report's sequence is still stored in the `hiddenMetadata` of the issue.

I wanted to add a unit test but this would be difficult with the current design of this method since the testable logic for this particular problem has more to do with the generated sequence passed in. I can think of ways to adjust the design but none is an absolute win so I decided this was out of scope. Let me know if reviewers think otherwise.

addresses #1110 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207383005191128