### PR TITLE
Filter 'Days Away' in snapshots

### DIFF
--- a/client/tests/e2e/snapshots/utils.js
+++ b/client/tests/e2e/snapshots/utils.js
@@ -36,7 +36,8 @@ async function cleanAndNormalizeSnapshot(page) {
         if (
           text.includes('Ready for Review') ||
           text.includes('Review in Progress') ||
-          (text.includes('Days') && text.includes('Past'))
+          (text.includes('Days') &&
+            (text.includes('Past') || text.includes('Away')))
         ) {
           el.remove();
         }


### PR DESCRIPTION
Small change based on [this comment](https://github.com/w3c/aria-at-app/pull/1181#discussion_r1698569787). Now snapshots also filter 'Days Away' elements. This didn't affect current snapshots because all of the tested target days are in the past currently but this could change in the future.