### PR TITLE
fix: onHide error thrown on `ESC` press when `<UpdateVersionModal />` is open

### DIFF
--- a/client/components/common/BasicModal/index.jsx
+++ b/client/components/common/BasicModal/index.jsx
@@ -79,8 +79,8 @@ const BasicModal = ({
         id={`focus-trapped-${id}`}
         centered={centered}
         animation={animation}
-        onHide={useOnHide ? handleHide || handleClose : null}
-        onExit={!useOnHide ? handleHide || handleClose : null}
+        onHide={useOnHide ? handleHide || handleClose : () => {}}
+        onExit={!useOnHide ? handleHide || handleClose : () => {}}
         /* Disabled due to buggy implementation which jumps the page */
         autoFocus={false}
         aria-labelledby={`title-${id}`}


### PR DESCRIPTION
I was opening the `Manage Assistive Technology Versions` disclosure on the Test Queue page to add/edit AT verions. Found that if I hit `ESC` on my keyboard to close either modals, an error is thrown which reads `onHide is not a function` where the stacktrace points to a line inside `react-bootstrap`'s Modal component. Screenshot:

![Screenshot showing onHide error](https://github.com/user-attachments/assets/1f007d84-03bb-4003-86df-deafd6b4e572)

I confirmed this doesn't happen on production so my only guess is this error was introduced in #1148 when `react-bootstrap` was bumped from `2.7.0` to `2.10.4`. Although, nothing obvious jumps out at me when viewing the [release notes](https://github.com/react-bootstrap/react-bootstrap/releases).

This PR should restore the functionality that's on production (although I'm also wondering if the title refocus instead of closing the modal is intentional).