### PR TITLE
Add NVDA 2024.4.1 to supported automation versions

### DIFF
--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -6,7 +6,7 @@ const AT_VERSIONS_SUPPORTED_BY_COLLECTION_JOBS = {
   // https://github.com/bocoup/aria-at-gh-actions-helper/blob/main/.github/workflows/voiceover-test.yml#L39
   'VoiceOver for macOS': ['13.0', '14.0'],
   // These are tracked with the https://github.com/bocoup/aria-at-automation-nvda-builds/releases
-  NVDA: ['2024.1', '2023.3.3', '2023.3']
+  NVDA: ['2024.4.1', '2024.1', '2023.3.3', '2023.3']
 };
 
 const VENDOR_NAME_TO_AT_MAPPING = {


### PR DESCRIPTION
see #1268 

This PR was preceded by work creating [a release in aria-at-automation-nvda-builds](https://github.com/bocoup/aria-at-automation-nvda-builds/releases/tag/2024.4.1). That [release was tested using Github workflows](https://github.com/bocoup/aria-at-gh-actions-helper/actions/runs/12287347380).