### PR TITLE
Add database management API calls and update crons

### DIFF
--- a/deploy/roles/application/tasks/cron.yml
+++ b/deploy/roles/application/tasks/cron.yml
@@ -1,15 +1,33 @@
 ---
 # Create a cron to import the most recent tests from aria-at
-- name: Set a cron job to build test results
+- name: Set a cron job to build and import latest test versions from aria-at
   cron:
     name: "import latest aria-at tests"
     minute: "15"
     job: "curl -X POST https://{{fqdn}}/api/test/import"
-  when: deployment_mode != 'development' 
+  when: deployment_mode != 'development'
 
-- name: Set a cron job to build test results in development
+- name: Set a cron job to build and import latest test versions from aria-at in development
   cron:
     name: "import latest aria-at tests"
     minute: "15"
     job: "curl -X POST http://localhost:5000/api/test/import"
   when: deployment_mode == 'development'
+
+# Create a cron to dump the database in staging and production
+- name: Set a cron job to create a new database dump
+  cron:
+    name: "create new database dump"
+    hour: "0"
+    minute: "0"
+    job: "curl -X POST https://{{fqdn}}/api/database/dump"
+  when: deployment_mode == 'staging' or deployment_mode == 'production'
+
+# Create a cron to clean up the database dumps folder in staging and production
+- name: Set a cron job to clean up the database dumps folder
+  cron:
+    name: "clean up the database dumps folder is necessary"
+    hour: "0"
+    minute: "5"
+    job: "curl -X POST https://{{fqdn}}/api/database/cleanFolder"
+  when: deployment_mode == 'staging' or deployment_mode == 'production'

--- a/deploy/roles/application/tasks/cron.yml
+++ b/deploy/roles/application/tasks/cron.yml
@@ -14,7 +14,7 @@
     job: "curl -X POST http://localhost:5000/api/test/import"
   when: deployment_mode == 'development'
 
-# Create a cron to dump the database in staging and production
+# Create a cron to dump the database in staging and production (run every day at 00:00)
 - name: Set a cron job to create a new database dump
   cron:
     name: "create new database dump"
@@ -23,10 +23,10 @@
     job: "curl -X POST https://{{fqdn}}/api/database/dump"
   when: deployment_mode == 'staging' or deployment_mode == 'production'
 
-# Create a cron to clean up the database dumps folder in staging and production
+# Create a cron to clean up the database dumps folder in staging and production (run every day at 00:05)
 - name: Set a cron job to clean up the database dumps folder
   cron:
-    name: "clean up the database dumps folder is necessary"
+    name: "clean up the database dumps folder if necessary"
     hour: "0"
     minute: "5"
     job: "curl -X POST https://{{fqdn}}/api/database/cleanFolder"

--- a/deploy/roles/application/tasks/cron.yml
+++ b/deploy/roles/application/tasks/cron.yml
@@ -14,6 +14,25 @@
     job: "curl -X POST http://localhost:5000/api/test/import"
   when: deployment_mode == 'development'
 
+- name: Ensure proper permissions for application_user on db_dumps directory
+  become: yes
+  block:
+    - name: Ensure the db_dumps directory exists
+      file:
+        path: /home/{{application_user}}/db_dumps
+        state: directory
+        owner: '{{application_user}}'
+        group: '{{application_user}}'
+        mode: '0755'
+
+    - name: Ensure application_user has write permissions on the db_dumps directory
+      file:
+        path: /home/{{application_user}}/db_dumps
+        owner: '{{application_user}}'
+        group: '{{application_user}}'
+        mode: '0775'
+  when: deployment_mode == 'staging' or deployment_mode == 'production'
+
 # Create a cron to dump the database in staging and production (run every day at 00:00)
 - name: Set a cron job to create a new database dump
   cron:

--- a/server/app.js
+++ b/server/app.js
@@ -8,6 +8,7 @@ const authRoutes = require('./routes/auth');
 const testRoutes = require('./routes/tests');
 const transactionRoutes = require('./routes/transactions');
 const automationSchedulerRoutes = require('./routes/automation');
+const databaseRoutes = require('./routes/database');
 const path = require('path');
 const apolloServer = require('./graphql-server');
 const {
@@ -24,6 +25,7 @@ app.use('/auth', authRoutes);
 app.use('/test', testRoutes);
 app.use('/transactions', transactionRoutes);
 app.use('/jobs', automationSchedulerRoutes);
+app.use('/database', databaseRoutes);
 
 apolloServer.start().then(() => {
   apolloServer.applyMiddleware({ app });

--- a/server/controllers/DatabaseController.js
+++ b/server/controllers/DatabaseController.js
@@ -1,0 +1,240 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { Client } = require('pg');
+const { exec } = require('child_process');
+const { dates } = require('shared');
+
+// Database configuration
+const DB_NAME = process.env.PGDATABASE;
+const DB_USER = process.env.PGUSER;
+const DB_PASSWORD = process.env.PGPASSWORD;
+const DB_HOST = process.env.PGHOST;
+
+// To avoid unintentionally exposing environment variables in error messages
+const sanitizeError = message => {
+  const redacted = '#redacted#';
+
+  const dbNameRegex = new RegExp(DB_NAME, 'g');
+  const dbUserRegex = new RegExp(DB_USER, 'g');
+  const dbPasswordRegex = new RegExp(DB_PASSWORD, 'g');
+  const dbHostRegex = new RegExp(DB_HOST, 'g');
+
+  return message
+    .replace(dbNameRegex, redacted)
+    .replace(dbUserRegex, redacted)
+    .replace(dbPasswordRegex, redacted)
+    .replace(dbHostRegex, redacted);
+};
+
+const removeDatabaseTablesAndFunctions = async res => {
+  // Database connection configuration
+  const client = new Client({
+    user: DB_USER,
+    host: DB_HOST,
+    database: DB_NAME,
+    password: DB_PASSWORD
+  });
+
+  try {
+    // Init database connection
+    await client.connect();
+    res.write('Connected to the database.\n');
+
+    // [Tables DROP // START]
+    // Get all tables in the public schema
+    const tablesQuery = `
+      SELECT tablename
+      FROM pg_tables
+      WHERE schemaname = 'public';
+    `;
+    const tablesResult = await client.query(tablesQuery);
+
+    // Build and execute DROP TABLE commands
+    const tableNames = tablesResult.rows
+      .filter(row => row.tablename !== 'session')
+      .map(row => `"${row.tablename}"`);
+    if (tableNames.length === 0) {
+      res.write('No tables found to drop.\n');
+    } else {
+      res.write(`Dropping tables: ${tableNames.join(', ')}\n`);
+      await client.query(`DROP TABLE ${tableNames.join(', ')} CASCADE;`);
+      res.write('All tables have been dropped successfully.\n');
+    }
+    // [Tables DROP // END]
+
+    // [Functions DROP // START]
+    // Get all user-defined functions
+    const functionsQuery = `
+      SELECT 'DROP FUNCTION IF EXISTS ' || n.nspname || '.' || p.proname || '(' ||
+             pg_get_function_identity_arguments(p.oid) || ');' AS drop_statement
+      FROM pg_proc p
+             JOIN pg_namespace n ON p.pronamespace = n.oid
+      WHERE n.nspname NOT IN ('pg_catalog', 'information_schema');
+    `;
+
+    const functionsResult = await client.query(functionsQuery);
+    const dropStatements = functionsResult.rows.map(row => row.drop_statement);
+
+    // Execute each DROP FUNCTION statement
+    for (const dropStatement of dropStatements) {
+      res.write(`Executing: ${dropStatement}\n`);
+      await client.query(dropStatement);
+    }
+    res.write('All functions removed successfully!\n');
+    // [Functions DROP // END]
+  } catch (error) {
+    res.write(
+      `Error removing tables or functions: ${sanitizeError(error.message)}\n`
+    );
+  } finally {
+    await client.end();
+    res.write('Disconnected from the database.\n');
+  }
+};
+
+const dumpPostgresDatabase = async (req, res) => {
+  const { dumpOutputDirectory, dumpFileName } = req.body;
+
+  if (dumpFileName && !dumpFileName.includes('.sql'))
+    return res.status(400).send("Provided file name does not include '.sql'");
+
+  const OUTPUT_DIR = dumpOutputDirectory || path.join(os.homedir(), 'db_dumps');
+  const DUMP_FILE = path.join(
+    OUTPUT_DIR,
+    dumpFileName ||
+      `${process.env.ENVIRONMENT}_dump_${dates.convertDateToString(
+        new Date(),
+        'YYYYMMDD_HHmmss'
+      )}.sql`
+  );
+
+  try {
+    // pg_dump command
+    const pgDumpCommand = `PGPASSWORD=${DB_PASSWORD} pg_dump -U ${DB_USER} -h ${DB_HOST} -d ${DB_NAME} --exclude-table=session > ${DUMP_FILE}`;
+
+    // Execute the command
+    exec(pgDumpCommand, (error, stdout, stderr) => {
+      if (error) {
+        return res
+          .status(400)
+          .send(`Error executing pg_dump: ${sanitizeError(error.message)}`);
+      }
+      if (stderr) {
+        return res
+          .status(400)
+          .send(`pg_dump stderr:: ${sanitizeError(stderr)}`);
+      }
+      return res
+        .status(200)
+        .send(`Database dump completed successfully: ${DUMP_FILE}`);
+    });
+  } catch (error) {
+    return res
+      .status(400)
+      .send(`Unable to dump database: ${sanitizeError(error.message)}`);
+  }
+};
+
+const restorePostgresDatabase = async (req, res) => {
+  // Prevent unintentionally dropping or restoring database tables if ran on
+  // production unless manually done
+  if (process.env.ENVIRONMENT === 'production') {
+    return res.status(405).send('This request is not permitted');
+  }
+
+  const { pathToFile } = req.body;
+  if (!pathToFile)
+    return res.status(400).send("'pathToFile' is missing. Please provide.");
+
+  // Purge the database's tables and functions to make restoring with the
+  // pg import easier
+  await removeDatabaseTablesAndFunctions(res);
+
+  try {
+    // delete the tables currently in the db
+    const pgImportCommand = `PGPASSWORD=${DB_PASSWORD} psql -U ${DB_USER} -h ${DB_HOST} -d ${DB_NAME} -f ${pathToFile}`;
+
+    // Execute the command
+    exec(pgImportCommand, (error, stdout, stderr) => {
+      if (error) {
+        res
+          .status(400)
+          .write(`Error executing pg import: ${sanitizeError(error.message)}`);
+      }
+      if (stderr) {
+        res.status(400).write(`pg import stderr:: ${sanitizeError(stderr)}`);
+      }
+      res.status(200).write(`Database import completed successfully`);
+      return res.end();
+    });
+  } catch (error) {
+    res
+      .status(400)
+      .write(`Unable to import database: ${sanitizeError(error.message)}`);
+    return res.end();
+  }
+};
+
+// Function to clean up the dump folder
+const cleanFolder = (req, res) => {
+  const { dumpOutputDirectory, maxFiles } = req.body;
+
+  if (maxFiles) {
+    if (!isNaN(maxFiles) && Number.isInteger(Number(maxFiles))) {
+      // continue
+    } else {
+      return res.status(400).send('Unable to parse maxFiles value provided');
+    }
+  } else {
+    // continue
+  }
+
+  const OUTPUT_DIR = dumpOutputDirectory || path.join(os.homedir(), 'db_dumps');
+  const MAX_FILES = Number(maxFiles) || 20;
+
+  try {
+    // Read all files in the folder
+    const files = fs.readdirSync(OUTPUT_DIR).map(file => {
+      const filePath = path.join(OUTPUT_DIR, file);
+      return {
+        name: file,
+        path: filePath,
+        time: fs.statSync(filePath).mtime.getTime() // Get last modified time
+      };
+    });
+
+    // Sort files by modification time (oldest first)
+    files.sort((a, b) => a.time - b.time);
+
+    // Delete files if there are more than maxFiles
+    if (files.length > MAX_FILES) {
+      const removedFiles = [];
+
+      const filesToDelete = files.slice(0, files.length - MAX_FILES);
+      filesToDelete.forEach(file => {
+        fs.unlinkSync(file.path); // Delete the file
+        removedFiles.push(file);
+      });
+      return res
+        .status(200)
+        .send(
+          `Removed the following files:\n${removedFiles
+            .map(({ name }, index) => `#${index + 1}) ${name}`)
+            .join('\n')}`
+        );
+    } else {
+      return res
+        .status(200)
+        .send('No files to delete. Folder is within the limit.');
+    }
+  } catch (error) {
+    return res.status(400).send(`Error cleaning folder: ${error.message}`);
+  }
+};
+
+module.exports = {
+  dumpPostgresDatabase,
+  restorePostgresDatabase,
+  cleanFolder
+};

--- a/server/controllers/DatabaseController.js
+++ b/server/controllers/DatabaseController.js
@@ -190,8 +190,10 @@ const cleanFolder = (req, res) => {
     // continue
   }
 
+  // Default the output directory to ~/db_dumps if no path provided
   const OUTPUT_DIR = dumpOutputDirectory || path.join(os.homedir(), 'db_dumps');
-  const MAX_FILES = Number(maxFiles) || 20;
+  // Default the number of max files to 28 if no value provided
+  const MAX_FILES = Number(maxFiles) || 28;
 
   try {
     // Read all files in the folder

--- a/server/routes/database.js
+++ b/server/routes/database.js
@@ -1,0 +1,14 @@
+const { Router } = require('express');
+const {
+  dumpPostgresDatabase,
+  restorePostgresDatabase,
+  cleanFolder
+} = require('../controllers/DatabaseController');
+
+const router = Router();
+
+router.post('/dump', dumpPostgresDatabase);
+router.post('/restore', restorePostgresDatabase);
+router.post('/cleanFolder', cleanFolder);
+
+module.exports = router;


### PR DESCRIPTION
Partially address #759 in making it easier to get a database dump from `production` and restoring it in `staging` or `sandbox`.

This PR adds API functions:
* Dumping postgres database
* Restoring postgres database
* Cleaning up the database dumps directory so it doesn't grow too large (defaulted to max of 28 days)

This PR adds the following cron jobs:
* Dumping postgres database every day at 00:00
* Cleaning up the dumps directory if necessary every day at 00:05