### PR TITLE
fix: Only include CollectionJob metrics in Bot Status calculation on Test Queue page when `tester.isBot` is true

### DIFF
--- a/client/components/BotRunTestStatusList/index.js
+++ b/client/components/BotRunTestStatusList/index.js
@@ -60,8 +60,11 @@ const BotRunTestStatusList = ({ testPlanReportId }) => {
     };
     let anyPossibleUpdates = false;
     if (testPlanRunsQueryResult?.testPlanRuns) {
-      for (const { collectionJob } of testPlanRunsQueryResult.testPlanRuns) {
-        if (collectionJob?.testStatus) {
+      for (const {
+        collectionJob,
+        tester
+      } of testPlanRunsQueryResult.testPlanRuns) {
+        if (collectionJob?.testStatus && tester?.isBot) {
           for (const { status } of collectionJob.testStatus) {
             counter[status]++;
             if (status === 'QUEUED' || status === 'RUNNING') {

--- a/client/components/BotRunTestStatusList/queries.js
+++ b/client/components/BotRunTestStatusList/queries.js
@@ -6,6 +6,7 @@ export const TEST_PLAN_RUNS_TEST_RESULTS_QUERY = gql`
       id
       tester {
         username
+        isBot
       }
       testResults {
         id

--- a/client/tests/BotRunTestStatusList.test.jsx
+++ b/client/tests/BotRunTestStatusList.test.jsx
@@ -90,6 +90,50 @@ test('correctly ignores test results from a human-submitted test plan run', asyn
   });
 });
 
+// See gh-1237 - Check if user is a bot, to include in Bot Status calculation on Test Queue page
+// https://github.com/w3c/aria-at-app/pull/1237
+test('correctly ignores test results from a human-submitted test plan run with a collectionJob attribute', async () => {
+  const testPlanRuns = [
+    {
+      id: '0',
+      testResults: new Array(3).fill(null),
+      tester: { username: 'bot', isBot: true },
+      collectionJob: {
+        status: COLLECTION_JOB_STATUS.COMPLETED,
+        testStatus: [
+          { status: COLLECTION_JOB_STATUS.COMPLETED },
+          { status: COLLECTION_JOB_STATUS.COMPLETED },
+          { status: COLLECTION_JOB_STATUS.COMPLETED }
+        ]
+      }
+    },
+    {
+      id: '1',
+      testResults: new Array(3).fill(null),
+      tester: { username: 'human', isBot: false },
+        status: COLLECTION_JOB_STATUS.COMPLETED,
+        testStatus: [
+          { status: COLLECTION_JOB_STATUS.COMPLETED },
+          { status: COLLECTION_JOB_STATUS.COMPLETED },
+          { status: COLLECTION_JOB_STATUS.COMPLETED }
+        ]
+    }
+  ];
+
+  const mocks = getMocks(testPlanRuns);
+
+  const { getByText } = render(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <BotRunTestStatusList testPlanReportId="1" />
+    </MockedProvider>
+  );
+
+  await waitFor(async () => {
+    expect(getByText('3 Tests Completed')).toBeInTheDocument();
+    expect(getByText('0 Tests Queued')).toBeInTheDocument();
+  });
+});
+
 test('correctly displays statuses for CANCELLED test run', async () => {
   const testPlanRuns = [
     {

--- a/client/tests/BotRunTestStatusList.test.jsx
+++ b/client/tests/BotRunTestStatusList.test.jsx
@@ -111,12 +111,14 @@ test('correctly ignores test results from a human-submitted test plan run with a
       id: '1',
       testResults: new Array(3).fill(null),
       tester: { username: 'human', isBot: false },
+      collectionJob: {
         status: COLLECTION_JOB_STATUS.COMPLETED,
         testStatus: [
           { status: COLLECTION_JOB_STATUS.COMPLETED },
           { status: COLLECTION_JOB_STATUS.COMPLETED },
           { status: COLLECTION_JOB_STATUS.COMPLETED }
         ]
+      }
     }
   ];
 

--- a/client/tests/BotRunTestStatusList.test.jsx
+++ b/client/tests/BotRunTestStatusList.test.jsx
@@ -26,7 +26,7 @@ test('correctly displays statuses for single COMPLETED test run', async () => {
     {
       id: '0',
       testResults: new Array(3).fill(null),
-      tester: { username: 'bot' },
+      tester: { username: 'bot', isBot: true },
       collectionJob: {
         status: COLLECTION_JOB_STATUS.COMPLETED,
         testStatus: [
@@ -59,7 +59,7 @@ test('correctly ignores test results from a human-submitted test plan run', asyn
     {
       id: '0',
       testResults: new Array(2).fill(null),
-      tester: { username: 'bot' },
+      tester: { username: 'bot', isBot: true },
       collectionJob: {
         status: COLLECTION_JOB_STATUS.COMPLETED,
         testStatus: [
@@ -71,7 +71,7 @@ test('correctly ignores test results from a human-submitted test plan run', asyn
     {
       id: '1',
       testResults: new Array(2).fill(null),
-      tester: { username: 'human' },
+      tester: { username: 'human', isBot: false },
       collectionJob: null
     }
   ];
@@ -95,7 +95,7 @@ test('correctly displays statuses for CANCELLED test run', async () => {
     {
       id: '0',
       testResults: new Array(2).fill(null),
-      tester: { username: 'bot' },
+      tester: { username: 'bot', isBot: true },
       collectionJob: {
         status: COLLECTION_JOB_STATUS.CANCELLED,
         testStatus: [
@@ -127,7 +127,7 @@ test('correctly displays statuses for multiple RUNNING and QUEUED test runs', as
     {
       id: '0',
       testResults: new Array(2).fill(null),
-      tester: { username: 'bot' },
+      tester: { username: 'bot', isBot: true },
       collectionJob: {
         status: COLLECTION_JOB_STATUS.RUNNING,
         testStatus: [
@@ -140,7 +140,7 @@ test('correctly displays statuses for multiple RUNNING and QUEUED test runs', as
     {
       id: '1',
       testResults: new Array(2).fill(null),
-      tester: { username: 'bot' },
+      tester: { username: 'bot', isBot: true },
       collectionJob: {
         status: COLLECTION_JOB_STATUS.CANCELLED,
         testStatus: [


### PR DESCRIPTION
This PR is to address the case in which a bot run is assigned to a manual user to be evaluated, and then a bot is assigned a run on the same report again. It would cause an aggregation of the assigned bot's and the previously assigned tester's results which would create confusing metrics in the Bot Status calculation, on the Test Queue page.