### PR TITLE
fix: Exclude unsupported assertion results from failure count in report headings; use separate "unsupported" metric

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -507,16 +507,23 @@ const CandidateTestPlanRun = () => {
             const testResult =
               testPlanReport.finalizedTestResults[currentTestIndex];
 
-            const { assertionsPassedCount, assertionsFailedCount } = getMetrics(
-              { testResult }
-            );
+            const {
+              assertionsPassedCount,
+              mustAssertionsFailedCount,
+              shouldAssertionsFailedCount,
+              mayAssertionsFailedCount
+            } = getMetrics({ testResult });
+
+            const mustShouldAssertionsFailedCount =
+              mustAssertionsFailedCount + shouldAssertionsFailedCount;
 
             return (
               <>
                 <h2 className="test-results-header">
                   Test Results&nbsp;(
                   {assertionsPassedCount} passed,&nbsp;
-                  {assertionsFailedCount} failed)
+                  {mustShouldAssertionsFailedCount} failed,&nbsp;
+                  {mayAssertionsFailedCount} unsupported)
                 </h2>
                 <TestPlanResultsTable
                   key={`${testPlanReport.id} + ${testResult.id}`}

--- a/client/components/Reports/SummarizeTestPlanReport.jsx
+++ b/client/components/Reports/SummarizeTestPlanReport.jsx
@@ -272,17 +272,26 @@ const SummarizeTestPlanReport = ({ testPlanVersion, testPlanReports }) => {
           'https://aria-at.netlify.app'
         );
 
-        const { assertionsPassedCount, assertionsFailedCount } = getMetrics({
+        const {
+          assertionsPassedCount,
+          mustAssertionsFailedCount,
+          shouldAssertionsFailedCount,
+          mayAssertionsFailedCount
+        } = getMetrics({
           testResult
         });
+
+        const mustShouldAssertionsFailedCount =
+          mustAssertionsFailedCount + shouldAssertionsFailedCount;
 
         return (
           <Fragment key={testResult.id}>
             <div className="test-result-heading">
               <h2 id={`result-${testResult.id}`} tabIndex="-1">
                 Test {index + 1}: {test.title}&nbsp;(
-                {assertionsPassedCount}
-                &nbsp;passed, {assertionsFailedCount} failed)
+                {assertionsPassedCount} passed,&nbsp;
+                {mustShouldAssertionsFailedCount} failed,&nbsp;
+                {mayAssertionsFailedCount} unsupported)
                 <DisclaimerInfo phase={testPlanVersion.phase} />
               </h2>
               <div className="test-result-buttons">

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -476,9 +476,17 @@ const TestRenderer = ({
     const { results } = submitResult;
     const { header } = results;
 
-    const { assertionsPassedCount, assertionsFailedCount } = getMetrics({
+    const {
+      assertionsPassedCount,
+      mustAssertionsFailedCount,
+      shouldAssertionsFailedCount,
+      mayAssertionsFailedCount
+    } = getMetrics({
       testResult
     });
+
+    const mustShouldAssertionsFailedCount =
+      mustAssertionsFailedCount + shouldAssertionsFailedCount;
 
     return (
       <>
@@ -486,7 +494,8 @@ const TestRenderer = ({
         <SubHeadingText id="overallstatus">
           Test Results&nbsp;(
           {assertionsPassedCount} passed,&nbsp;
-          {assertionsFailedCount} failed)
+          {mustShouldAssertionsFailedCount} failed,&nbsp;
+          {mayAssertionsFailedCount} unsupported)
         </SubHeadingText>
         <TestPlanResultsTable
           test={{ title: header, at }}

--- a/client/components/common/TestPlanResultsTable/index.jsx
+++ b/client/components/common/TestPlanResultsTable/index.jsx
@@ -44,10 +44,15 @@ const TestPlanResultsTable = ({
       {testResult.scenarioResults.map((scenarioResult, index) => {
         const {
           assertionsPassedCount,
-          assertionsFailedCount,
+          mustAssertionsFailedCount,
+          shouldAssertionsFailedCount,
+          mayAssertionsFailedCount,
           severeImpactPassedAssertionCount,
           moderateImpactPassedAssertionCount
         } = getMetrics({ scenarioResult });
+
+        const mustShouldAssertionsFailedCount =
+          mustAssertionsFailedCount + shouldAssertionsFailedCount;
 
         const hasNoSevereUnexpectedBehavior =
           severeImpactPassedAssertionCount > 0;
@@ -119,7 +124,8 @@ const TestPlanResultsTable = ({
             <CommandHeading>
               {commandsString}&nbsp;Results:&nbsp;
               {assertionsPassedCount} passed,&nbsp;
-              {assertionsFailedCount} failed
+              {mustShouldAssertionsFailedCount} failed,&nbsp;
+              {mayAssertionsFailedCount} unsupported
             </CommandHeading>
             <p className="test-plan-results-response-p">
               {test.at?.name} Response:

--- a/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1.html
+++ b/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1.html
@@ -501,10 +501,12 @@
                               aria-labelledby="disclosure-btn-test-instructions-and-results-Test Results for Chrome"
                               class="css-19fsyrg">
                               <h2 class="test-results-header">
-                                Test Results&nbsp;(12 passed,&nbsp;0 failed)
+                                Test Results&nbsp;(12 passed,&nbsp;0
+                                failed,&nbsp;0 unsupported)
                               </h2>
                               <h3>
-                                Space&nbsp;Results:&nbsp;6 passed,&nbsp;0 failed
+                                Space&nbsp;Results:&nbsp;6 passed,&nbsp;0
+                                failed,&nbsp;0 unsupported
                               </h3>
                               <p class="test-plan-results-response-p">
                                 JAWS Response:
@@ -576,7 +578,8 @@
                               Other behaviors that create negative impact: None
                               <hr aria-hidden="true" />
                               <h3>
-                                Enter&nbsp;Results:&nbsp;6 passed,&nbsp;0 failed
+                                Enter&nbsp;Results:&nbsp;6 passed,&nbsp;0
+                                failed,&nbsp;0 unsupported
                               </h3>
                               <p class="test-plan-results-response-p">
                                 JAWS Response:

--- a/client/tests/e2e/snapshots/saved/_report_67_targets_20.html
+++ b/client/tests/e2e/snapshots/saved/_report_67_targets_20.html
@@ -362,7 +362,7 @@
           <div class="test-result-heading">
             <h2 id="result-NjAyYeyIxMiI6MjB92VjN2" tabindex="-1">
               Test 1: Navigate forwards to a mixed checkbox in reading
-              mode&nbsp;(28&nbsp;passed, 0 failed)
+              mode&nbsp;(28 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -440,7 +440,9 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>X&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              X&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -506,7 +508,9 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>F&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              F&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -572,7 +576,9 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -640,7 +646,7 @@
             <hr aria-hidden="true" />
             <h4>
               Down Arrow then Down Arrow&nbsp;Results:&nbsp;7 passed,&nbsp;0
-              failed
+              failed,&nbsp;0 unsupported
             </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
@@ -751,7 +757,7 @@
           <div class="test-result-heading">
             <h2 id="result-YWJlZeyIxMiI6MjB9jEzNm" tabindex="-1">
               Test 2: Navigate forwards to a mixed checkbox in interaction
-              mode&nbsp;(7&nbsp;passed, 0 failed)
+              mode&nbsp;(7 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -829,7 +835,9 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -939,7 +947,7 @@
           <div class="test-result-heading">
             <h2 id="result-ODhiYeyIxMiI6MjB9TRkYW" tabindex="-1">
               Test 3: Navigate backwards to a mixed checkbox in reading
-              mode&nbsp;(27&nbsp;passed, 1 failed)
+              mode&nbsp;(27 passed,&nbsp;1 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -1017,7 +1025,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Shift+X&nbsp;Results:&nbsp;6 passed,&nbsp;1 failed</h4>
+            <h4>
+              Shift+X&nbsp;Results:&nbsp;6 passed,&nbsp;1 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -1103,7 +1114,10 @@
               </table>
             </div>
             <hr aria-hidden="true" />
-            <h4>Shift+F&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Shift+F&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -1169,7 +1183,10 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Shift+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Shift+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -1236,7 +1253,8 @@
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
             <h4>
-              Up Arrow then Up Arrow&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed
+              Up Arrow then Up Arrow&nbsp;Results:&nbsp;7 passed,&nbsp;0
+              failed,&nbsp;0 unsupported
             </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
@@ -1347,7 +1365,7 @@
           <div class="test-result-heading">
             <h2 id="result-NDZmYeyIxMiI6MjB9jg3Nm" tabindex="-1">
               Test 4: Navigate backwards to a mixed checkbox in interaction
-              mode&nbsp;(7&nbsp;passed, 0 failed)
+              mode&nbsp;(7 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -1425,7 +1443,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Shift+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Shift+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -1535,7 +1556,7 @@
           <div class="test-result-heading">
             <h2 id="result-OTBlYeyIxMiI6MjB9jY5Mz" tabindex="-1">
               Test 5: Read information about a mixed checkbox in reading
-              mode&nbsp;(14&nbsp;passed, 0 failed)
+              mode&nbsp;(14 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -1613,7 +1634,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Insert+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Insert+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -1679,7 +1703,10 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Insert+Up&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Insert+Up&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -1789,7 +1816,7 @@
           <div class="test-result-heading">
             <h2 id="result-ZDg3NeyIxMiI6MjB9zcwMj" tabindex="-1">
               Test 6: Read information about a mixed checkbox in interaction
-              mode&nbsp;(14&nbsp;passed, 0 failed)
+              mode&nbsp;(14 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -1867,7 +1894,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Insert+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Insert+Tab&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -1933,7 +1963,10 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Insert+Up&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed</h4>
+            <h4>
+              Insert+Up&nbsp;Results:&nbsp;7 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2042,8 +2075,8 @@
           </div>
           <div class="test-result-heading">
             <h2 id="result-MjJhZeyIxMiI6MjB9TRiZG" tabindex="-1">
-              Test 7: Operate a mixed checkbox in reading
-              mode&nbsp;(3&nbsp;passed, 0 failed)
+              Test 7: Operate a mixed checkbox in reading mode&nbsp;(3
+              passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -2121,7 +2154,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed</h4>
+            <h4>
+              Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2210,8 +2246,8 @@
           </div>
           <div class="test-result-heading">
             <h2 id="result-MjNmMeyIxMiI6MjB9zIwOD" tabindex="-1">
-              Test 8: Operate a mixed checkbox in interaction
-              mode&nbsp;(3&nbsp;passed, 0 failed)
+              Test 8: Operate a mixed checkbox in interaction mode&nbsp;(3
+              passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -2289,7 +2325,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed</h4>
+            <h4>
+              Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2378,8 +2417,8 @@
           </div>
           <div class="test-result-heading">
             <h2 id="result-OTNhZeyIxMiI6MjB9jAwMT" tabindex="-1">
-              Test 9: Operate an unchecked checkbox in reading
-              mode&nbsp;(3&nbsp;passed, 0 failed)
+              Test 9: Operate an unchecked checkbox in reading mode&nbsp;(3
+              passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -2457,7 +2496,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed</h4>
+            <h4>
+              Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2546,8 +2588,8 @@
           </div>
           <div class="test-result-heading">
             <h2 id="result-ZDUzZeyIxMiI6MjB9GM0MD" tabindex="-1">
-              Test 10: Operate an unchecked checkbox in interaction
-              mode&nbsp;(3&nbsp;passed, 0 failed)
+              Test 10: Operate an unchecked checkbox in interaction mode&nbsp;(3
+              passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -2625,7 +2667,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed</h4>
+            <h4>
+              Space&nbsp;Results:&nbsp;3 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2715,7 +2760,7 @@
           <div class="test-result-heading">
             <h2 id="result-YTMzNeyIxMiI6MjB9mNjMz" tabindex="-1">
               Test 11: Navigate forwards out of a checkbox group in reading
-              mode&nbsp;(20&nbsp;passed, 0 failed)
+              mode&nbsp;(20 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -2793,7 +2838,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Down Arrow&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              Down Arrow&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2849,7 +2897,9 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>U&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              U&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2905,7 +2955,9 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>K&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              K&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -2961,7 +3013,9 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -3061,7 +3115,7 @@
           <div class="test-result-heading">
             <h2 id="result-YzJlYeyIxMiI6MjB9jdkZG" tabindex="-1">
               Test 12: Navigate forwards out of a checkbox group in interaction
-              mode&nbsp;(5&nbsp;passed, 0 failed)
+              mode&nbsp;(5 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -3139,7 +3193,9 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0 unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -3239,7 +3295,7 @@
           <div class="test-result-heading">
             <h2 id="result-MmM4OeyIxMiI6MjB9DBjZD" tabindex="-1">
               Test 13: Navigate backwards out of a checkbox group in reading
-              mode&nbsp;(20&nbsp;passed, 0 failed)
+              mode&nbsp;(20 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -3318,7 +3374,8 @@
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
             <h4>
-              Up Arrow then Up Arrow&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed
+              Up Arrow then Up Arrow&nbsp;Results:&nbsp;5 passed,&nbsp;0
+              failed,&nbsp;0 unsupported
             </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
@@ -3375,7 +3432,10 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Shift+K&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              Shift+K&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -3431,7 +3491,10 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Shift+U&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              Shift+U&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -3487,7 +3550,10 @@
             </div>
             Other behaviors that create negative impact: None
             <hr aria-hidden="true" />
-            <h4>Shift+Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              Shift+Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output
@@ -3587,7 +3653,7 @@
           <div class="test-result-heading">
             <h2 id="result-YjM4MeyIxMiI6MjB9mU0OW" tabindex="-1">
               Test 14: Navigate backwards out of a checkbox group in interaction
-              mode&nbsp;(5&nbsp;passed, 0 failed)
+              mode&nbsp;(5 passed,&nbsp;0 failed,&nbsp;0 unsupported)
               <div class="css-9b7rl3">
                 <details>
                   <summary
@@ -3665,7 +3731,10 @@
           </div>
           <div class="css-1l6ouvs">
             <h3>Results for each command</h3>
-            <h4>Shift+Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed</h4>
+            <h4>
+              Shift+Tab&nbsp;Results:&nbsp;5 passed,&nbsp;0 failed,&nbsp;0
+              unsupported
+            </h4>
             <p class="test-plan-results-response-p">NVDA Response:</p>
             <blockquote class="test-plan-results-blockquote">
               automatically seeded sample output

--- a/client/tests/e2e/snapshots/saved/_run_2.html
+++ b/client/tests/e2e/snapshots/saved/_run_2.html
@@ -371,9 +371,13 @@
                             combobox in reading mode
                           </h1>
                           <h2 id="overallstatus" class="css-ncfvkt">
-                            Test Results&nbsp;(24 passed,&nbsp;0 failed)
+                            Test Results&nbsp;(24 passed,&nbsp;0 failed,&nbsp;0
+                            unsupported)
                           </h2>
-                          <h3>F&nbsp;Results:&nbsp;6 passed,&nbsp;0 failed</h3>
+                          <h3>
+                            F&nbsp;Results:&nbsp;6 passed,&nbsp;0 failed,&nbsp;0
+                            unsupported
+                          </h3>
                           <p class="test-plan-results-response-p">
                             NVDA Response:
                           </p>
@@ -442,7 +446,10 @@
                           </div>
                           Other behaviors that create negative impact: None
                           <hr aria-hidden="true" />
-                          <h3>C&nbsp;Results:&nbsp;6 passed,&nbsp;0 failed</h3>
+                          <h3>
+                            C&nbsp;Results:&nbsp;6 passed,&nbsp;0 failed,&nbsp;0
+                            unsupported
+                          </h3>
                           <p class="test-plan-results-response-p">
                             NVDA Response:
                           </p>
@@ -512,7 +519,8 @@
                           Other behaviors that create negative impact: None
                           <hr aria-hidden="true" />
                           <h3>
-                            Tab&nbsp;Results:&nbsp;6 passed,&nbsp;0 failed
+                            Tab&nbsp;Results:&nbsp;6 passed,&nbsp;0
+                            failed,&nbsp;0 unsupported
                           </h3>
                           <p class="test-plan-results-response-p">
                             NVDA Response:
@@ -584,7 +592,7 @@
                           <hr aria-hidden="true" />
                           <h3>
                             Down Arrow&nbsp;Results:&nbsp;6 passed,&nbsp;0
-                            failed
+                            failed,&nbsp;0 unsupported
                           </h3>
                           <p class="test-plan-results-response-p">
                             NVDA Response:


### PR DESCRIPTION
Address #1248.