### PR TITLE
Allow public viewing for Conflicts Page

### DIFF
--- a/client/components/TestPlanReportStatusDialog/index.jsx
+++ b/client/components/TestPlanReportStatusDialog/index.jsx
@@ -60,7 +60,6 @@ const TestPlanReportStatusDialog = ({
           <ReportStatusSummary
             testPlanVersion={testPlanVersion}
             testPlanReport={testPlanReport}
-            me={me}
           />
           {isSignedIn && isAdmin && !testPlanReport ? (
             <AddTestToQueueWithConfirmation

--- a/client/components/TestQueue/Conflicts/TestConflictsActions.jsx
+++ b/client/components/TestQueue/Conflicts/TestConflictsActions.jsx
@@ -29,31 +29,36 @@ const ActionButton = styled(Button)`
   margin: 0;
 `;
 
-const TestConflictsActions = ({ issueLink, isAdmin, testPlanRuns }) => {
+const TestConflictsActions = ({
+  issueLink,
+  isAdmin,
+  testPlanRuns,
+  testIndex
+}) => {
+  const openResultsLabel = isAdmin ? 'Open run as...' : 'View Results for...';
+
   return (
     <ActionContainer>
       <Button variant="secondary" target="_blank" href={issueLink}>
         <FontAwesomeIcon icon={faExclamationCircle} />
         Raise an Issue for Conflict
       </Button>
-      {isAdmin && (
-        <Dropdown>
-          <Dropdown.Toggle variant="secondary" as={ActionButton}>
-            <FontAwesomeIcon icon={faFileImport} />
-            Open run as...
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            {testPlanRuns.map(testPlanRun => (
-              <Dropdown.Item
-                key={testPlanRun.id}
-                href={`/run/${testPlanRun.id}?user=${testPlanRun.tester.id}`}
-              >
-                {testPlanRun.tester.username}
-              </Dropdown.Item>
-            ))}
-          </Dropdown.Menu>
-        </Dropdown>
-      )}
+      <Dropdown>
+        <Dropdown.Toggle variant="secondary" as={ActionButton}>
+          <FontAwesomeIcon icon={faFileImport} />
+          {openResultsLabel}
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          {testPlanRuns.map(testPlanRun => (
+            <Dropdown.Item
+              key={testPlanRun.id}
+              href={`/run/${testPlanRun.id}?user=${testPlanRun.tester.id}#${testIndex}`}
+            >
+              {testPlanRun.tester.username}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+      </Dropdown>
     </ActionContainer>
   );
 };

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -332,7 +332,6 @@ const TestQueue = () => {
             <ReportStatusSummary
               testPlanVersion={testPlanVersion}
               testPlanReport={testPlanReport}
-              me={data.me}
               fromTestQueue
             />
             {hasBotRun ? (

--- a/client/components/common/ReportStatusSummary/index.jsx
+++ b/client/components/common/ReportStatusSummary/index.jsx
@@ -8,7 +8,6 @@ import {
   TestPlanRunPropType,
   UserPropType
 } from '../proptypes';
-import { evaluateAuth } from '../../../utils/evaluateAuth';
 
 const IncompleteStatusReport = styled.span`
   min-width: 5rem;
@@ -18,11 +17,8 @@ const IncompleteStatusReport = styled.span`
 const ReportStatusSummary = ({
   testPlanVersion,
   testPlanReport,
-  me,
   fromTestQueue = false
 }) => {
-  const { isSignedIn, isAdmin, isTester, isVendor } = evaluateAuth(me);
-
   const renderCompleteReportStatus = testPlanReport => {
     const formattedDate = dates.convertDateToString(
       testPlanReport.markedFinalAt,
@@ -37,8 +33,6 @@ const ReportStatusSummary = ({
 
   const getConflictsAnchor = conflictsCount => {
     if (conflictsCount === 0) return null;
-    if (!isSignedIn) return null;
-    if (!isTester && !isVendor && !isAdmin) return null;
     return (
       <a
         style={{ color: '#ce1b4c' }}

--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -42,11 +42,7 @@ export default () => (
     <Route
       exact
       path="/test-queue/:testPlanReportId/conflicts"
-      element={
-        <ConfirmAuth requiredPermission="TESTER">
-          <TestQueueConflicts />
-        </ConfirmAuth>
-      }
+      element={<TestQueueConflicts />}
     />
     <Route
       exact


### PR DESCRIPTION
After additional discussions with the CG, this should be supported and I was wrong in https://github.com/w3c/aria-at-app/pull/1195#discussion_r1722498164 so this change mainly reverts that commit.

Also noticed a small bug with the indexing not being done when opening a test from the Conflicts page.