### PR TITLE
fix: Change `Issue.testNumberFilteredByAt` type from Int to Float

### DIFF
--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1013,7 +1013,7 @@ const graphqlSchema = gql`
     """
     Test Number the issue was raised for.
     """
-    testNumberFilteredByAt: Int
+    testNumberFilteredByAt: Float
     """
     The time the issue was created, according to GitHub.
     """


### PR DESCRIPTION
Fixes app's GitHub Issue search non-integer error being thrown when the hidden content has a test number which is represented as a float.