### PR TITLE
Address incorrect aria-at harness path being updated during API updates on deployment environments

### DIFF
--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -257,19 +257,19 @@
                       <option value="49">Main Landmark</option>
                       <option value="60">Media Seek Slider</option>
                       <option value="54">Meter</option>
-                      <option value="86">Modal Dialog Example</option>
-                      <option value="52">Navigation Menu Button</option>
+                      <option value="87">Modal Dialog Example</option>
+                      <option value="86">Navigation Menu Button</option>
                       <option value="74">
                         Radio Group Example Using Roving tabindex
                       </option>
-                      <option value="87">
+                      <option value="88">
                         Radio Group Example Using aria-activedescendant
                       </option>
                       <option value="59">Rating Slider</option>
                       <option value="7">Select Only Combobox Example</option>
                       <option value="61">Switch Example</option>
                       <option value="62">Tabs with Manual Activation</option>
-                      <option value="88">Toggle Button</option>
+                      <option value="89">Toggle Button</option>
                       <option value="64">Vertical Temperature Slider</option>
                     </select>
                   </div>
@@ -623,7 +623,7 @@
                     <span
                       class="full-width auto-width css-36z7cz"
                       role="listitem"
-                      ><a href="/test-review/86"
+                      ><a href="/test-review/87"
                         ><span
                           ><svg
                             aria-hidden="true"
@@ -1005,7 +1005,7 @@
                     <span
                       class="full-width auto-width css-36z7cz"
                       role="listitem"
-                      ><a href="/test-review/88"
+                      ><a href="/test-review/89"
                         ><span
                           ><svg
                             aria-hidden="true"
@@ -2232,7 +2232,7 @@
                 <td>
                   <div class="css-bpz90">
                     <span class="rd full-width css-be9e2a">R&amp;D</span>
-                    <p class="review-text">Complete <b>May 26, 2022</b></p>
+                    <p class="review-text">Complete <b>Sep 19, 2024</b></p>
                   </div>
                 </td>
                 <td>
@@ -2240,7 +2240,7 @@
                     <span
                       class="full-width auto-width css-36z7cz"
                       role="listitem"
-                      ><a href="/test-review/52"
+                      ><a href="/test-review/86"
                         ><span
                           ><svg
                             aria-hidden="true"
@@ -2255,7 +2255,7 @@
                             <path
                               fill="currentColor"
                               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V22.05.26</b></span
+                          ><b>V24.09.19</b></span
                         ></a
                       ></span
                     ><button
@@ -2344,7 +2344,7 @@
                     <span
                       class="full-width auto-width css-36z7cz"
                       role="listitem"
-                      ><a href="/test-review/87"
+                      ><a href="/test-review/88"
                         ><span
                           ><svg
                             aria-hidden="true"

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -208,7 +208,7 @@
                       <option value="1">Alert Example</option>
                       <option value="67">Checkbox Example (Mixed-State)</option>
                       <option value="68">Command Button Example</option>
-                      <option value="86">Modal Dialog Example</option>
+                      <option value="87">Modal Dialog Example</option>
                       <option value="7">Select Only Combobox Example</option>
                       <option value="31">Toggle Button</option>
                     </select>
@@ -553,7 +553,7 @@
               aria-labelledby="disclosure-btn-modal-dialog-0"
               class="css-19fsyrg">
               <div class="css-25wfk">
-                <a href="/test-review/86"
+                <a href="/test-review/87"
                   ><svg
                     aria-hidden="true"
                     focusable="false"

--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -10,6 +10,15 @@
 
 - include: upload-source-code.yml
 
+- name: Allow aria-bot user to run import script as admin on sandbox
+  lineinfile:
+    path: /etc/sudoers
+    state: present
+    line: 'aria-bot ALL=(ALL) NOPASSWD:{{source_dir}}/deploy/scripts/export-and-exec.sh'
+    validate: 'visudo -cf %s'
+  become: yes
+  when: deployment_mode == 'sandbox'
+
 # TODO: these permissions changes are a workaround solution
 
 - name: Make server scripts folder writable for import tests API endpoint

--- a/server/controllers/TestController.js
+++ b/server/controllers/TestController.js
@@ -10,7 +10,7 @@ async function importTests(req, res) {
     console.log(error.message);
     // This is when the script fails because the git hash is invalid
     // Sending semantic error.
-    res.sendStatus(422);
+    res.status(422).send(error.message);
   }
 }
 

--- a/server/scripts/import-tests/testPlanVersionOperations.js
+++ b/server/scripts/import-tests/testPlanVersionOperations.js
@@ -236,8 +236,15 @@ const processTestPlanVersion = async ({
  */
 const importHarness = () => {
   const sourceFolder = path.resolve(`${testsDirectory}/resources`);
-  const targetFolder = path.resolve('../', 'client/resources');
-  console.info(`Updating harness directory, ${targetFolder} ...`);
+  const targetFolder = path.resolve(
+    __dirname,
+    '../../../',
+    'client',
+    'resources'
+  );
+  console.info(
+    `Updating harness directory, copying from ${sourceFolder} to ${targetFolder} ...`
+  );
   fse.rmSync(targetFolder, { recursive: true, force: true });
 
   // Copy source folder

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -11,6 +11,7 @@ async function runImportScript(git_hash) {
     let importScriptDirectoryPrefix = isDevelopmentProcess ? '.' : './server';
     let command = `${deployDirectoryPrefix}/deploy/scripts/export-and-exec.sh ${process.env.IMPORT_CONFIG} node ${importScriptDirectoryPrefix}/scripts/import-tests/index.js`;
     if (git_hash) command += ` -c ${git_hash}`;
+    if (process.env.ENVIRONMENT === 'sandbox') command = `sudo ${command}`;
     exec(command, (error, stdout, stderr) => {
       if (error) {
         reject(error);


### PR DESCRIPTION
Fixes issue where the import script API (and cron job) would put the updated harness files into `<PROJECT_ROOT>/../client/resources` instead of `PROJECT_ROOT/client/resources`. The resources were properly placed during a deployment, and remain unaffected.

Also had to make adjustments to support the resources being updated on the current sandbox environment.