### PR TITLE
permit automated testing for firefox and chrome with voiceover

### DIFF
--- a/client/components/AddTestToQueueWithConfirmation/index.jsx
+++ b/client/components/AddTestToQueueWithConfirmation/index.jsx
@@ -166,7 +166,8 @@ function AddTestToQueueWithConfirmation({
           } catch (e) {
             console.error(e);
           }
-        }
+        },
+        testId: 'add-run-later'
       });
 
       if (!alreadyHasBotInTestPlanReport) {
@@ -186,7 +187,8 @@ function AddTestToQueueWithConfirmation({
             } catch (e) {
               console.error(e);
             }
-          }
+          },
+          testId: 'add-run-bot'
         });
       }
     }

--- a/client/components/common/BasicModal/index.jsx
+++ b/client/components/common/BasicModal/index.jsx
@@ -61,6 +61,7 @@ const BasicModal = ({
           variant={action.variant ?? 'primary'}
           onClick={action.onClick}
           className={action.className ?? ''}
+          data-testid={action.testId ?? ''}
         >
           {action.label ?? 'Continue'}
         </Button>
@@ -138,6 +139,7 @@ BasicModal.propTypes = {
       onClick: PropTypes.func,
       variant: PropTypes.string,
       className: PropTypes.string,
+      testId: PropTypes.string,
       component: PropTypes.elementType,
       props: PropTypes.object
     })

--- a/client/tests/AddTestToQueueWithConfirmation.test.jsx
+++ b/client/tests/AddTestToQueueWithConfirmation.test.jsx
@@ -111,6 +111,7 @@ describe('AddTestToQueueWithConfirmation', () => {
 
   test('calls mutation on button click with correct variables', async () => {
     fireEvent.click(getByTestId('add-button'));
+    fireEvent.click(await getByTestId('add-run-later'));
 
     await waitFor(() => {
       expect(mutationMock).toHaveBeenCalled();

--- a/client/utils/automation.js
+++ b/client/utils/automation.js
@@ -19,10 +19,13 @@ export const isSupportedByResponseCollector = ctx => {
   // Check if the AT and browser are supported by the automation
   const isNvdaWithSupportedBrowser =
     atKey === 'nvda' && (browserKey === 'chrome' || browserKey === 'firefox');
-  const isVoiceOverMacWithSafari =
-    atKey === 'voiceover_macos' && browserKey === 'safari_macos';
+  const isVoiceOverMacWithSupportedBrowser =
+    atKey === 'voiceover_macos' &&
+    (browserKey === 'safari_macos' ||
+      browserKey === 'chrome' ||
+      browserKey === 'firefox');
 
-  if (!isNvdaWithSupportedBrowser && !isVoiceOverMacWithSafari) {
+  if (!isNvdaWithSupportedBrowser && !isVoiceOverMacWithSupportedBrowser) {
     return false;
   }
 
@@ -89,7 +92,12 @@ export const getBotUsernameFromAtBrowser = (at, browser) => {
   ) {
     return 'NVDA Bot';
   }
-  if (at?.key === 'voiceover_macos' && browser?.key === 'safari_macos') {
+  if (
+    at?.key === 'voiceover_macos' &&
+    (browser?.key === 'safari_macos' ||
+      browser?.key === 'chrome' ||
+      browser?.key === 'firefox')
+  ) {
     return 'VoiceOver Bot';
   }
 };

--- a/server/services/GithubWorkflowService.js
+++ b/server/services/GithubWorkflowService.js
@@ -154,6 +154,7 @@ const createGithubWorkflow = async ({ job, directory, gitSha, atVersion }) => {
     // due to limitations on Github workflow runners
     // See https://github.com/w3c/aria-at-app/issues/1143 for more info
     inputs.macos_version = atVersion?.name?.split('.')[0];
+    inputs.browser = browser;
   }
   const axiosConfig = {
     method: 'POST',


### PR DESCRIPTION
This PR addresses #1171 

- updates logic to allow running automated tests for voiceover with firefox and chrome
- adds ability to pass test-ids into modal component buttons
- updates test for user flow changes with new browser support