### PR TITLE
Update testing snapshot cleaner to account for changing Run History date

### DIFF
--- a/client/components/common/RunHistory/index.js
+++ b/client/components/common/RunHistory/index.js
@@ -24,6 +24,7 @@ const RunHistory = ({ testPlanReports, testId }) => {
         if (testResult?.completedAt) {
           l.push(
             <RunListItem
+              className="run-history-item"
               key={`${testResult.atVersion.id}-${testResult.browserVersion.id}-${testResult.test.id}-${tester.username}`}
             >
               Tested with{' '}

--- a/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1.html
+++ b/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1.html
@@ -639,7 +639,7 @@
                               aria-labelledby="disclosure-btn-test-instructions-and-results-Run History"
                               class="css-19fsyrg">
                               <ul style="margin-bottom: 0px">
-                                <li class="css-j662fd">
+                                <li class="run-history-item css-j662fd">
                                   Tested with <b>JAWS 2021.2111.13</b> and
                                   <b>Chrome 99.0.4844.84</b> by
                                   <b
@@ -648,7 +648,6 @@
                                       >esmeralda-baggins</a
                                     ></b
                                   >
-                                  on August 14, 2024.
                                 </li>
                               </ul>
                             </div>

--- a/client/tests/e2e/snapshots/utils.js
+++ b/client/tests/e2e/snapshots/utils.js
@@ -41,11 +41,21 @@ async function cleanAndNormalizeSnapshot(page) {
         ) {
           el.remove();
         }
+
+        // Confirm text is from Run History component
+        if (
+          text.includes('Tested with') &&
+          text.includes('and') &&
+          text.includes('by') &&
+          text.includes('on')
+        ) {
+          el.innerHTML = el.innerHTML.replace(/on [^<]*$/, '');
+        }
       });
     }
 
     removeElements(
-      '.ready-for-review, .in-progress, .target-days-container button'
+      '.ready-for-review, .in-progress, .target-days-container button, .run-history-item'
     );
   });
 


### PR DESCRIPTION
Based on the [latest build's push to `development`](https://github.com/w3c/aria-at-app/actions/runs/10404400325/job/28812810708), the Candidate Test Run snapshot will fail on every new date when the populate script is ran, because of how the Run History is evaluated.

Here is an attempt at updating the cleaner to account for this dynamism.