### PR TITLE
fix: sortable table th rendering bug

### DIFF
--- a/client/components/common/SortableTableHeader/index.js
+++ b/client/components/common/SortableTableHeader/index.js
@@ -21,23 +21,16 @@ const SortableTableHeaderButton = styled(Button)`
   color: black;
   font-size: 1rem;
   font-weight: 700;
-  text-align: left;
   width: 100%;
-  min-height: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  padding: 0.5rem;
-  border-radius: 0;
-  margin: 0;
-
-  position: relative;
   height: 100%;
   min-height: 100%;
   flex: 1 1 auto;
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
+  padding: 0.5rem;
+  border-radius: 0;
+  margin: 0;
 
   &:hover,
   &:focus {

--- a/client/components/common/SortableTableHeader/index.js
+++ b/client/components/common/SortableTableHeader/index.js
@@ -31,11 +31,13 @@ const SortableTableHeaderButton = styled(Button)`
   border-radius: 0;
   margin: 0;
 
-  // Force the button to stretch
   position: relative;
-  height: stretch;
-  height: -webkit-fill-available;
-  height: -moz-available;
+  height: 100%;
+  min-height: 100%;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
 
   &:hover,
   &:focus {

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -421,7 +421,7 @@
                   scope="col"
                   aria-sort="none"
                   class="css-i93j34">
-                  <button type="button" class="css-ikcenn btn btn-primary">
+                  <button type="button" class="css-1at7njo btn btn-primary">
                     Test Plan<svg
                       aria-hidden="true"
                       focusable="false"
@@ -442,7 +442,7 @@
                   scope="col"
                   aria-sort="none"
                   class="css-i93j34">
-                  <button type="button" class="css-ikcenn btn btn-primary">
+                  <button type="button" class="css-1at7njo btn btn-primary">
                     Covered AT<svg
                       aria-hidden="true"
                       focusable="false"
@@ -463,7 +463,7 @@
                   scope="col"
                   aria-sort="descending"
                   class="css-i93j34">
-                  <button type="button" class="css-ikcenn btn btn-primary">
+                  <button type="button" class="css-1at7njo btn btn-primary">
                     Overall Status<svg
                       aria-hidden="true"
                       focusable="false"


### PR DESCRIPTION
see title

Safari Before:
<img width="1305" alt="Sortable table header with enclosing button element shorter than the text" src="https://github.com/user-attachments/assets/faf039ae-660f-4293-bcc7-7994f6af4b05">

Safari After:
<img width="1310" alt="Sortable table header with enclosing button element tall enough to enclose the text" src="https://github.com/user-attachments/assets/1f1a712b-9d13-4593-a408-d124df1ed3a6">

