### PR TITLE
feat: Support minimum and exact AT Version requirements in Test Run's version selection modal

### DIFF
--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -1390,9 +1390,24 @@ const TestRun = () => {
                         isAdmin={isAdminReviewer}
                         atName={testPlanReport.at.name}
                         atVersion={currentTest.testResult?.atVersion?.name}
-                        atVersions={testPlanReport.at.atVersions.map(
-                            item => item.name
-                        )}
+                        atVersions={testPlanReport.at.atVersions
+                            .filter(item => {
+                                // Only provide at version options that released
+                                // at the same time or later than the minimum
+                                // AT version
+                                let earliestReleasedAt = null;
+                                if (testPlanReport.minimumAtVersion) {
+                                    earliestReleasedAt = new Date(
+                                        testPlanReport.minimumAtVersion.releasedAt
+                                    );
+                                    return (
+                                        new Date(item.releasedAt) >=
+                                        earliestReleasedAt
+                                    );
+                                }
+                                return item;
+                            })
+                            .map(item => item.name)}
                         browserName={testPlanReport.browser.name}
                         browserVersion={
                             currentTest.testResult?.browserVersion?.name
@@ -1402,6 +1417,7 @@ const TestRun = () => {
                         )}
                         patternName={testPlanVersion.title}
                         testerName={tester.username}
+                        exactAtVersion={testPlanReport.exactAtVersion}
                         handleAction={handleAtAndBrowserDetailsModalAction}
                         handleClose={handleAtAndBrowserDetailsModalCloseAction}
                     />

--- a/client/components/TestRun/queries.js
+++ b/client/components/TestRun/queries.js
@@ -122,7 +122,17 @@ export const TEST_RUN_PAGE_QUERY = gql`
                     atVersions {
                         id
                         name
+                        releasedAt
                     }
+                }
+                minimumAtVersion {
+                    id
+                    name
+                    releasedAt
+                }
+                exactAtVersion {
+                    id
+                    name
                 }
                 browser {
                     id
@@ -427,7 +437,17 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                             atVersions {
                                 id
                                 name
+                                releasedAt
                             }
+                        }
+                        minimumAtVersion {
+                            id
+                            name
+                            releasedAt
+                        }
+                        exactAtVersion {
+                            id
+                            name
                         }
                         browser {
                             id
@@ -525,7 +545,17 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
                         atVersions {
                             id
                             name
+                            releasedAt
                         }
+                    }
+                    minimumAtVersion {
+                        id
+                        name
+                        releasedAt
+                    }
+                    exactAtVersion {
+                        id
+                        name
                     }
                     browser {
                         id
@@ -721,7 +751,17 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                             atVersions {
                                 id
                                 name
+                                releasedAt
                             }
+                        }
+                        minimumAtVersion {
+                            id
+                            name
+                            releasedAt
+                        }
+                        exactAtVersion {
+                            id
+                            name
                         }
                         browser {
                             id
@@ -818,7 +858,17 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
                         atVersions {
                             id
                             name
+                            releasedAt
                         }
+                    }
+                    minimumAtVersion {
+                        id
+                        name
+                        releasedAt
+                    }
+                    exactAtVersion {
+                        id
+                        name
                     }
                     browser {
                         id
@@ -1013,7 +1063,17 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                             atVersions {
                                 id
                                 name
+                                releasedAt
                             }
+                        }
+                        minimumAtVersion {
+                            id
+                            name
+                            releasedAt
+                        }
+                        exactAtVersion {
+                            id
+                            name
                         }
                         browser {
                             id
@@ -1110,7 +1170,17 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
                         atVersions {
                             id
                             name
+                            releasedAt
                         }
+                    }
+                    minimumAtVersion {
+                        id
+                        name
+                        releasedAt
+                    }
+                    exactAtVersion {
+                        id
+                        name
                     }
                     browser {
                         id

--- a/client/components/common/AtAndBrowserDetailsModal/index.jsx
+++ b/client/components/common/AtAndBrowserDetailsModal/index.jsx
@@ -51,6 +51,7 @@ const AtAndBrowserDetailsModal = ({
     browserVersion = '',
     patternName = '', // admin related prop
     testerName = '', // admin related prop
+    exactAtVersion = null,
     handleAction = () => {},
     handleClose = () => {}
 }) => {
@@ -69,8 +70,9 @@ const AtAndBrowserDetailsModal = ({
 
     const [showExitModal, setShowExitModal] = useState(false);
     const [isFirstLoad, setIsFirstLoad] = useState(true);
-    const [updatedAtVersion, setUpdatedAtVersion] =
-        useState('Select a Version');
+    const [updatedAtVersion, setUpdatedAtVersion] = useState(
+        exactAtVersion ? exactAtVersion.name : 'Select a Version'
+    );
     const [updatedBrowserVersion, setUpdatedBrowserVersion] = useState('');
 
     const [isAtVersionError, setIsAtVersionError] = useState(false);
@@ -316,6 +318,27 @@ const AtAndBrowserDetailsModal = ({
                                             </span>
                                         </Alert>
                                     )}
+                                {exactAtVersion ? (
+                                    <Alert
+                                        variant="warning"
+                                        className="at-browser-details-modal-alert"
+                                    >
+                                        <FontAwesomeIcon
+                                            icon={faExclamationTriangle}
+                                        />
+                                        <span>
+                                            Results collected for this test plan
+                                            require{' '}
+                                            <b>
+                                                {atName} {updatedAtVersion}
+                                            </b>
+                                            . By continuing, you confirm that
+                                            your results are being recorded
+                                            using the specified version of the
+                                            Assistive Technology.
+                                        </span>
+                                    </Alert>
+                                ) : null}
                                 <Form.Group className="form-group">
                                     <Form.Label>
                                         Assistive Technology Name
@@ -326,42 +349,59 @@ const AtAndBrowserDetailsModal = ({
                                         value={atName}
                                     />
                                 </Form.Group>
-
                                 <Form.Group className="form-group">
-                                    <Form.Label>
-                                        Assistive Technology Version
-                                        <Required aria-hidden />
-                                    </Form.Label>
-                                    <Form.Select
-                                        ref={updatedAtVersionDropdownRef}
-                                        value={updatedAtVersion}
-                                        onChange={handleAtVersionChange}
-                                        isInvalid={isAtVersionError}
-                                        required
-                                    >
-                                        {[
-                                            'Select a Version',
-                                            ...atVersions
-                                        ].map(item => (
-                                            <option
-                                                key={`atVersionKey-${item}`}
-                                                value={item}
-                                                disabled={
-                                                    item === 'Select a Version'
+                                    {exactAtVersion ? (
+                                        <>
+                                            <Form.Label>
+                                                Assistive Technology Version
+                                            </Form.Label>
+                                            <Form.Control
+                                                disabled
+                                                type="text"
+                                                value={exactAtVersion.name}
+                                            />
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Form.Label>
+                                                Assistive Technology Version
+                                                <Required aria-hidden />
+                                            </Form.Label>
+                                            <Form.Select
+                                                ref={
+                                                    updatedAtVersionDropdownRef
                                                 }
+                                                value={updatedAtVersion}
+                                                onChange={handleAtVersionChange}
+                                                isInvalid={isAtVersionError}
+                                                required
                                             >
-                                                {item}
-                                            </option>
-                                        ))}
-                                    </Form.Select>
-                                    {isAtVersionError && (
-                                        <Form.Control.Feedback
-                                            style={{ display: 'block' }}
-                                            type="invalid"
-                                        >
-                                            Please select an Assistive
-                                            Technology Version.
-                                        </Form.Control.Feedback>
+                                                {[
+                                                    'Select a Version',
+                                                    ...atVersions
+                                                ].map(item => (
+                                                    <option
+                                                        key={`atVersionKey-${item}`}
+                                                        value={item}
+                                                        disabled={
+                                                            item ===
+                                                            'Select a Version'
+                                                        }
+                                                    >
+                                                        {item}
+                                                    </option>
+                                                ))}
+                                            </Form.Select>
+                                            {isAtVersionError && (
+                                                <Form.Control.Feedback
+                                                    style={{ display: 'block' }}
+                                                    type="invalid"
+                                                >
+                                                    Please select an Assistive
+                                                    Technology Version.
+                                                </Form.Control.Feedback>
+                                            )}
+                                        </>
                                     )}
                                 </Form.Group>
                             </FieldsetRow>
@@ -638,6 +678,10 @@ AtAndBrowserDetailsModal.propTypes = {
     browserVersions: PropTypes.arrayOf(PropTypes.string),
     patternName: PropTypes.string,
     testerName: PropTypes.string,
+    exactAtVersion: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired
+    }),
     handleClose: PropTypes.func,
     handleAction: PropTypes.func
 };


### PR DESCRIPTION
This is related to discussions shared in #791. This PR makes the following changes to the `<AtAndBrowserDetailsModal>` component:
1. If a minimum AT Version is set for a `TestPlanReport`, it prevents AT Versions released before the minimum specified AT Version to be selected on the Test Run page.
2. If an exact AT Version is set for a `TestPlanReport`, it Includes a disclaimer message that it's expected that the tester is using the specified AT Version and prevents any AT Version selection. The disclaimer message is:

> Results collected for this test plan require {atName} {atVersion}. By continuing, you confirm that your results are being recorded using the specified version of the Assistive Technology.