### PR TITLE
Enhanced conflict review [extended]

### DIFF
--- a/client/components/TestQueue/AssignTesters.jsx
+++ b/client/components/TestQueue/AssignTesters.jsx
@@ -94,7 +94,7 @@ const AssignTesters = ({ me, testers, testPlanReport }) => {
 
   const onKeyDown = event => {
     const { key } = event;
-    if (key.match(/[0-9a-zA-Z]/)) {
+    if (key.length === 1 && key.match(/[a-zA-Z0-9]/)) {
       const container = event.target.closest('[role=menu]');
       const matchingMenuItem = Array.from(container.children).find(menuItem => {
         return menuItem.innerText

--- a/client/components/TestQueue/Conflicts/index.jsx
+++ b/client/components/TestQueue/Conflicts/index.jsx
@@ -3,13 +3,12 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Container } from 'react-bootstrap';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
+import styled from '@emotion/styled';
 import { TEST_QUEUE_CONFLICTS_PAGE_QUERY } from '../queries';
 import PageStatus from '../../common/PageStatus';
 import DisclosureComponent from '../../common/DisclosureComponent';
 import ConflictSummaryTable from './ConflictSummaryTable';
 import createIssueLink from '../../../utils/createIssueLink';
-import { dates } from 'shared';
-import styled from '@emotion/styled';
 import { evaluateAuth } from '../../../utils/evaluateAuth';
 
 const PageContainer = styled(Container)`
@@ -85,17 +84,16 @@ const TestQueueConflicts = () => {
     return createIssueLink({
       testPlanTitle: testPlanVersion.title,
       testPlanDirectory: testPlanVersion.testPlan.directory,
-      versionString: `V${dates.convertDateToString(
-        testPlanVersion.updatedAt,
-        'YY.MM.DD'
-      )}`,
+      versionString: testPlanVersion.versionString,
       testTitle: conflict.conflictingResults[0].test.title,
       testRowNumber: conflict.conflictingResults[0].test.rowNumber,
       testSequenceNumber: getConflictTestNumberFilteredByAt(conflict),
       testRenderedUrl: conflict.conflictingResults[0].test.renderedUrl,
       atName: data.testPlanReport.at.name,
       browserName: data.testPlanReport.browser.name,
-      atVersionName: data.testPlanReport.requiredAtVersion?.name
+      atVersionName: data.testPlanReport.exactAtVersion?.name
+        ? data.testPlanReport.exactAtVersion?.name
+        : `${data.testPlanReport.minimumAtVersion?.name} and above`
     });
   };
 
@@ -162,8 +160,8 @@ const TestQueueConflicts = () => {
   } = data?.testPlanReport.testPlanVersion ?? {};
   const { name: browserName } = data?.testPlanReport.browser ?? {};
   const { name: atName } = data?.testPlanReport.at ?? {};
-  const { name: requiredAtVersionName } =
-    data?.testPlanReport.requiredAtVersion ?? {};
+  const { name: exactAtVersionName } =
+    data?.testPlanReport.exactAtVersion ?? {};
   const { name: minimumAtVersionName } =
     data?.testPlanReport.minimumAtVersion ?? {};
 
@@ -199,8 +197,8 @@ const TestQueueConflicts = () => {
           <MetadataItem>
             <MetadataLabel>Assistive Technology:</MetadataLabel>
             {atName}
-            {requiredAtVersionName
-              ? ` (${requiredAtVersionName})`
+            {exactAtVersionName
+              ? ` (${exactAtVersionName})`
               : ` (${minimumAtVersionName} and above)`}
           </MetadataItem>
           <MetadataItem>

--- a/client/components/TestQueue/Conflicts/index.jsx
+++ b/client/components/TestQueue/Conflicts/index.jsx
@@ -102,7 +102,11 @@ const TestQueueConflicts = () => {
   const disclosureLabels = useMemo(() => {
     return data?.testPlanReport?.conflicts?.map(conflict => {
       const testIndex = getConflictTestNumberFilteredByAt(conflict);
-      return `Test ${testIndex}: ${conflict.conflictingResults[0].test.title}`;
+      return `Test ${testIndex}: ${
+        conflict.conflictingResults[0].test.title
+      } (${conflict.conflictingResults[0].scenario.commands
+        .map(({ text }) => text)
+        .join(' then ')})`;
     });
   }, [data?.testPlanReport?.conflicts]);
 

--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -131,6 +131,11 @@ export const TEST_QUEUE_CONFLICTS_PAGE_QUERY = gql`
             title
             renderedUrl
           }
+          scenario {
+            commands {
+              text
+            }
+          }
           scenarioResult {
             output
             unexpectedBehaviors {

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -1087,7 +1087,7 @@
                 <td>
                   <div class="css-bpz90">
                     <span class="rd full-width css-be9e2a">R&amp;D</span>
-                    <p class="review-text">Complete <b>Aug 12, 2024</b></p>
+                    <p class="review-text">Complete <b>Aug 21, 2024</b></p>
                   </div>
                 </td>
                 <td>
@@ -1110,7 +1110,7 @@
                             <path
                               fill="currentColor"
                               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V24.08.12</b></span
+                          ><b>V24.08.21</b></span
                         ></a
                       ></span
                     ><button

--- a/client/tests/e2e/snapshots/saved/_test-queue_2_conflicts.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue_2_conflicts.html
@@ -109,19 +109,20 @@
           <section class="css-xz63dn">
             <h2 class="css-wndajv">Conflicts</h2>
             <p class="css-1unwn3">
-              There are currently<strong> 3 conflicts </strong>for this test
-              plan report.
+              There are currently<strong> 3 conflicts </strong>across<strong>
+                3 tests </strong
+              >and<strong> 3 assertions </strong>for this test plan report.
             </p>
             <div class="css-5akihl">
               <h3>
                 <button
-                  id="disclosure-btn-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode"
+                  id="disclosure-btn-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode (Shift+Tab)"
                   type="button"
-                  aria-controls="disclosure-btn-controls-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode"
-                  class="css-10jxhio"
-                  aria-expanded="false">
+                  aria-expanded="false"
+                  aria-controls="disclosure-btn-controls-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode (Shift+Tab)"
+                  class="css-10jxhio">
                   Test 4: Navigate backwards to a collapsed select-only combobox
-                  in interaction mode<svg
+                  in interaction mode (Shift+Tab)<svg
                     aria-hidden="true"
                     focusable="false"
                     data-prefix="fas"
@@ -138,8 +139,8 @@
               </h3>
               <div
                 role="region"
-                id="disclosure-container-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode"
-                aria-labelledby="disclosure-btn-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode"
+                id="disclosure-container-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode (Shift+Tab)"
+                aria-labelledby="disclosure-btn-undefined-Test 4: Navigate backwards to a collapsed select-only combobox in interaction mode (Shift+Tab)"
                 class="css-19fsyrg">
                 <div class="table-responsive">
                   <table class="css-1o41lau table table-bordered">
@@ -236,7 +237,7 @@
                   <a
                     role="button"
                     tabindex="0"
-                    href="https://github.com/bocoup/aria-at/issues/new?title=Feedback:%20%22Navigate%20backwards%20to%20a%20collapsed%20select-only%20combobox%20in%20interaction%20mode%22%20(Select%20Only%20Combobox%20Example,%20Test%204,%20V)&amp;labels=nvda,feedback&amp;body=%23%23%20Description%20of%20Behavior%0A%0A%3C!--%20Write%20your%20description%20here%20--%3E%0A%0A%23%23%20Test%20Setup%0A%0A-%20Test%20File%3A%20%5Btest-04-navigate-backwards-to-collapsed-select-only-combobox-interaction-nvda.collected.html%5D(https%3A%2F%2Faria-at.netlify.app%2Ftests%2Fcombobox-select-only%2Ftest-04-navigate-backwards-to-collapsed-select-only-combobox-interaction-nvda.collected.html)%0A-%20AT%3A%20NVDA%0A-%20Browser%3A%20Firefox%0A%0A%3C!--%20The%20following%20data%20allows%20the%20issue%20to%20be%20imported%20into%20the%20ARIA%20AT%20App%20--%3E%0A%3C!--%20ARIA_AT_APP_ISSUE_DATA%20%3D%20%7B%22testPlanDirectory%22%3A%22combobox-select-only%22%2C%22versionString%22%3A%22V%22%2C%22atName%22%3A%22NVDA%22%2C%22browserName%22%3A%22Firefox%22%2C%22testRowNumber%22%3A4%2C%22testSequenceNumber%22%3A4%2C%22isCandidateReview%22%3Afalse%2C%22isCandidateReviewChangesRequested%22%3Afalse%7D%20--%3E"
+                    href="https://github.com/bocoup/aria-at/issues/new?title=Feedback:%20%22Navigate%20backwards%20to%20a%20collapsed%20select-only%20combobox%20in%20interaction%20mode%22%20(Select%20Only%20Combobox%20Example,%20Test%204,%20V22.03.17)&amp;labels=nvda,feedback&amp;body=%23%23%20Description%20of%20Behavior%0A%0A%3C!--%20Write%20your%20description%20here%20--%3E%0A%0A%23%23%20Test%20Setup%0A%0A-%20Test%20File%3A%20%5Btest-04-navigate-backwards-to-collapsed-select-only-combobox-interaction-nvda.collected.html%5D(https%3A%2F%2Faria-at.netlify.app%2Ftests%2Fcombobox-select-only%2Ftest-04-navigate-backwards-to-collapsed-select-only-combobox-interaction-nvda.collected.html)%0A-%20AT%3A%20NVDA%20(Version%202020.4%20and%20above)%0A-%20Browser%3A%20Firefox%0A%0A%3C!--%20The%20following%20data%20allows%20the%20issue%20to%20be%20imported%20into%20the%20ARIA%20AT%20App%20--%3E%0A%3C!--%20ARIA_AT_APP_ISSUE_DATA%20%3D%20%7B%22testPlanDirectory%22%3A%22combobox-select-only%22%2C%22versionString%22%3A%22V22.03.17%22%2C%22atName%22%3A%22NVDA%22%2C%22browserName%22%3A%22Firefox%22%2C%22testRowNumber%22%3A4%2C%22testSequenceNumber%22%3A4%2C%22isCandidateReview%22%3Afalse%2C%22isCandidateReviewChangesRequested%22%3Afalse%7D%20--%3E%0A%0A%23%23%20Review%20Conflicts%20for%20%22Navigate%20backwards%20to%20a%20collapsed%20select-only%20combobox%20in%20interaction%20mode%22%0A%0A1.%20%23%23%23%20Assertion%20Results%20for%20%22Shift%2BTab%22%20Command%20and%20%22Role%20'combobox'%20is%20conveyed%22%20Assertion%0A-%20Tester%20esmeralda-baggins%20recorded%20output%20%22automatically%20seeded%20sample%20output%22%20and%20marked%20assertion%20as%20passing%0A-%20Tester%20tom-proudfeet%20recorded%20output%20%22automatically%20seeded%20sample%20output%22%20and%20marked%20assertion%20as%20failing"
                     target="_blank"
                     class="btn btn-secondary"
                     ><svg
@@ -277,13 +278,13 @@
               </div>
               <h3>
                 <button
-                  id="disclosure-btn-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode"
+                  id="disclosure-btn-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode (Insert+Tab)"
                   type="button"
-                  aria-controls="disclosure-btn-controls-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode"
-                  class="css-10jxhio"
-                  aria-expanded="false">
+                  aria-expanded="false"
+                  aria-controls="disclosure-btn-controls-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode (Insert+Tab)"
+                  class="css-10jxhio">
                   Test 6: Read information about a collapsed select-only
-                  combobox in interaction mode<svg
+                  combobox in interaction mode (Insert+Tab)<svg
                     aria-hidden="true"
                     focusable="false"
                     data-prefix="fas"
@@ -300,8 +301,8 @@
               </h3>
               <div
                 role="region"
-                id="disclosure-container-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode"
-                aria-labelledby="disclosure-btn-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode"
+                id="disclosure-container-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode (Insert+Tab)"
+                aria-labelledby="disclosure-btn-undefined-Test 6: Read information about a collapsed select-only combobox in interaction mode (Insert+Tab)"
                 class="css-19fsyrg">
                 <div class="table-responsive">
                   <table class="css-1o41lau table table-bordered">
@@ -328,7 +329,7 @@
                   <a
                     role="button"
                     tabindex="0"
-                    href="https://github.com/bocoup/aria-at/issues/new?title=Feedback:%20%22Read%20information%20about%20a%20collapsed%20select-only%20combobox%20in%20interaction%20mode%22%20(Select%20Only%20Combobox%20Example,%20Test%206,%20V)&amp;labels=nvda,feedback&amp;body=%23%23%20Description%20of%20Behavior%0A%0A%3C!--%20Write%20your%20description%20here%20--%3E%0A%0A%23%23%20Test%20Setup%0A%0A-%20Test%20File%3A%20%5Btest-08-read-information-about-collapsed-select-only-combobox-interaction-nvda.collected.html%5D(https%3A%2F%2Faria-at.netlify.app%2Ftests%2Fcombobox-select-only%2Ftest-08-read-information-about-collapsed-select-only-combobox-interaction-nvda.collected.html)%0A-%20AT%3A%20NVDA%0A-%20Browser%3A%20Firefox%0A%0A%3C!--%20The%20following%20data%20allows%20the%20issue%20to%20be%20imported%20into%20the%20ARIA%20AT%20App%20--%3E%0A%3C!--%20ARIA_AT_APP_ISSUE_DATA%20%3D%20%7B%22testPlanDirectory%22%3A%22combobox-select-only%22%2C%22versionString%22%3A%22V%22%2C%22atName%22%3A%22NVDA%22%2C%22browserName%22%3A%22Firefox%22%2C%22testRowNumber%22%3A8%2C%22testSequenceNumber%22%3A6%2C%22isCandidateReview%22%3Afalse%2C%22isCandidateReviewChangesRequested%22%3Afalse%7D%20--%3E"
+                    href="https://github.com/bocoup/aria-at/issues/new?title=Feedback:%20%22Read%20information%20about%20a%20collapsed%20select-only%20combobox%20in%20interaction%20mode%22%20(Select%20Only%20Combobox%20Example,%20Test%206,%20V22.03.17)&amp;labels=nvda,feedback&amp;body=%23%23%20Description%20of%20Behavior%0A%0A%3C!--%20Write%20your%20description%20here%20--%3E%0A%0A%23%23%20Test%20Setup%0A%0A-%20Test%20File%3A%20%5Btest-08-read-information-about-collapsed-select-only-combobox-interaction-nvda.collected.html%5D(https%3A%2F%2Faria-at.netlify.app%2Ftests%2Fcombobox-select-only%2Ftest-08-read-information-about-collapsed-select-only-combobox-interaction-nvda.collected.html)%0A-%20AT%3A%20NVDA%20(Version%202020.4%20and%20above)%0A-%20Browser%3A%20Firefox%0A%0A%3C!--%20The%20following%20data%20allows%20the%20issue%20to%20be%20imported%20into%20the%20ARIA%20AT%20App%20--%3E%0A%3C!--%20ARIA_AT_APP_ISSUE_DATA%20%3D%20%7B%22testPlanDirectory%22%3A%22combobox-select-only%22%2C%22versionString%22%3A%22V22.03.17%22%2C%22atName%22%3A%22NVDA%22%2C%22browserName%22%3A%22Firefox%22%2C%22testRowNumber%22%3A8%2C%22testSequenceNumber%22%3A6%2C%22isCandidateReview%22%3Afalse%2C%22isCandidateReviewChangesRequested%22%3Afalse%7D%20--%3E%0A%0A%23%23%20Review%20Conflicts%20for%20%22Read%20information%20about%20a%20collapsed%20select-only%20combobox%20in%20interaction%20mode%22%0A%0A1.%20%23%23%23%20Unexpected%20Behaviors%20Results%20for%20%22Insert%2BTab%22%20Command%0A-%20Tester%20tom-proudfeet%20recorded%20output%20%22automatically%20seeded%20sample%20output%22%20and%20noted%20%22Other%20(Details%3A%20Seeded%20other%20unexpected%20behavior%2C%20Impact%3A%20MODERATE)%22"
                     target="_blank"
                     class="btn btn-secondary"
                     ><svg
@@ -369,13 +370,13 @@
               </div>
               <h3>
                 <button
-                  id="disclosure-btn-undefined-Test 7: Open a collapsed select-only combobox in reading mode"
+                  id="disclosure-btn-undefined-Test 7: Open a collapsed select-only combobox in reading mode (Alt+Down)"
                   type="button"
-                  aria-controls="disclosure-btn-controls-undefined-Test 7: Open a collapsed select-only combobox in reading mode"
-                  class="css-10jxhio"
-                  aria-expanded="false">
-                  Test 7: Open a collapsed select-only combobox in reading
-                  mode<svg
+                  aria-expanded="false"
+                  aria-controls="disclosure-btn-controls-undefined-Test 7: Open a collapsed select-only combobox in reading mode (Alt+Down)"
+                  class="css-10jxhio">
+                  Test 7: Open a collapsed select-only combobox in reading mode
+                  (Alt+Down)<svg
                     aria-hidden="true"
                     focusable="false"
                     data-prefix="fas"
@@ -392,8 +393,8 @@
               </h3>
               <div
                 role="region"
-                id="disclosure-container-undefined-Test 7: Open a collapsed select-only combobox in reading mode"
-                aria-labelledby="disclosure-btn-undefined-Test 7: Open a collapsed select-only combobox in reading mode"
+                id="disclosure-container-undefined-Test 7: Open a collapsed select-only combobox in reading mode (Alt+Down)"
+                aria-labelledby="disclosure-btn-undefined-Test 7: Open a collapsed select-only combobox in reading mode (Alt+Down)"
                 class="css-19fsyrg">
                 <div class="table-responsive">
                   <table class="css-1o41lau table table-bordered">
@@ -430,7 +431,7 @@
                   <a
                     role="button"
                     tabindex="0"
-                    href="https://github.com/bocoup/aria-at/issues/new?title=Feedback:%20%22Open%20a%20collapsed%20select-only%20combobox%20in%20reading%20mode%22%20(Select%20Only%20Combobox%20Example,%20Test%207,%20V)&amp;labels=nvda,feedback&amp;body=%23%23%20Description%20of%20Behavior%0A%0A%3C!--%20Write%20your%20description%20here%20--%3E%0A%0A%23%23%20Test%20Setup%0A%0A-%20Test%20File%3A%20%5Btest-10-open-collapsed-select-only-combobox-reading-nvda.collected.html%5D(https%3A%2F%2Faria-at.netlify.app%2Ftests%2Fcombobox-select-only%2Ftest-10-open-collapsed-select-only-combobox-reading-nvda.collected.html)%0A-%20AT%3A%20NVDA%0A-%20Browser%3A%20Firefox%0A%0A%3C!--%20The%20following%20data%20allows%20the%20issue%20to%20be%20imported%20into%20the%20ARIA%20AT%20App%20--%3E%0A%3C!--%20ARIA_AT_APP_ISSUE_DATA%20%3D%20%7B%22testPlanDirectory%22%3A%22combobox-select-only%22%2C%22versionString%22%3A%22V%22%2C%22atName%22%3A%22NVDA%22%2C%22browserName%22%3A%22Firefox%22%2C%22testRowNumber%22%3A10%2C%22testSequenceNumber%22%3A7%2C%22isCandidateReview%22%3Afalse%2C%22isCandidateReviewChangesRequested%22%3Afalse%7D%20--%3E"
+                    href="https://github.com/bocoup/aria-at/issues/new?title=Feedback:%20%22Open%20a%20collapsed%20select-only%20combobox%20in%20reading%20mode%22%20(Select%20Only%20Combobox%20Example,%20Test%207,%20V22.03.17)&amp;labels=nvda,feedback&amp;body=%23%23%20Description%20of%20Behavior%0A%0A%3C!--%20Write%20your%20description%20here%20--%3E%0A%0A%23%23%20Test%20Setup%0A%0A-%20Test%20File%3A%20%5Btest-10-open-collapsed-select-only-combobox-reading-nvda.collected.html%5D(https%3A%2F%2Faria-at.netlify.app%2Ftests%2Fcombobox-select-only%2Ftest-10-open-collapsed-select-only-combobox-reading-nvda.collected.html)%0A-%20AT%3A%20NVDA%20(Version%202020.4%20and%20above)%0A-%20Browser%3A%20Firefox%0A%0A%3C!--%20The%20following%20data%20allows%20the%20issue%20to%20be%20imported%20into%20the%20ARIA%20AT%20App%20--%3E%0A%3C!--%20ARIA_AT_APP_ISSUE_DATA%20%3D%20%7B%22testPlanDirectory%22%3A%22combobox-select-only%22%2C%22versionString%22%3A%22V22.03.17%22%2C%22atName%22%3A%22NVDA%22%2C%22browserName%22%3A%22Firefox%22%2C%22testRowNumber%22%3A10%2C%22testSequenceNumber%22%3A7%2C%22isCandidateReview%22%3Afalse%2C%22isCandidateReviewChangesRequested%22%3Afalse%7D%20--%3E%0A%0A%23%23%20Review%20Conflicts%20for%20%22Open%20a%20collapsed%20select-only%20combobox%20in%20reading%20mode%22%0A%0A1.%20%23%23%23%20Unexpected%20Behaviors%20Results%20for%20%22Alt%2BDown%22%20Command%0A-%20Tester%20tom-proudfeet%20recorded%20output%20%22automatically%20seeded%20sample%20output%22%20and%20noted%20%22Output%20is%20excessively%20verbose%2C%20e.g.%2C%20includes%20redundant%20and%2For%20irrelevant%20speech%20(Details%3A%20N%2FA%2C%20Impact%3A%20MODERATE)%22%20and%20%22Other%20(Details%3A%20Seeded%20other%20unexpected%20behavior%2C%20Impact%3A%20SEVERE)%22"
                     target="_blank"
                     class="btn btn-secondary"
                     ><svg

--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -17,6 +17,7 @@
     path: '{{source_dir}}/server/scripts'
     mode: '0777'
     recurse: yes
+  become: yes
   when: deployment_mode != 'development'
   notify: "restart server"
 
@@ -25,6 +26,7 @@
     path: '{{source_dir}}/server/resources'
     mode: '0777'
     recurse: yes
+  become: yes
   when: deployment_mode != 'development'
   notify: "restart server"
 
@@ -33,6 +35,7 @@
     path: '{{source_dir}}/client/resources'
     mode: '0777'
     recurse: yes
+  become: yes
   when: deployment_mode != 'development'
   notify: "restart server"
 
@@ -86,6 +89,7 @@
 
 - name: Import latest tests and harness from w3c/aria-at
   shell: ../deploy/scripts/export-and-exec.sh {{environment_config.dest}} node ./scripts/import-tests/index.js
+  become: yes
   args:
     chdir: '{{source_dir}}/server'
 

--- a/deploy/roles/nodejs/tasks/main.yml
+++ b/deploy/roles/nodejs/tasks/main.yml
@@ -25,7 +25,6 @@
     name:
       - nodejs
       - yarn
-      - npm
     state: present
   become: yes
 


### PR DESCRIPTION
@stalgiag while doing additional checks on #1195, noticed a few usability concerns that I've addressed in this PR that I had originally missed:

* Include versionString in issue body and title when creating from `/conflicts`
* The `requiredAtVersionName` variable was incorrect. Changed to using `exactAtVersionName`
* Updated the disclosures to be unique by commands per test, otherwise the same conflict was being duplicated if tester1 and tester2 had different results for assertion1 and assertion2 in the same test (each difference counts as conflict which was being mapped over in the view)
* Added support for the markdown conflict being included from the Raise an Issue for Conflict button