### PR TITLE
Add "View Logs" button to Manage Bot Run Dialog

### DIFF
--- a/client/components/ManageBotRunDialog/ViewLogsButton/index.jsx
+++ b/client/components/ManageBotRunDialog/ViewLogsButton/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+
+const ViewLogsButton = ({ externalLogsUrl }) => {
+  const onClick = () => {
+    window.open(externalLogsUrl, '_blank');
+  };
+
+  return (
+    <Button
+      disabled={!externalLogsUrl}
+      aria-disabled={!externalLogsUrl}
+      onClick={onClick}
+      role="link"
+      aria-label={`View logs at ${externalLogsUrl}`}
+      variant="secondary"
+    >
+      View Log
+    </Button>
+  );
+};
+
+ViewLogsButton.propTypes = {
+  externalLogsUrl: PropTypes.string
+};
+
+export default ViewLogsButton;

--- a/client/components/ManageBotRunDialog/ViewLogsButton/index.jsx
+++ b/client/components/ManageBotRunDialog/ViewLogsButton/index.jsx
@@ -13,7 +13,6 @@ const ViewLogsButton = ({ externalLogsUrl }) => {
       aria-disabled={!externalLogsUrl}
       onClick={onClick}
       role="link"
-      aria-label={`View logs at ${externalLogsUrl}`}
       variant="secondary"
     >
       View Log

--- a/client/components/ManageBotRunDialog/index.jsx
+++ b/client/components/ManageBotRunDialog/index.jsx
@@ -15,6 +15,7 @@ import './ManageBotRunDialog.css';
 import MarkBotRunFinishedButton from './MarkBotRunFinishedButton';
 import RetryCanceledCollectionsButton from './RetryCanceledCollectionsButton';
 import StopRunningCollectionButton from './StopRunningCollectionButton';
+import ViewLogsButton from './ViewLogsButton';
 
 const ManageBotRunDialog = ({
   testPlanReportId,
@@ -79,6 +80,13 @@ const ManageBotRunDialog = ({
         }
       },
       {
+        component: ViewLogsButton,
+        props: {
+          externalLogsUrl:
+            collectionJobQuery?.collectionJobByTestPlanRunId?.externalLogsUrl
+        }
+      },
+      {
         component: StopRunningCollectionButton,
         props: {
           collectionJob: collectionJobQuery?.collectionJobByTestPlanRunId,
@@ -107,7 +115,14 @@ const ManageBotRunDialog = ({
         }
       }
     ];
-  }, [testPlanReportId, testPlanRun, possibleReassignees, onChange]);
+  }, [
+    testPlanReportId,
+    testPlanRun,
+    possibleReassignees,
+    onChange,
+    collectionJobQuery
+  ]);
+
   const deleteConfirmationContent = (
     <>
       <p>

--- a/client/components/ManageBotRunDialog/queries.js
+++ b/client/components/ManageBotRunDialog/queries.js
@@ -5,6 +5,7 @@ export const COLLECTION_JOB_ID_BY_TEST_PLAN_RUN_ID_QUERY = gql`
     collectionJobByTestPlanRunId(testPlanRunId: $testPlanRunId) {
       id
       status
+      externalLogsUrl
     }
   }
 `;


### PR DESCRIPTION
addresses #1108 

Opted for a button link with proper aria attributes in order to get disabled and enabled behavior that matches the rest of the buttons in the dialog.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207387087905472