### PR TITLE
fix: prevent reassignment of bot run before status is completed, cancelled, or errored

### DIFF
--- a/client/components/ManageBotRunDialog/index.jsx
+++ b/client/components/ManageBotRunDialog/index.jsx
@@ -17,6 +17,7 @@ import RetryCanceledCollectionsButton from './RetryCanceledCollectionsButton';
 import StopRunningCollectionButton from './StopRunningCollectionButton';
 import ViewLogsButton from './ViewLogsButton';
 import { TestPlanRunPropType, UserPropType } from '../common/proptypes';
+import { COLLECTION_JOB_STATUS } from '../../utils/collectionJobStatus';
 
 const ManageBotRunDialog = ({
   testPlanReportId,
@@ -68,6 +69,19 @@ const ManageBotRunDialog = ({
     [testers, testPlanReportAssignedTestersQuery]
   );
 
+  const isBotRunFinished = useMemo(() => {
+    const status = collectionJobQuery?.collectionJobByTestPlanRunId?.status;
+    if (!status) return false;
+    switch (status) {
+      case COLLECTION_JOB_STATUS.COMPLETED:
+      case COLLECTION_JOB_STATUS.ERROR:
+      case COLLECTION_JOB_STATUS.CANCELLED:
+        return true;
+      default:
+        return false;
+    }
+  }, [collectionJobQuery]);
+
   const actions = useMemo(() => {
     return [
       {
@@ -77,6 +91,7 @@ const ManageBotRunDialog = ({
           testPlanRun: testPlanRun,
           possibleTesters: possibleReassignees,
           label: 'Assign To ...',
+          disabled: !isBotRunFinished,
           onChange
         }
       },

--- a/client/components/common/AssignTesterDropdown/index.jsx
+++ b/client/components/common/AssignTesterDropdown/index.jsx
@@ -28,6 +28,7 @@ const AssignTesterDropdown = ({
   possibleTesters,
   onChange,
   label,
+  disabled = false,
   dropdownAssignTesterButtonRef,
   setAlertMessage = () => {}
 }) => {
@@ -139,6 +140,7 @@ const AssignTesterDropdown = ({
           aria-label="Assign testers"
           className="assign-tester"
           variant="secondary"
+          disabled={disabled}
         >
           {renderLabel()}
         </Dropdown.Toggle>
@@ -216,7 +218,8 @@ AssignTesterDropdown.propTypes = {
   label: PropTypes.string,
   draftTestPlanRuns: PropTypes.arrayOf(TestPlanRunPropType),
   setAlertMessage: PropTypes.func,
-  dropdownAssignTesterButtonRef: PropTypes.object
+  dropdownAssignTesterButtonRef: PropTypes.object,
+  disabled: PropTypes.bool
 };
 
 export default AssignTesterDropdown;


### PR DESCRIPTION
see title

partially addresses #1270 

We don't currently have a good way to write e2e tests for these delayed simulated bot run ui flows. I think this is out of scope for this particular task but is worth considering in the future.