### PR TITLE
Reset TestPlanVersion `nextval` during import if IDs aren't used

### DIFF
--- a/server/migrations/20240715150459-resetTestPlanVersionIdToLatest.js
+++ b/server/migrations/20240715150459-resetTestPlanVersionIdToLatest.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { sequelize } = require('../models');
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    return queryInterface.sequelize.transaction(async transaction => {
+      const [latestTestPlanVersion] = await queryInterface.sequelize.query(
+        `select id
+         from "TestPlanVersion"
+         order by id desc
+         limit 1`,
+        {
+          type: Sequelize.QueryTypes.SELECT,
+          transaction
+        }
+      );
+
+      await sequelize.query(
+        `SELECT setval(pg_get_serial_sequence('"TestPlanVersion"', 'id'), :currentSequenceValue)`,
+        {
+          replacements: { currentSequenceValue: latestTestPlanVersion.id },
+          transaction
+        }
+      );
+    });
+  },
+
+  async down() {}
+};

--- a/server/migrations/20240715150459-resetTestPlanVersionIdToLatest.js
+++ b/server/migrations/20240715150459-resetTestPlanVersionIdToLatest.js
@@ -16,13 +16,15 @@ module.exports = {
         }
       );
 
-      await sequelize.query(
-        `SELECT setval(pg_get_serial_sequence('"TestPlanVersion"', 'id'), :currentSequenceValue)`,
-        {
-          replacements: { currentSequenceValue: latestTestPlanVersion.id },
-          transaction
-        }
-      );
+      if (latestTestPlanVersion) {
+        await sequelize.query(
+          `SELECT setval(pg_get_serial_sequence('"TestPlanVersion"', 'id'), :currentSequenceValue)`,
+          {
+            replacements: { currentSequenceValue: latestTestPlanVersion.id },
+            transaction
+          }
+        );
+      }
     });
   },
 

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -270,7 +270,7 @@ describe('graphql', () => {
             id
             status
           }
-          v2TestPlanVersion: testPlanVersion(id: 133) {
+          v2TestPlanVersion: testPlanVersion(id: 80) {
             __typename
             id
             metadata

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -181,444 +181,444 @@ describe('graphql', () => {
     // eslint-disable-next-line no-unused-vars
     const queryResult = await typeAwareQuery(
       gql`
-                query {
-                    __typename
-                    browsers {
-                        __typename
-                        id
-                        key
-                        name
-                        ats {
-                            __typename
-                            id
-                            name
-                        }
-                        candidateAts {
-                            __typename
-                            id
-                            name
-                        }
-                        recommendedAts {
-                            __typename
-                            id
-                            name
-                        }
-                        browserVersions {
-                            __typename
-                            id
-                            name
-                        }
-                    }
-                    ats {
-                        __typename
-                        id
-                        key
-                        name
-                        browsers {
-                            __typename
-                            id
-                            name
-                        }
-                        candidateBrowsers {
-                            __typename
-                            id
-                            name
-                        }
-                        recommendedBrowsers {
-                            __typename
-                            id
-                            name
-                        }
-                        atVersions {
-                            __typename
-                            id
-                            name
-                            releasedAt
-                        }
-                    }
-                    users {
-                        __typename
-                        username
-                        roles
-                        isBot
-                    }
-                    me {
-                        __typename
-                        id
-                        username
-                        roles
-                        ats {
-                            id
-                            name
-                        }
-                    }
-                    collectionJob(id: 1) {
-                        __typename
-                        id
-                        status
-                        testPlanRun {
-                            id
-                        }
-                    }
-                    collectionJobs {
-                        __typename
-                        id
-                        status
-                    }
-                    collectionJobByTestPlanRunId(testPlanRunId: 1) {
-                        __typename
-                        id
-                        status
-                    }
-                    v2TestPlanVersion: testPlanVersion(id: 133) {
-                        __typename
-                        id
-                        metadata
-                        tests {
-                            __typename
-                            assertions {
-                                __typename
-                                phrase
-                            }
-                        }
-                    }
-                    testPlan(id: "checkbox") {
-                        __typename
-                        id
-                        directory
-                        title
-                        latestTestPlanVersion {
-                            __typename
-                            id
-                            title
-                            updatedAt
-                            gitSha
-                            gitMessage
-                            updatedAt
-                            testPageUrl
-                            metadata
-                            tests {
-                                __typename
-                                id
-                                rowNumber
-                                title
-                                ats {
-                                    id
-                                }
-                                scenarios {
-                                    __typename
-                                    id
-                                    at {
-                                        id
-                                    }
-                                    commands {
-                                        __typename
-                                        id
-                                        text
-                                        atOperatingMode
-                                    }
-                                }
-                                assertions {
-                                    __typename
-                                    id
-                                    priority
-                                    text
-                                }
-                                testFormatVersion
-                            }
-                        }
-                        testPlanVersions {
-                            id
-                        }
-                        issues {
-                            __typename
-                            author
-                            title
-                            link
-                            isCandidateReview
-                            feedbackType
-                            isOpen
-                            testNumberFilteredByAt
-                            createdAt
-                            closedAt
-                            at {
-                                name
-                            }
-                            browser {
-                                name
-                            }
-                        }
-                    }
-                    testPlans {
-                        directory
-                        title
-                    }
-                    testPlanRuns {
-                        id
-                    }
-                    testPlanVersions {
-                        __typename
-                        id
-                        phase
-                        draftPhaseReachedAt
-                        candidatePhaseReachedAt
-                        recommendedPhaseTargetDate
-                        recommendedPhaseReachedAt
-                        deprecatedAt
-                        versionString
-                    }
-                    testPlanVersion(id: 1) {
-                        __typename
-                        id
-                        testPlanReports {
-                            id
-                        }
-                        testPlan {
-                            id
-                            directory
-                        }
-                    }
-                    recommendedTestPlanVersion: testPlanVersion(id: 69) {
-                        __typename
-                        id
-                        testPlanReports {
-                            __typename
-                            id
-                            recommendedAtVersion {
-                                __typename
-                                id
-                                name
-                                releasedAt
-                            }
-                        }
-                        earliestAtVersion(atId: 1) {
-                            id
-                            name
-                            releasedAt
-                        }
-                        testPlanReportStatuses {
-                            __typename
-                            isRequired
-                            at {
-                                id
-                            }
-                            exactAtVersion {
-                                id
-                            }
-                            minimumAtVersion {
-                                id
-                            }
-                            browser {
-                                id
-                            }
-                            testPlanReport {
-                                id
-                            }
-                        }
-                    }
-                    conflictTestPlanReport: testPlanReport(id: 2) {
-                        __typename
-                        id
-                        isFinal
-                        createdAt
-                        vendorReviewStatus
-                        testPlanVersion {
-                            id
-                        }
-                        at {
-                            __typename
-                            id
-                        }
-                        browser {
-                            __typename
-                            id
-                        }
-                        runnableTests {
-                            __typename
-                            id
-                            renderableContent
-                            renderableContents {
-                                __typename
-                                at {
-                                    id
-                                }
-                                renderableContent
-                            }
-                            renderedUrl
-                            renderedUrls {
-                                __typename
-                                at {
-                                    id
-                                }
-                                renderedUrl
-                            }
-                        }
-                        runnableTestsLength
-                        draftTestPlanRuns {
-                            __typename
-                            id
-                            tester {
-                                username
-                            }
-                            testResults {
-                                __typename
-                                id
-                                test {
-                                    id
-                                }
-                                atVersion {
-                                    __typename
-                                    id
-                                    name
-                                    releasedAt
-                                }
-                                browserVersion {
-                                    __typename
-                                    id
-                                    name
-                                }
-                                scenarioResults {
-                                    __typename
-                                    id
-                                    scenario {
-                                        id
-                                    }
-                                    output
-                                    assertionResults {
-                                        __typename
-                                        id
-                                        assertion {
-                                            id
-                                        }
-                                        passed
-                                    }
-                                    unexpectedBehaviors {
-                                        __typename
-                                        id
-                                        text
-                                        impact
-                                        details
-                                    }
-                                }
-                            }
-                            testResultsLength
-                        }
-                        conflicts {
-                            __typename
-                            source {
-                                locationOfData
-                            }
-                            conflictingResults {
-                                locationOfData
-                            }
-                        }
-                        issues {
-                            __typename
-                        }
-                    }
-                    testPlanReport(id: 3) {
-                        __typename
-                        finalizedTestResults {
-                            __typename
-                            id
-                            startedAt
-                            completedAt
-                        }
-                        metrics
-                        conflictsLength
-                        atVersions {
-                            id
-                            name
-                            releasedAt
-                        }
-                        latestAtVersionReleasedAt {
-                            id
-                            name
-                            releasedAt
-                        }
-                        markedFinalAt
-                        minimumAtVersion {
-                            id
-                        }
-                    }
-                    recommendedPhaseTestPlanReport: testPlanReport(id: 12) {
-                        __typename
-                        exactAtVersion {
-                            id
-                        }
-                    }
-                    testPlanReports {
-                        id
-                        atVersions {
-                            id
-                            name
-                            releasedAt
-                        }
-                        latestAtVersionReleasedAt {
-                            id
-                            name
-                            releasedAt
-                        }
-                    }
-                    testPlanRun(id: 1) {
-                        __typename
-                        id
-                        initiatedByAutomation
-                        collectionJob { id }
-                        testPlanReport {
-                            id
-                        }
-                    }
-                    populateData(locationOfData: {
-                        assertionResultId: "${assertionResultId}"
-                    }) {
-                        __typename
-                        locationOfData
-                        testPlan {
-                            id
-                        }
-                        testPlanVersion {
-                            id
-                        }
-                        testPlanReport {
-                            id
-                        }
-                        at {
-                            id
-                        }
-                        browser {
-                            id
-                        }
-                        testPlanRun {
-                            id
-                        }
-                        test {
-                            id
-                        }
-                        scenario {
-                            id
-                        }
-                        assertion {
-                            id
-                        }
-                        testResult {
-                            id
-                        }
-                        atVersion {
-                            id
-                        }
-                        browserVersion {
-                            id
-                        }
-                        scenarioResult {
-                            id
-                        }
-                        assertionResult {
-                            id
-                        }
-                    }
+        query {
+          __typename
+          browsers {
+            __typename
+            id
+            key
+            name
+            ats {
+              __typename
+              id
+              name
+            }
+            candidateAts {
+              __typename
+              id
+              name
+            }
+            recommendedAts {
+              __typename
+              id
+              name
+            }
+            browserVersions {
+              __typename
+              id
+              name
+            }
+          }
+          ats {
+            __typename
+            id
+            key
+            name
+            browsers {
+              __typename
+              id
+              name
+            }
+            candidateBrowsers {
+              __typename
+              id
+              name
+            }
+            recommendedBrowsers {
+              __typename
+              id
+              name
+            }
+            atVersions {
+              __typename
+              id
+              name
+              releasedAt
+            }
+          }
+          users {
+            __typename
+            username
+            roles
+            isBot
+          }
+          me {
+            __typename
+            id
+            username
+            roles
+            ats {
+              id
+              name
+            }
+          }
+          collectionJob(id: 1) {
+            __typename
+            id
+            status
+            testPlanRun {
+              id
+            }
+          }
+          collectionJobs {
+            __typename
+            id
+            status
+          }
+          collectionJobByTestPlanRunId(testPlanRunId: 1) {
+            __typename
+            id
+            status
+          }
+          v2TestPlanVersion: testPlanVersion(id: 133) {
+            __typename
+            id
+            metadata
+            tests {
+              __typename
+              assertions {
+                __typename
+                phrase
+              }
+            }
+          }
+          testPlan(id: "checkbox") {
+            __typename
+            id
+            directory
+            title
+            latestTestPlanVersion {
+              __typename
+              id
+              title
+              updatedAt
+              gitSha
+              gitMessage
+              updatedAt
+              testPageUrl
+              metadata
+              tests {
+                __typename
+                id
+                rowNumber
+                title
+                ats {
+                  id
                 }
-            `,
+                scenarios {
+                  __typename
+                  id
+                  at {
+                    id
+                  }
+                  commands {
+                    __typename
+                    id
+                    text
+                    atOperatingMode
+                  }
+                }
+                assertions {
+                  __typename
+                  id
+                  priority
+                  text
+                }
+                testFormatVersion
+              }
+            }
+            testPlanVersions {
+              id
+            }
+            issues {
+              __typename
+              author
+              title
+              link
+              isCandidateReview
+              feedbackType
+              isOpen
+              testNumberFilteredByAt
+              createdAt
+              closedAt
+              at {
+                name
+              }
+              browser {
+                name
+              }
+            }
+          }
+          testPlans {
+            directory
+            title
+          }
+          testPlanRuns {
+            id
+          }
+          testPlanVersions {
+            __typename
+            id
+            phase
+            draftPhaseReachedAt
+            candidatePhaseReachedAt
+            recommendedPhaseTargetDate
+            recommendedPhaseReachedAt
+            deprecatedAt
+            versionString
+          }
+          testPlanVersion(id: 1) {
+            __typename
+            id
+            testPlanReports {
+              id
+            }
+            testPlan {
+              id
+              directory
+            }
+          }
+          recommendedTestPlanVersion: testPlanVersion(id: 67) {
+            __typename
+            id
+            testPlanReports {
+              __typename
+              id
+              recommendedAtVersion {
+                __typename
+                id
+                name
+                releasedAt
+              }
+            }
+            earliestAtVersion(atId: 1) {
+              id
+              name
+              releasedAt
+            }
+            testPlanReportStatuses {
+              __typename
+              isRequired
+              at {
+                id
+              }
+              exactAtVersion {
+                id
+              }
+              minimumAtVersion {
+                id
+              }
+              browser {
+                id
+              }
+              testPlanReport {
+                id
+              }
+            }
+          }
+          conflictTestPlanReport: testPlanReport(id: 2) {
+            __typename
+            id
+            isFinal
+            createdAt
+            vendorReviewStatus
+            testPlanVersion {
+              id
+            }
+            at {
+              __typename
+              id
+            }
+            browser {
+              __typename
+              id
+            }
+            runnableTests {
+              __typename
+              id
+              renderableContent
+              renderableContents {
+                __typename
+                at {
+                  id
+                }
+                renderableContent
+              }
+              renderedUrl
+              renderedUrls {
+                __typename
+                at {
+                  id
+                }
+                renderedUrl
+              }
+            }
+            runnableTestsLength
+            draftTestPlanRuns {
+              __typename
+              id
+              tester {
+                username
+              }
+              testResults {
+                __typename
+                id
+                test {
+                  id
+                }
+                atVersion {
+                  __typename
+                  id
+                  name
+                  releasedAt
+                }
+                browserVersion {
+                  __typename
+                  id
+                  name
+                }
+                scenarioResults {
+                  __typename
+                  id
+                  scenario {
+                    id
+                  }
+                  output
+                  assertionResults {
+                    __typename
+                    id
+                    assertion {
+                      id
+                    }
+                    passed
+                  }
+                  unexpectedBehaviors {
+                    __typename
+                    id
+                    text
+                    impact
+                    details
+                  }
+                }
+              }
+              testResultsLength
+            }
+            conflicts {
+              __typename
+              source {
+                locationOfData
+              }
+              conflictingResults {
+                locationOfData
+              }
+            }
+            issues {
+              __typename
+            }
+          }
+          testPlanReport(id: 3) {
+            __typename
+            finalizedTestResults {
+              __typename
+              id
+              startedAt
+              completedAt
+            }
+            metrics
+            conflictsLength
+            atVersions {
+              id
+              name
+              releasedAt
+            }
+            latestAtVersionReleasedAt {
+              id
+              name
+              releasedAt
+            }
+            markedFinalAt
+            minimumAtVersion {
+              id
+            }
+          }
+          recommendedPhaseTestPlanReport: testPlanReport(id: 12) {
+            __typename
+            exactAtVersion {
+              id
+            }
+          }
+          testPlanReports {
+            id
+            atVersions {
+              id
+              name
+              releasedAt
+            }
+            latestAtVersionReleasedAt {
+              id
+              name
+              releasedAt
+            }
+          }
+          testPlanRun(id: 1) {
+            __typename
+            id
+            initiatedByAutomation
+            collectionJob { id }
+            testPlanReport {
+              id
+            }
+          }
+          populateData(locationOfData: {
+            assertionResultId: "${assertionResultId}"
+          }) {
+            __typename
+            locationOfData
+            testPlan {
+              id
+            }
+            testPlanVersion {
+              id
+            }
+            testPlanReport {
+              id
+            }
+            at {
+              id
+            }
+            browser {
+              id
+            }
+            testPlanRun {
+              id
+            }
+            test {
+              id
+            }
+            scenario {
+              id
+            }
+            assertion {
+              id
+            }
+            testResult {
+              id
+            }
+            atVersion {
+              id
+            }
+            browserVersion {
+              id
+            }
+            scenarioResult {
+              id
+            }
+            assertionResult {
+              id
+            }
+          }
+        }
+      `,
       { transaction: false }
     );
 


### PR DESCRIPTION
I was inspecting the production's data from July 10 2024 and took note of significantly high id numbers in the `TestPlanVersion` table. The latest row's id is `163615` but there is just 103 rows in the table, which uses auto-increment IDs. Running `select currval(pg_get_serial_sequence('"TestPlanVersion"', 'id'))` also gives `175465`.

This happens because the `import-tests` script is dependent on knowing the "next" id to create relevant data that is retrieved using [postgres' nextval (which also also updates the next possible ID value)](https://github.com/w3c/aria-at-app/blob/1f61c87fa0bad33e63e2ce145fe989942b332dd8/server/scripts/import-tests/index.js#L143:L148). The issue with this is that those ids could go unused if a potential TestPlanVersion being created is ["discarded" if non-unique data is found](https://github.com/w3c/aria-at-app/blob/1f61c87fa0bad33e63e2ce145fe989942b332dd8/server/scripts/import-tests/index.js#L183), but the incremented value is left as is.

The amount of test plan versions that could be imported is 35 and the cronjob responsible for doing that **should** run [every 15 minutes](https://github.com/w3c/aria-at-app/blob/76c49246b54ea22545e8b872a8838c20cdf82587/deploy/roles/application/tasks/cron.yml#L3:L8) . So potentially, the incremented value is unnecessarily bumped 140 times per hour (105 at a minimum) if there are no new test plan versions.

So this PR does the following:
* Resets `nextval` if it hasn't been used due to that non-unique data condition (continued using `nextval` for the evaluation of the reset value because `currval` or `lastval` may not successfully run if `nextval` hasn't been ran during the db's transaction session)
* Resets `nextval` to current latest ID + 1 in a migration