### PR TITLE
Ensure that "Target Days X Past" is not included in snapshot

### DIFF
--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -694,12 +694,8 @@
                       ><span role="listitem" class="more-issues-container"
                         ><span class="issues css-fidnqg"></span>0 Open
                         Issues</span
-                      ><span class="target-days-container"
-                        ><button>
-                          Target&nbsp;<b>575 Days</b>&nbsp;Past
-                        </button></span
-                      ></span
-                    >
+                      ><span class="target-days-container"></span
+                    ></span>
                   </div>
                 </td>
                 <td><span class="css-wpichc">None Yet</span></td>

--- a/client/tests/e2e/snapshots/utils.js
+++ b/client/tests/e2e/snapshots/utils.js
@@ -35,14 +35,17 @@ async function cleanAndNormalizeSnapshot(page) {
         const text = el.textContent.trim();
         if (
           text.includes('Ready for Review') ||
-          text.includes('Review in Progress')
+          text.includes('Review in Progress') ||
+          (text.includes('Days') && text.includes('Past'))
         ) {
           el.remove();
         }
       });
     }
 
-    removeElements('.ready-for-review, .in-progress');
+    removeElements(
+      '.ready-for-review, .in-progress, .target-days-container button'
+    );
   });
 
   const content = await page.content();


### PR DESCRIPTION
This is the first day after merging the snapshot testing and I realized that there is another date consideration, the "Target Days X Past" values will increment by one with each day. This means that if we test this value we would need to update the snapshots daily.

Since this is a small fix needed for dev today, it only affects testing without any implications for the app, and the only applicable reviewer is out today I am going to merge once the tests pass. I can revert if there are issues created by this.

cc for when you're back online @howard-e 