### PR TITLE
Update `server/resources/ats.json` following #1208 merge

### DIFF
--- a/server/resources/ats.json
+++ b/server/resources/ats.json
@@ -3,6 +3,7 @@
         "id": 1,
         "name": "JAWS",
         "key": "jaws",
+        "vendorId": 1,
         "defaultConfigurationInstructionsHTML": "Configure JAWS with default settings. For help, read &lt;a href=&quot;https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing&quot;&gt;Configuring Screen Readers for Testing&lt;/a&gt;.",
         "assertionTokens": {
             "screenReader": "JAWS",
@@ -31,6 +32,7 @@
         "id": 2,
         "name": "NVDA",
         "key": "nvda",
+        "vendorId": null,
         "defaultConfigurationInstructionsHTML": "Configure NVDA with default settings. For help, read &lt;a href=&quot;https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing&quot;&gt;Configuring Screen Readers for Testing&lt;/a&gt;.",
         "assertionTokens": {
             "screenReader": "NVDA",
@@ -59,6 +61,7 @@
         "id": 3,
         "name": "VoiceOver for macOS",
         "key": "voiceover_macos",
+        "vendorId": 4,
         "defaultConfigurationInstructionsHTML": "Configure VoiceOver with default settings. For help, read &lt;a href=&quot;https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing&quot;&gt;Configuring Screen Readers for Testing&lt;/a&gt;.",
         "assertionTokens": {
             "screenReader": "VoiceOver",

--- a/server/scripts/import-tests/testPlanVersionOperations.js
+++ b/server/scripts/import-tests/testPlanVersionOperations.js
@@ -62,7 +62,9 @@ const buildTestsAndCreateTestPlanVersions = async (commit, { transaction }) => {
 
   const { support } = await updateJsons();
 
-  const ats = await At.findAll();
+  const ats = await At.findAll({
+    order: [['id', 'ASC']]
+  });
   await updateAtsJson({ ats, supportAts: support.ats });
 
   for (const directory of fse.readdirSync(builtTestsDirectory)) {


### PR DESCRIPTION
Update `server/resources/ats.json` which now has different attributes after #1208 merge. This change would happen locally when running:

```bash
yarn db-import-tests:dev;
```