### PR TITLE
fix: Assertion with EXCLUDE priority causing test result submit errors

### DIFF
--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -377,7 +377,7 @@
                 type="button"
                 aria-pressed="false"
                 class="css-14jv778 btn btn-secondary">
-                R&amp;D Complete (33)
+                R&amp;D Complete (32)
               </button>
             </li>
             <li>
@@ -385,7 +385,7 @@
                 type="button"
                 aria-pressed="false"
                 class="css-14jv778 btn btn-secondary">
-                In Draft Review (5)
+                In Draft Review (6)
               </button>
             </li>
             <li>
@@ -792,6 +792,64 @@
               </tr>
               <tr aria-rowindex="3">
                 <th>
+                  <a href="/data-management/horizontal-slider"
+                    ><b>Color Viewer Slider</b></a
+                  >
+                </th>
+                <td>
+                  <div>
+                    <b>JAWS</b><span>, </span><b>NVDA</b><span> and </span
+                    ><b>VoiceOver for macOS</b>
+                  </div>
+                </td>
+                <td>
+                  <div class="css-bpz90">
+                    <span class="draft full-width css-be9e2a">Draft</span>
+                    <p class="review-text">Review Started <b>Oct 2, 2024</b></p>
+                  </div>
+                </td>
+                <td><span class="css-wpichc">N/A</span></td>
+                <td>
+                  <div role="list" aria-setsize="3" class="css-1bj5ml9">
+                    <span
+                      class="full-width auto-width css-36z7cz"
+                      role="listitem"
+                      ><a href="/test-review/84"
+                        ><span
+                          ><svg
+                            aria-hidden="true"
+                            focusable="false"
+                            data-prefix="fas"
+                            data-icon="circle-check"
+                            class="svg-inline--fa fa-circle-check check"
+                            role="img"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 512 512"
+                            color="#2BA51C">
+                            <path
+                              fill="currentColor"
+                              d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                          ><b>V24.06.26</b></span
+                        ></a
+                      ></span
+                    ><span role="listitem"
+                      ><button
+                        type="button"
+                        class="css-1c4pbk0 btn btn-primary">
+                        <span
+                          ><span class="reports-missing css-fidnqg"></span>Some
+                          Required Reports <strong>Missing</strong></span
+                        >
+                      </button>
+                      <div></div
+                    ></span>
+                  </div>
+                </td>
+                <td><span class="css-wpichc">Not Started</span></td>
+                <td><span class="css-wpichc">None Yet</span></td>
+              </tr>
+              <tr aria-rowindex="4">
+                <th>
                   <a href="/data-management/command-button"
                     ><b>Command Button Example</b></a
                   >
@@ -887,7 +945,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="4">
+              <tr aria-rowindex="5">
                 <th>
                   <a href="/data-management/combobox-select-only"
                     ><b>Select Only Combobox Example</b></a
@@ -978,7 +1036,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="5">
+              <tr aria-rowindex="6">
                 <th>
                   <a href="/data-management/toggle-button"
                     ><b>Toggle Button</b></a
@@ -1069,7 +1127,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="6">
+              <tr aria-rowindex="7">
                 <th>
                   <a
                     href="/data-management/menu-button-actions-active-descendant"
@@ -1124,7 +1182,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="7">
+              <tr aria-rowindex="8">
                 <th>
                   <a href="/data-management/menu-button-actions"
                     ><b>Action Menu Button Example Using element.focus()</b></a
@@ -1176,7 +1234,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="8">
+              <tr aria-rowindex="9">
                 <th>
                   <a href="/data-management/banner"><b>Banner Landmark</b></a>
                 </th>
@@ -1226,7 +1284,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="9">
+              <tr aria-rowindex="10">
                 <th>
                   <a href="/data-management/breadcrumb"
                     ><b>Breadcrumb Example</b></a
@@ -1278,7 +1336,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="10">
+              <tr aria-rowindex="11">
                 <th>
                   <a href="/data-management/checkbox"
                     ><b>Checkbox Example (Two State)</b></a
@@ -1317,58 +1375,6 @@
                               fill="currentColor"
                               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
                           ><b>V22.03.17-1</b></span
-                        ></a
-                      ></span
-                    ><button
-                      type="button"
-                      class="advance-button btn btn-secondary">
-                      Advance to Draft
-                    </button>
-                  </div>
-                </td>
-                <td><span class="css-wpichc">Not Started</span></td>
-                <td><span class="css-wpichc">Not Started</span></td>
-                <td><span class="css-wpichc">None Yet</span></td>
-              </tr>
-              <tr aria-rowindex="11">
-                <th>
-                  <a href="/data-management/horizontal-slider"
-                    ><b>Color Viewer Slider</b></a
-                  >
-                </th>
-                <td>
-                  <div>
-                    <b>JAWS</b><span>, </span><b>NVDA</b><span> and </span
-                    ><b>VoiceOver for macOS</b>
-                  </div>
-                </td>
-                <td>
-                  <div class="css-bpz90">
-                    <span class="rd full-width css-be9e2a">R&amp;D</span>
-                    <p class="review-text">Complete <b>Jun 26, 2024</b></p>
-                  </div>
-                </td>
-                <td>
-                  <div role="list" aria-setsize="2" class="css-1bj5ml9">
-                    <span
-                      class="full-width auto-width css-36z7cz"
-                      role="listitem"
-                      ><a href="/test-review/84"
-                        ><span
-                          ><svg
-                            aria-hidden="true"
-                            focusable="false"
-                            data-prefix="fas"
-                            data-icon="circle-check"
-                            class="svg-inline--fa fa-circle-check check"
-                            role="img"
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 512 512"
-                            color="#2BA51C">
-                            <path
-                              fill="currentColor"
-                              d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V24.06.26</b></span
                         ></a
                       ></span
                     ><button

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -266,7 +266,7 @@
                         Radio Group Example Using aria-activedescendant
                       </option>
                       <option value="59">Rating Slider</option>
-                      <option value="7">Select Only Combobox Example</option>
+                      <option value="39">Select Only Combobox Example</option>
                       <option value="61">Switch Example</option>
                       <option value="62">Tabs with Manual Activation</option>
                       <option value="89">Toggle Button</option>
@@ -276,11 +276,11 @@
                   <div class="form-group">
                     <label class="disclosure-form-label form-label"
                       >Test Plan Version</label
-                    ><select
-                      disabled=""
-                      aria-disabled="true"
-                      class="form-select">
-                      <option>Versions in R&amp;D or Deprecated</option>
+                    ><select aria-disabled="false" class="form-select">
+                      <option value="85">
+                        Sep 18, 2024 at 6:30:36 pm UTC Add quick nav instruction
+                        for test 9 with VoiceOver (#1127) (122e07a)
+                      </option>
                     </select>
                   </div>
                   <div></div>
@@ -377,7 +377,7 @@
                 type="button"
                 aria-pressed="false"
                 class="css-14jv778 btn btn-secondary">
-                R&amp;D Complete (32)
+                R&amp;D Complete (31)
               </button>
             </li>
             <li>
@@ -401,7 +401,7 @@
                 type="button"
                 aria-pressed="false"
                 class="css-14jv778 btn btn-secondary">
-                Recommended Plans (1)
+                Recommended Plans (2)
               </button>
             </li>
           </ul>
@@ -482,6 +482,121 @@
             </thead>
             <tbody>
               <tr aria-rowindex="0">
+                <th>
+                  <a
+                    href="/data-management/menu-button-actions-active-descendant"
+                    ><b
+                      >Action Menu Button Example Using aria-activedescendant</b
+                    ></a
+                  >
+                </th>
+                <td>
+                  <div>
+                    <b>JAWS</b><span>, </span><b>NVDA</b><span> and </span
+                    ><b>VoiceOver for macOS</b>
+                  </div>
+                </td>
+                <td>
+                  <div class="css-bpz90">
+                    <span class="recommended full-width css-be9e2a"
+                      >Recommended</span
+                    >
+                    <p class="review-text">Since <b>Sep 23, 2024</b></p>
+                  </div>
+                </td>
+                <td><span class="css-wpichc">N/A</span></td>
+                <td>
+                  <div role="list" class="css-1bj5ml9">
+                    <span
+                      class="full-width auto-width css-36z7cz"
+                      role="listitem"
+                      ><span
+                        ><svg
+                          aria-hidden="true"
+                          focusable="false"
+                          data-prefix="fas"
+                          data-icon="circle-check"
+                          class="svg-inline--fa fa-circle-check check"
+                          role="img"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 512 512"
+                          color="#818F98">
+                          <path
+                            fill="currentColor"
+                            d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                        ><b>V24.09.18</b></span
+                      ></span
+                    ><span role="listitem" class="review-complete"
+                      >Review Completed&nbsp;<b>Sep 22, 2024</b></span
+                    >
+                  </div>
+                </td>
+                <td>
+                  <div role="list" class="css-1bj5ml9">
+                    <span
+                      class="full-width auto-width css-36z7cz"
+                      role="listitem"
+                      ><span
+                        ><svg
+                          aria-hidden="true"
+                          focusable="false"
+                          data-prefix="fas"
+                          data-icon="circle-check"
+                          class="svg-inline--fa fa-circle-check check"
+                          role="img"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 512 512"
+                          color="#818F98">
+                          <path
+                            fill="currentColor"
+                            d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                        ><b>V24.09.18</b></span
+                      ></span
+                    ><span role="listitem" class="review-complete"
+                      >Review Completed&nbsp;<b>Sep 23, 2024</b></span
+                    >
+                  </div>
+                </td>
+                <td>
+                  <div role="list" class="css-1bj5ml9">
+                    <span
+                      class="full-width auto-width css-36z7cz"
+                      role="listitem"
+                      ><a href="/test-review/85"
+                        ><span
+                          ><svg
+                            aria-hidden="true"
+                            focusable="false"
+                            data-prefix="fas"
+                            data-icon="circle-check"
+                            class="svg-inline--fa fa-circle-check check"
+                            role="img"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 512 512"
+                            color="#2BA51C">
+                            <path
+                              fill="currentColor"
+                              d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                          ><b>V24.09.18</b></span
+                        ></a
+                      ></span
+                    ><span role="listitem"
+                      ><button
+                        type="button"
+                        class="css-1c4pbk0 btn btn-primary">
+                        <span
+                          ><span class="reports-complete css-fidnqg"></span
+                          >Required Reports <strong>Complete</strong></span
+                        >
+                      </button>
+                      <div></div></span
+                    ><span role="listitem" class="review-complete"
+                      >Approved&nbsp;<b>Sep 23, 2024</b></span
+                    >
+                  </div>
+                </td>
+              </tr>
+              <tr aria-rowindex="1">
                 <th>
                   <a href="/data-management/checkbox-tri-state"
                     ><b>Checkbox Example (Tri State)</b></a
@@ -593,7 +708,7 @@
                   </div>
                 </td>
               </tr>
-              <tr aria-rowindex="1">
+              <tr aria-rowindex="2">
                 <th>
                   <a href="/data-management/modal-dialog"
                     ><b>Modal Dialog Example</b></a
@@ -701,7 +816,7 @@
                 </td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="2">
+              <tr aria-rowindex="3">
                 <th>
                   <a href="/data-management/alert"><b>Alert Example</b></a>
                 </th>
@@ -790,7 +905,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="3">
+              <tr aria-rowindex="4">
                 <th>
                   <a href="/data-management/horizontal-slider"
                     ><b>Color Viewer Slider</b></a
@@ -848,7 +963,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="4">
+              <tr aria-rowindex="5">
                 <th>
                   <a href="/data-management/command-button"
                     ><b>Command Button Example</b></a
@@ -945,7 +1060,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="5">
+              <tr aria-rowindex="6">
                 <th>
                   <a href="/data-management/combobox-select-only"
                     ><b>Select Only Combobox Example</b></a
@@ -1036,7 +1151,7 @@
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>
-              <tr aria-rowindex="6">
+              <tr aria-rowindex="7">
                 <th>
                   <a href="/data-management/toggle-button"
                     ><b>Toggle Button</b></a
@@ -1124,61 +1239,6 @@
                     ></span>
                   </div>
                 </td>
-                <td><span class="css-wpichc">Not Started</span></td>
-                <td><span class="css-wpichc">None Yet</span></td>
-              </tr>
-              <tr aria-rowindex="7">
-                <th>
-                  <a
-                    href="/data-management/menu-button-actions-active-descendant"
-                    ><b
-                      >Action Menu Button Example Using aria-activedescendant</b
-                    ></a
-                  >
-                </th>
-                <td>
-                  <div>
-                    <b>JAWS</b><span>, </span><b>NVDA</b><span> and </span
-                    ><b>VoiceOver for macOS</b>
-                  </div>
-                </td>
-                <td>
-                  <div class="css-bpz90">
-                    <span class="rd full-width css-be9e2a">R&amp;D</span>
-                    <p class="review-text">Complete <b>Sep 18, 2024</b></p>
-                  </div>
-                </td>
-                <td>
-                  <div role="list" aria-setsize="2" class="css-1bj5ml9">
-                    <span
-                      class="full-width auto-width css-36z7cz"
-                      role="listitem"
-                      ><a href="/test-review/85"
-                        ><span
-                          ><svg
-                            aria-hidden="true"
-                            focusable="false"
-                            data-prefix="fas"
-                            data-icon="circle-check"
-                            class="svg-inline--fa fa-circle-check check"
-                            role="img"
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 512 512"
-                            color="#2BA51C">
-                            <path
-                              fill="currentColor"
-                              d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V24.09.18</b></span
-                        ></a
-                      ></span
-                    ><button
-                      type="button"
-                      class="advance-button btn btn-secondary">
-                      Advance to Draft
-                    </button>
-                  </div>
-                </td>
-                <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">Not Started</span></td>
                 <td><span class="css-wpichc">None Yet</span></td>
               </tr>

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -207,6 +207,7 @@
                     ><select class="form-select">
                       <option value="1">Alert Example</option>
                       <option value="67">Checkbox Example (Mixed-State)</option>
+                      <option value="84">Color Viewer Slider</option>
                       <option value="68">Command Button Example</option>
                       <option value="87">Modal Dialog Example</option>
                       <option value="7">Select Only Combobox Example</option>
@@ -448,6 +449,226 @@
                             <button
                               type="button"
                               disabled=""
+                              aria-expanded="false"
+                              class="dropdown-toggle btn btn-secondary">
+                              <svg
+                                aria-hidden="true"
+                                focusable="false"
+                                data-prefix="fas"
+                                data-icon="file-import"
+                                class="svg-inline--fa fa-file-import"
+                                role="img"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 512 512">
+                                <path
+                                  fill="currentColor"
+                                  d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                              >Open run as...
+                            </button>
+                          </div>
+                          <button
+                            type="button"
+                            disabled=""
+                            class="btn btn-secondary">
+                            <svg
+                              aria-hidden="true"
+                              focusable="false"
+                              data-prefix="fas"
+                              data-icon="square-check"
+                              class="svg-inline--fa fa-square-check"
+                              role="img"
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 448 512">
+                              <path
+                                fill="currentColor"
+                                d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zM337 209L209 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L303 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                            >Mark as Final</button
+                          ><button type="button" class="btn btn-secondary">
+                            <svg
+                              aria-hidden="true"
+                              focusable="false"
+                              data-prefix="fas"
+                              data-icon="trash-can"
+                              class="svg-inline--fa fa-trash-can"
+                              role="img"
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 448 512">
+                              <path
+                                fill="currentColor"
+                                d="M135.2 17.7C140.6 6.8 151.7 0 163.8 0H284.2c12.1 0 23.2 6.8 28.6 17.7L320 32h96c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 96 0 81.7 0 64S14.3 32 32 32h96l7.2-14.3zM32 128H416V448c0 35.3-28.7 64-64 64H96c-35.3 0-64-28.7-64-64V128zm96 64c-8.8 0-16 7.2-16 16V432c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16V432c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm96 0c-8.8 0-16 7.2-16 16V432c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16z"></path></svg
+                            >Delete Report
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+          <h2 tabindex="-1" id="horizontal-slider">Color Viewer Slider</h2>
+          <div class="css-b7x2fk">
+            <h3>
+              <button
+                id="disclosure-btn-horizontal-slider-0"
+                type="button"
+                aria-expanded="false"
+                aria-controls="disclosure-btn-controls-horizontal-slider-0"
+                class="css-10jxhio">
+                <span class="css-36z7cz"
+                  ><span
+                    ><svg
+                      aria-hidden="true"
+                      focusable="false"
+                      data-prefix="fas"
+                      data-icon="circle-check"
+                      class="svg-inline--fa fa-circle-check check"
+                      role="img"
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 512 512"
+                      color="#2BA51C">
+                      <path
+                        fill="currentColor"
+                        d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                    ><b>V24.06.26</b></span
+                  ></span
+                >&nbsp;<span class="draft css-be9e2a">Draft</span
+                ><svg
+                  aria-hidden="true"
+                  focusable="false"
+                  data-prefix="fas"
+                  data-icon="chevron-down"
+                  class="svg-inline--fa fa-chevron-down disclosure-icon"
+                  role="img"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 512 512">
+                  <path
+                    fill="currentColor"
+                    d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"></path>
+                </svg>
+              </button>
+            </h3>
+            <div
+              role="region"
+              id="disclosure-container-horizontal-slider-0"
+              aria-labelledby="disclosure-btn-horizontal-slider-0"
+              class="css-19fsyrg">
+              <div class="css-25wfk">
+                <a href="/test-review/84"
+                  ><svg
+                    aria-hidden="true"
+                    focusable="false"
+                    data-prefix="fas"
+                    data-icon="arrow-up-right-from-square"
+                    class="svg-inline--fa fa-arrow-up-right-from-square fa-xs"
+                    role="img"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 512 512"
+                    color="#818F98">
+                    <path
+                      fill="currentColor"
+                      d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"></path></svg
+                  >View tests in V24.06.26</a
+                ><button type="button" class="css-1c4pbk0 btn btn-primary">
+                  <span
+                    ><span class="reports-missing css-fidnqg"></span>Some
+                    Required Reports <strong>Missing</strong></span
+                  >
+                </button>
+                <div></div>
+              </div>
+              <div class="css-1iwfp5o">
+                <table
+                  aria-label="Reports for Color Viewer Slider V24.06.26 in draft phase"
+                  class="css-hfams3 table table-bordered">
+                  <thead>
+                    <tr>
+                      <th>Assistive Technology</th>
+                      <th>Browser</th>
+                      <th>Testers</th>
+                      <th>Status</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>
+                        <div class="css-1rahl5j">
+                          VoiceOver for macOS&nbsp;<span
+                            >11.6 (20G165) or later</span
+                          >
+                        </div>
+                      </td>
+                      <td>
+                        <div class="css-1rahl5j">
+                          Safari&nbsp;<span>Any version</span>
+                        </div>
+                      </td>
+                      <td>
+                        <div class="css-1578spe">
+                          <div id="assign-testers-20" class="dropdown">
+                            <button
+                              type="button"
+                              aria-expanded="false"
+                              class="css-1qdmm25 dropdown-toggle btn btn-secondary">
+                              <span class="sr-only">Assign Testers</span
+                              ><svg
+                                aria-hidden="true"
+                                focusable="false"
+                                data-prefix="fas"
+                                data-icon="user"
+                                class="svg-inline--fa fa-user"
+                                role="img"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 448 512">
+                                <path
+                                  fill="currentColor"
+                                  d="M224 256A128 128 0 1 0 224 0a128 128 0 1 0 0 256zm-45.7 48C79.8 304 0 383.8 0 482.3C0 498.7 13.3 512 29.7 512H418.3c16.4 0 29.7-13.3 29.7-29.7C448 383.8 368.2 304 269.7 304H178.3z"></path>
+                              </svg>
+                            </button>
+                          </div>
+                          <button type="button" class="btn btn-secondary">
+                            Assign Yourself
+                          </button>
+                        </div>
+                        <ul class="css-9acwza">
+                          <li>
+                            <a
+                              href="https://github.com/esmeralda-baggins"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              >esmeralda-baggins</a
+                            ><em>0 of 9 tests complete</em>
+                          </li>
+                        </ul>
+                      </td>
+                      <td>
+                        <div class="css-78pgex">
+                          <div class="progress clipped">
+                            <div
+                              class="front"
+                              style="clip-path: inset(0px 0px 0px 0%)"></div>
+                            <div class="back"></div>
+                          </div>
+                          <span
+                            >0% complete by&nbsp;<a
+                              href="https://github.com/esmeralda-baggins"
+                              >esmeralda-baggins</a
+                            >&nbsp;</span
+                          >
+                        </div>
+                      </td>
+                      <td>
+                        <div class="css-1mwhzii">
+                          <button
+                            type="button"
+                            disabled=""
+                            class="btn btn-primary">
+                            Start Testing
+                          </button>
+                          <div class="dropdown">
+                            <button
+                              type="button"
                               aria-expanded="false"
                               class="dropdown-toggle btn btn-secondary">
                               <svg

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -609,7 +609,7 @@
                       </td>
                       <td>
                         <div class="css-1578spe">
-                          <div id="assign-testers-20" class="dropdown">
+                          <div id="assign-testers-27" class="dropdown">
                             <button
                               type="button"
                               aria-expanded="false"

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -644,19 +644,26 @@ const graphqlSchema = gql`
   Some assertions are more akin to recommendations or best practices, and,
   while we want to record whether they are passing or failing, we do not want
   to count the entire test as failing when they fail.
+
+  These definitions for MUST, SHOULD and MAY are described at
+  https://github.com/w3c/aria-at/wiki/Glossary#assertion-priority in more
+  detail
   """
   enum AssertionPriority {
     """
-    All required assertions must pass for the test to pass. This should be
-    considered as 'MUST Behaviors'.
+    The assertion is an absolute requirement for the test to pass. This should
+    be considered as 'MUST Behaviors'.
     """
     MUST
     """
-    This assertion is not considered when deciding if a test is passing.
-    This should be considered as 'SHOULD Behaviors'.
+    This assertion is a strongly recommended requirement. This should be
+    considered as 'SHOULD Behaviors'.
     """
     SHOULD
-    # TODO Define MAY
+    """
+    This assertion is truly optional. This should be considered as 'MAY
+    Behaviors'.
+    """
     MAY
     """
     This assertion should not be included in the test and should not be

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -60,7 +60,7 @@ const saveTestResultCommon = async ({
   }
 
   if (isSubmit) {
-    assertTestResultIsValid(newTestResult);
+    assertTestResultIsValid(newTestResult, test.assertions);
     newTestResult.completedAt = new Date();
   } else {
     newTestResult.completedAt = null;
@@ -115,15 +115,22 @@ const saveTestResultCommon = async ({
   return populateData({ testResultId }, { context });
 };
 
-const assertTestResultIsValid = newTestResult => {
+const assertTestResultIsValid = (newTestResult, assertions = []) => {
   let failed = false;
 
   const checkAssertionResult = assertionResult => {
+    const isExcluded = assertions.find(
+      assertion =>
+        assertion.id === assertionResult.assertionId &&
+        assertion.priority === 'EXCLUDE'
+    );
+
     if (
       assertionResult.passed === null ||
       assertionResult.passed === undefined
     ) {
-      failed = true;
+      if (isExcluded) assertionResult.passed = false;
+      else failed = true;
     }
   };
 

--- a/server/scripts/populate-test-data/pg_dump_test_data.sql
+++ b/server/scripts/populate-test-data/pg_dump_test_data.sql
@@ -83,6 +83,7 @@ INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "markedFinal
 INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "markedFinalAt", "atId", "minimumAtVersionId", "browserId", "vendorReviewStatus") VALUES (17, get_test_plan_version_id(text 'Command Button Example', '2'), '2023-12-13 14:18:23.602-05', '2023-12-14', 2, 2, 2, 'READY');
 INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "markedFinalAt", "atId", "minimumAtVersionId", "browserId", "vendorReviewStatus") VALUES (18, get_test_plan_version_id(text 'Command Button Example', '2'), '2023-12-13 14:18:23.602-05', '2023-12-14', 3, 3, 3, 'READY');
 INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "atId", "minimumAtVersionId", "browserId", "vendorReviewStatus") VALUES (19, get_test_plan_version_id(text 'Modal Dialog Example', '2'), '2024-05-14 14:18:23.602-05', 2, 2, 2, 'READY');
+INSERT INTO "TestPlanReport" (id, "testPlanVersionId", "createdAt", "atId", "minimumAtVersionId", "browserId", "vendorReviewStatus") VALUES (20, get_test_plan_version_id(text 'Color Viewer Slider', '2'), '2024-10-02 14:18:23.602-05', 3, 3, 3, 'READY');
 
 --
 -- Data for Name: TestPlanVersion; Type: TABLE DATA; Schema: public; Owner: atr
@@ -95,6 +96,7 @@ UPDATE "TestPlanVersion" SET "phase" = 'RECOMMENDED', "candidatePhaseReachedAt" 
 UPDATE "TestPlanVersion" SET "phase" = 'DRAFT', "draftPhaseReachedAt" = '2022-07-06' WHERE id = get_test_plan_version_id(text 'Alert Example', '1');
 UPDATE "TestPlanVersion" SET "phase" = 'DRAFT', "draftPhaseReachedAt" = '2023-12-14' WHERE id = get_test_plan_version_id(text 'Command Button Example', '2');
 UPDATE "TestPlanVersion" SET "phase" = 'DRAFT', "draftPhaseReachedAt" = '2024-05-14' WHERE id = get_test_plan_version_id(text 'Modal Dialog Example', '2');
+UPDATE "TestPlanVersion" SET "phase" = 'DRAFT', "draftPhaseReachedAt" = '2024-10-02' WHERE id = get_test_plan_version_id(text 'Color Viewer Slider', '2');
 
 --
 -- Data for Name: User; Type: TABLE DATA; Schema: public; Owner: atr
@@ -133,6 +135,7 @@ INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults"
 INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (17, 1, 17, '[]');
 INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (18, 1, 18, '[]');
 INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (19, 1, 19, '[]');
+INSERT INTO "TestPlanRun" (id, "testerUserId", "testPlanReportId", "testResults") VALUES (20, 1, 20, '[]');
 
 --
 -- Data for Name: CollectionJob; Type: TABLE DATA; Schema: public; Owner: atr


### PR DESCRIPTION
Address #1228.

This seems to be a special case that happens when the assertion is excluded in tests the tests.csv and then included in *-commands.csv's `assertionExceptions` with a non-excluding priority. For example:
* [Navigation Menu Button's `navForwardsToMenuButton` test](https://github.com/w3c/aria-at/blob/bab79e2321ae203e8cfdd464871809247fddd3c3/tests/menu-button-navigation/data/tests.csv) which excludes `interactionModeEnabled` by default and any of [it's `*-commands.csv` which then includes `interactionModeEnabled` using `assertionExceptions`](https://github.com/w3c/aria-at/blob/bab79e2321ae203e8cfdd464871809247fddd3c3/tests/menu-button-navigation/data/nvda-commands.csv).
* Do note an example of this exclusion pattern has already been been pushed through successfully with the latest Color Viewer Slider. Based on my checking, the issue started to happen when [v1.7.0](https://github.com/w3c/aria-at-app/blob/development/CHANGELOG.md#170-2024-08-26) was released on August 26, 2024 and the reports for Color Viewer Slider were completed by the latest on [July 25, 2024](https://aria-at.w3.org/report/163615).
* I've also confirmed this doesn't affect the other method of assertion exclusion where the `*-commands.csv` excludes an assertion through the `assertionExceptions` instead, like in the case of [modal-dialog](https://github.com/w3c/aria-at/blob/c1a3b08d12454779f053cae6e7df98ec7f6d011f/tests/modal-dialog/data/nvda-commands.csv).