### PR TITLE
Bump `ansible-core` to address package support issues

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.10'
       - name: Install ansible and deploy to production
         run: |
-          python -m pip install --user ansible-core==2.11.1
+          python -m pip install --user ansible-core==2.16.14
           cd deploy
           echo ${{ secrets.ANSIBLE_VAULT_PASSWORD }} > ansible-vault-password.txt
           ansible-vault view --vault-password-file ansible-vault-password.txt files/jwt-signing-key.pem.enc > ../jwt-signing-key.pem

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@ name: Deploy to staging (aria-at-staging.w3.org)
 on:
   push:
     branches:
-      - development
+      - ansible-bump
 
 jobs:
   deploy-staging:
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.10'
       - name: Install ansible and deploy to staging
         run: |
-          python -m pip install --user ansible-core==2.11.1
+          python -m pip install --user ansible-core==2.16.14
           cd deploy
           echo ${{ secrets.ANSIBLE_VAULT_PASSWORD }} > ansible-vault-password.txt
           ansible-vault view --vault-password-file ansible-vault-password.txt files/jwt-signing-key.pem.enc > ../jwt-signing-key.pem

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@ name: Deploy to staging (aria-at-staging.w3.org)
 on:
   push:
     branches:
-      - ansible-bump
+      - development
 
 jobs:
   deploy-staging:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,23 +24,19 @@ machine will not have all the capabilities of the production system.
 1. Install [Vagrant](https://www.vagrantup.com/) (version 2) and
    [VirtualBox](https://www.virtualbox.org/) (version 5.2)
 2. Install vagrant-hostsupdater
-    ```
-    vagrant plugin install vagrant-hostsupdater
-    ```
+   ```
+   vagrant plugin install vagrant-hostsupdater
+   ```
 3. Open a terminal and navigate to the directory containing this text file
 4. Run the following command:
-    ```
-    vagrant up
-    ```
-This will initiate the creation of a virtual machine. You will be prompted for your sudo password. Further documentation on using Vagrant can be found in [the "Getting Started" guide by the maintainers of that project](https://www.vagrantup.com/intro/getting-started/index.html).
+   ` vagrant up `
+   This will initiate the creation of a virtual machine. You will be prompted for your sudo password. Further documentation on using Vagrant can be found in [the "Getting Started" guide by the maintainers of that project](https://www.vagrantup.com/intro/getting-started/index.html).
 
 Once the vagrant box is up you can test by running by going to the ip configured
 in the `Vagrantfile` [192.168.10.40](192.168.10.40).
 
 If you make any changes locally and want to run them again:
-    ```
-    vagrant rsync && vagrant up --provision
-    ```
+` vagrant rsync && vagrant up --provision `
 
 If you want to debug you can run `vagrant ssh` to ssh into the vagrant box. You
 can view logging from ansible with `sudo -i cat /var/log/messages`.
@@ -50,46 +46,52 @@ can view logging from ansible with `sudo -i cat /var/log/messages`.
 To deploy this project to server:
 
 1. Merge from development to the releases branch as detailed in [docs/release.md](../docs/release.md).
-1. Obtain an authorized key and add it to your keychain. This is needed for deploys to Staging and Production. 
-  - The shared key is named `aria-at-bocoup`.
-  - Place it in the ~/.ssh directory.
-  - For security, set permissions on the key file, which is required by the OS: `chmod 600 ~/.ssh/aria-at-bocoup`.
-  - Add it to your keychain with the following command: `ssh-add ~/.ssh/aria-at-bocoup`.
-  - Add the following `Host` client configuration option to `~/.ssh/config`:
-    ```
-    Host *.w3.internal
-      ProxyJump bocoupinfra@ssh-aws.w3.org
-    ```
-    - The RSA key fingerprint for `ssh-aws.w3.org` is `SHA256:Nlyly0XFZebw0/k8yCGUXA+Y03W7WB7CPnXiZZb7XE8`.
-  - Run `ssh root@bestla.w3.internal` (aria-at-staging.w3.org's server) and `ssh root@fenrir.w3.internal` (aria-at.w3.org's server) to verify that you can connect to the servers.
-    - The RSA key fingerprint for `bestla.w3.internal` is `SHA256:F16aX2Wx4e39jbHhqEkeH8iRgY41C3WgxvAgvh7PQZ0`.
-    - The RSA key fingerprint for `fenrir.w3.internal` is `SHA256:cF6u/K00P2ELEVbIazVVqqMz5q+Sbh4+Jog/VmXZomg`.
+1. Obtain an authorized key and add it to your keychain. This is needed for deploys to Staging and Production.
+
+- The shared key is named `aria-at-bocoup`.
+- Place it in the ~/.ssh directory.
+- For security, set permissions on the key file, which is required by the OS: `chmod 600 ~/.ssh/aria-at-bocoup`.
+- Add it to your keychain with the following command: `ssh-add ~/.ssh/aria-at-bocoup`.
+- Add the following `Host` client configuration option to `~/.ssh/config`:
+  ```
+  Host *.w3.internal
+    ProxyJump bocoupinfra@ssh-aws.w3.org
+  ```
+  - The RSA key fingerprint for `ssh-aws.w3.org` is `SHA256:Nlyly0XFZebw0/k8yCGUXA+Y03W7WB7CPnXiZZb7XE8`.
+- Run `ssh root@bestla.w3.internal` (aria-at-staging.w3.org's server) and `ssh root@fenrir.w3.internal` (aria-at.w3.org's server) to verify that you can connect to the servers.
+  - The RSA key fingerprint for `bestla.w3.internal` is `SHA256:F16aX2Wx4e39jbHhqEkeH8iRgY41C3WgxvAgvh7PQZ0`.
+  - The RSA key fingerprint for `fenrir.w3.internal` is `SHA256:cF6u/K00P2ELEVbIazVVqqMz5q+Sbh4+Jog/VmXZomg`.
+
 1. Bocoup maintains its own instance of the app on its internal infrastructure for quick and easy testing. Note that you must be a Bocouper to deploy to this environment. Follow the steps below to verify you are able to connect.
-  - Run `ssh aria-at-app-sandbox.bocoup.com` and confirm you can connect.
-  - Confirm that `sudo su` successfully switches you to the root user. You will need to enter the sudo password you chose during your Bocoup onboarding. This password will be required when deploying to the Sandbox.
+
+- Run `ssh aria-at-app-sandbox.bocoup.com` and confirm you can connect.
+- Confirm that `sudo su` successfully switches you to the root user. You will need to enter the sudo password you chose during your Bocoup onboarding. This password will be required when deploying to the Sandbox.
+
 1. Obtain a copy of the `ansible-vault-password.txt` file in LastPass and place it in the directory which contains this document.
-1. Install [Ansible](https://www.ansible.com/) version 2.11. Instructions for macOS are as follows:
-  - Install Ansible at the specific 2.11 version: `python3 -m pip install --user ansible-core==2.11.1`
-  - Add the following line to your `~/.zshrc` file, changing the path below to match where Python installs Ansible for you:
-    ```
-    export PATH=$PATH:/Users/Luigi/Library/Python/3.9/bin
-    ```
-  - Run `source ~/.zshrc` to refresh your shell.
-  - Install `ansible.posix` to make use of the [ansible.posix.synchronize](https://docs.ansible.com/ansible/latest/collections/ansible/posix/synchronize_module.html#ansible-posix-synchronize-module-a-wrapper-around-rsync-to-make-common-tasks-in-your-playbooks-quick-and-easy) module: `ansible-galaxy collection install ansible.posix`
-  - Run `ansible --version` to verify your ansible is on version 2.11.
+1. Install [Ansible](https://www.ansible.com/) version 2.16. Instructions for macOS are as follows:
+
+- Install Ansible at the specific 2.16 version: `python3 -m pip install --user ansible-core==2.16.14`
+- Add the following line to your `~/.zshrc` file, changing the path below to match where Python installs Ansible for you:
+  ```
+  export PATH=$PATH:/Users/Luigi/Library/Python/3.9/bin
+  ```
+- Run `source ~/.zshrc` to refresh your shell.
+- Install `ansible.posix` to make use of the [ansible.posix.synchronize](https://docs.ansible.com/ansible/latest/collections/ansible/posix/synchronize_module.html#ansible-posix-synchronize-module-a-wrapper-around-rsync-to-make-common-tasks-in-your-playbooks-quick-and-easy) module: `ansible-galaxy collection install ansible.posix`
+- Run `ansible --version` to verify your ansible is on version 2.16.
+
 1. Execute the following command from the deploy directory:
    - Sandbox:
-    ```
-    ansible-playbook provision.yml --inventory inventory/sandbox.yml
-    ```
+   ```
+   ansible-playbook provision.yml --inventory inventory/sandbox.yml
+   ```
    - Staging:
-    ```
-    ansible-playbook provision.yml --inventory inventory/staging.yml
-    ```
+   ```
+   ansible-playbook provision.yml --inventory inventory/staging.yml
+   ```
    - Production:
-    ```
-    ansible-playbook provision.yml --inventory inventory/production.yml
-    ```
+   ```
+   ansible-playbook provision.yml --inventory inventory/production.yml
+   ```
 
 ## Environment Configuration
 
@@ -102,25 +104,28 @@ ansible-vault edit files/config-sandbox.env
 ```
 
 ## Manual DB Backup
+
 From the `deploy` folder:
 
 1. Retrieve the database user (aka PGUSER) and database password (aka PGPASSWORD), the environment is `production` or `staging`.
    `ansible-vault view --vault-password-file ansible-vault-password.txt files/config-<environment>.env`
 2. Ssh into the machine. The deploy key will be at `~/.ssh/aria-at-bocoup`, if you followed the deploy setup instructions. The domain is `aria-at.w3.org` for production and `aria-at-staging.w3.org` for staging.
-  `ssh -i <deploy key> root@<domain>`
+   `ssh -i <deploy key> root@<domain>`
 3. Create the backup and save it to a file. After running the command, the terminal prompt will ask for the PGPASSWORD. Use the current date for the timestamp, e.g. `20230406`. Run
-  `pg_dump -U <value for PGUSER> -h localhost -d aria_at_report > <environment>_dump_<timestamp>.sql`. 
+   `pg_dump -U <value for PGUSER> -h localhost -d aria_at_report > <environment>_dump_<timestamp>.sql`.
 4. From another terminal window that's not connected to the server, copy the backup to your machine.
-  `scp -i <deploy key> root@<domain>:<environment>_dump_<timestamp>.sql .`
+   `scp -i <deploy key> root@<domain>:<environment>_dump_<timestamp>.sql .`
 
 ## Database Restore
+
 1. Ssh into the machine.
-  `ssh -i <deploy key> root@aria-at.w3.org`
+   `ssh -i <deploy key> root@aria-at.w3.org`
 2. Load the backup that was created
-  `psql -d aria_at_report -f <environment>_dump_<timestamp>.sql`
+   `psql -d aria_at_report -f <environment>_dump_<timestamp>.sql`
 
 ## Github Workflow Automation Configuration
-* The `jwt-signing-key.pem` file should be located in the project root folder.
+
+- The `jwt-signing-key.pem` file should be located in the project root folder.
   From within the `deploy` folder, you can run `ansible-vault view --vault-password-file ansible-vault-password.txt files/jwt-signing-key.pem.enc > ../jwt-signing-key.pem` to decrypt the configuration file.
-* The `AUTOMATION_CALLBACK_FQDN` environment variable in the environment configuration file should be a **fully qualified domain name** that is accessible from the github workflow server pointing at the running instance of aria-at-app.  For local development testing of these features, a forwarding proxy server like `ngrok` is recommended: `npx ngrok http 3000 --host-header=rewrite` will setup a server forwarding to your local 3000 development port.  You can then use the domain it gives you when launching the app:
+- The `AUTOMATION_CALLBACK_FQDN` environment variable in the environment configuration file should be a **fully qualified domain name** that is accessible from the github workflow server pointing at the running instance of aria-at-app. For local development testing of these features, a forwarding proxy server like `ngrok` is recommended: `npx ngrok http 3000 --host-header=rewrite` will setup a server forwarding to your local 3000 development port. You can then use the domain it gives you when launching the app:
   `AUTOMATION_CALLBACK_FQDN=128935b17294.ngrok.app yarn dev`

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -29,8 +29,11 @@ machine will not have all the capabilities of the production system.
    ```
 3. Open a terminal and navigate to the directory containing this text file
 4. Run the following command:
-   `bash vagrant up `
-   This will initiate the creation of a virtual machine. You will be prompted for your sudo password. Further documentation on using Vagrant can be found in [the "Getting Started" guide by the maintainers of that project](https://www.vagrantup.com/intro/getting-started/index.html).
+   ```bash
+   vagrant up
+   ```
+
+This will initiate the creation of a virtual machine. You will be prompted for your sudo password. Further documentation on using Vagrant can be found in [the "Getting Started" guide by the maintainers of that project](https://www.vagrantup.com/intro/getting-started/index.html).
 
 Once the vagrant box is up you can test by running by going to the ip configured
 in the `Vagrantfile` [192.168.10.40](192.168.10.40).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,19 +24,22 @@ machine will not have all the capabilities of the production system.
 1. Install [Vagrant](https://www.vagrantup.com/) (version 2) and
    [VirtualBox](https://www.virtualbox.org/) (version 5.2)
 2. Install vagrant-hostsupdater
-   ```
+   ```bash
    vagrant plugin install vagrant-hostsupdater
    ```
 3. Open a terminal and navigate to the directory containing this text file
 4. Run the following command:
-   ` vagrant up `
+   `bash vagrant up `
    This will initiate the creation of a virtual machine. You will be prompted for your sudo password. Further documentation on using Vagrant can be found in [the "Getting Started" guide by the maintainers of that project](https://www.vagrantup.com/intro/getting-started/index.html).
 
 Once the vagrant box is up you can test by running by going to the ip configured
 in the `Vagrantfile` [192.168.10.40](192.168.10.40).
 
 If you make any changes locally and want to run them again:
-` vagrant rsync && vagrant up --provision `
+
+```bash
+vagrant rsync && vagrant up --provision
+```
 
 If you want to debug you can run `vagrant ssh` to ssh into the vagrant box. You
 can view logging from ansible with `sudo -i cat /var/log/messages`.

--- a/deploy/provision.yml
+++ b/deploy/provision.yml
@@ -2,7 +2,7 @@
 - hosts: all
   become_method: sudo
   pre_tasks:
-    - include: tasks/prompt-for-become-password.yml
+    - import_tasks: tasks/prompt-for-become-password.yml
       when: needs_become_password|default(false, true)
   roles:
     - permissions

--- a/deploy/roles/application/tasks/main.yml
+++ b/deploy/roles/application/tasks/main.yml
@@ -8,7 +8,7 @@
   set_fact:
     source_dir: /home/{{application_user}}/aria-at-report
 
-- include: upload-source-code.yml
+- include_tasks: upload-source-code.yml
 
 - name: Allow aria-bot user to run import script as admin on sandbox
   lineinfile:
@@ -28,7 +28,7 @@
     recurse: yes
   become: yes
   when: deployment_mode != 'development'
-  notify: "restart server"
+  notify: 'restart server'
 
 - name: Make server resources folder writable for import tests API endpoint
   file:
@@ -37,7 +37,7 @@
     recurse: yes
   become: yes
   when: deployment_mode != 'development'
-  notify: "restart server"
+  notify: 'restart server'
 
 - name: Make client resources folder writable for import harness
   file:
@@ -46,7 +46,7 @@
     recurse: yes
   become: yes
   when: deployment_mode != 'development'
-  notify: "restart server"
+  notify: 'restart server'
 
 - name: Link application code
   file:
@@ -108,6 +108,6 @@
   args:
     chdir: '{{source_dir}}'
 
-- include: service.yml
+- import_tasks: service.yml
 
-- include: cron.yml
+- include_tasks: cron.yml

--- a/deploy/roles/nodejs/tasks/main.yml
+++ b/deploy/roles/nodejs/tasks/main.yml
@@ -8,7 +8,7 @@
     - https://dl.yarnpkg.com/debian/pubkey.gpg
     - https://deb.nodesource.com/gpgkey/nodesource.gpg.key
 
-- include: upgrade.yml
+- include_tasks: upgrade.yml
 
 - name: Add software repositories
   apt_repository:


### PR DESCRIPTION
Thursday's latest deploy to the staging environment caused an [error](https://github.com/w3c/aria-at-app/actions/runs/12698011352/job/35398847198) with the following message:

```bash
ModuleNotFoundError: No module named 'ansible.module_utils.six.moves'
```

`ubuntu-latest` was recently updated to Ubuntu 24.0.1, updated from the recent 22 LTS. This suggests that the previously packaged python [six module](https://pypi.org/project/six/) wasn't included by default in 24 as it was in 22.

Running the following would also address this error:

```bash
pip install six
```

But after checking the [ansible-core release versions](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix), we've long since been at EOL (Nov 22). So I'd like to take the chance to bump ansible-core from `2.11` to `2.16`. I've also confirmed this [builds and deploys](https://github.com/w3c/aria-at-app/actions/runs/12750303888/job/35534727666) as expected with minimal changes to the tasks (using `include_tasks` or `import_tasks` in place of `include`, introduced in [`ansible-core 2.12`](https://github.com/ansible/ansible/blob/stable-2.12/changelogs/CHANGELOG-v2.12.rst#deprecated-features)).