### PR TITLE
fix: terminology update for priority 3 (MAY), passed/failing -> supported/unsupported

### DIFF
--- a/client/components/common/TestPlanResultsTable/index.jsx
+++ b/client/components/common/TestPlanResultsTable/index.jsx
@@ -5,6 +5,13 @@ import nextId from 'react-id-generator';
 import { getMetrics } from 'shared';
 import './TestPlanResultsTable.css';
 
+const getAssertionResultText = (passed, priority) => {
+  if (priority === 'MAY') {
+    return passed ? 'Supported' : 'Unsupported';
+  }
+  return passed ? 'Passed' : 'Failed';
+};
+
 const renderAssertionRow = (assertionResult, priorityString) => {
   return (
     <tr key={`${assertionResult.id}__${nextId()}`}>
@@ -16,7 +23,7 @@ const renderAssertionRow = (assertionResult, priorityString) => {
           : assertionResult.assertion.text.charAt(0).toUpperCase() +
             assertionResult.assertion.text.slice(1)}
       </td>
-      <td>{assertionResult.passed ? 'Passed' : 'Failed'}</td>
+      <td>{getAssertionResultText(assertionResult.passed, priorityString)}</td>
     </tr>
   );
 };

--- a/server/migrations/20240711160607-update-may-terminology.js
+++ b/server/migrations/20240711160607-update-may-terminology.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+const updateMetricsTerminology = async (
+  queryInterface,
+  Sequelize,
+  oldTerm,
+  newTerm
+) => {
+  const [reports] = await queryInterface.sequelize.query(
+    'SELECT id, metrics FROM "TestPlanReport";'
+  );
+
+  const updatePromises = reports.map(report => {
+    const { metrics } = report;
+
+    if (metrics.mayFormatted) {
+      metrics.mayFormatted = metrics.mayFormatted.replace(oldTerm, newTerm);
+    }
+
+    return queryInterface.sequelize.query(
+      'UPDATE "TestPlanReport" SET metrics = :metrics WHERE id = :id',
+      {
+        replacements: {
+          metrics: JSON.stringify(metrics),
+          id: report.id
+        },
+        type: Sequelize.QueryTypes.UPDATE
+      }
+    );
+  });
+
+  await Promise.all(updatePromises);
+};
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await updateMetricsTerminology(
+      queryInterface,
+      Sequelize,
+      'passed',
+      'supported'
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await updateMetricsTerminology(
+      queryInterface,
+      Sequelize,
+      'supported',
+      'passed'
+    );
+  }
+};

--- a/shared/getMetrics.js
+++ b/shared/getMetrics.js
@@ -221,7 +221,7 @@ const getMetrics = ({
   const mayFormatted =
     mayAssertionsCount === 0
       ? false
-      : `${mayAssertionsPassedCount} of ${mayAssertionsCount} passed`;
+      : `${mayAssertionsPassedCount} of ${mayAssertionsCount} supported`;
 
   const unexpectedBehaviorCount = countUnexpectedBehaviors({ ...result });
   const unexpectedBehaviorsFormatted =


### PR DESCRIPTION
This PR updates language in the UI for assertion verdicts from 'passed/failed' to 'unsupported/supported' for priority 3 (MAY) assertions.

This supersedes the previous incorrect PR at #1149 . Thanks for pointing out my misreading of the task @howard-e !

This PR addresses #1145

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207778064599278