### PR TITLE
Only use push event for running tests

### DIFF
--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -1,5 +1,5 @@
 name: Run the tests
-on: [push, pull_request]
+on: [push]
 
 jobs:
   runtest_task:


### PR DESCRIPTION
We're getting duplicate runs in some situations but "push" should cover all the cases we need on its own.