### PR TITLE
`aria-at` harness path permission updates for `staging` and `production` environments

### DIFF
--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -17,7 +17,7 @@
     line: 'aria-bot ALL=(ALL) NOPASSWD:{{source_dir}}/deploy/scripts/export-and-exec.sh'
     validate: 'visudo -cf %s'
   become: yes
-  when: deployment_mode == 'sandbox'
+  when: deployment_mode != 'development'
 
 # TODO: these permissions changes are a workaround solution
 

--- a/server/services/TestService.js
+++ b/server/services/TestService.js
@@ -11,7 +11,13 @@ async function runImportScript(git_hash) {
     let importScriptDirectoryPrefix = isDevelopmentProcess ? '.' : './server';
     let command = `${deployDirectoryPrefix}/deploy/scripts/export-and-exec.sh ${process.env.IMPORT_CONFIG} node ${importScriptDirectoryPrefix}/scripts/import-tests/index.js`;
     if (git_hash) command += ` -c ${git_hash}`;
-    if (process.env.ENVIRONMENT === 'sandbox') command = `sudo ${command}`;
+    if (
+      process.env.ENVIRONMENT === 'sandbox' ||
+      process.env.ENVIRONMENT === 'staging' ||
+      process.env.ENVIRONMENT === 'production'
+    ) {
+      command = `sudo ${command}`;
+    }
     exec(command, (error, stdout, stderr) => {
       if (error) {
         reject(error);


### PR DESCRIPTION
Apply the same in #1212 for the `sandbox` environment to `staging` and `production` as well to ensure the correct aria-at harness path is updated during API updates