### PR TITLE
fix: Include result of undesirable behaviors assertions in summary of failing assertions

### DIFF
--- a/client/components/TestRun/TestNavigator.jsx
+++ b/client/components/TestRun/TestNavigator.jsx
@@ -34,7 +34,11 @@ const TestNavigator = ({
   );
 
   const shouldShowFailingAssertionsSummary = useMemo(() => {
-    return isVendor && testPlanReport.metrics.assertionsFailedCount > 0;
+    return (
+      isVendor &&
+      (testPlanReport.metrics.mustAssertionsFailedCount > 0 ||
+        testPlanReport.metrics.shouldAssertionsFailedCount > 0)
+    );
   }, [isVendor, testPlanReport]);
 
   return (

--- a/client/hooks/useFailingAssertions.js
+++ b/client/hooks/useFailingAssertions.js
@@ -9,27 +9,61 @@ export const useFailingAssertions = testPlanReport => {
     return testPlanReport.finalizedTestResults.flatMap(
       (testResult, testIndex) => {
         return testResult.scenarioResults.flatMap(scenarioResult => {
-          return (
-            scenarioResult.assertionResults
-              .filter(assertionResult => !assertionResult.passed)
-              // We only want to show MUST and SHOULD assertions
-              .filter(
-                assertionResult =>
-                  assertionResult.assertion.priority !== 'MAY' &&
-                  assertionResult.assertion.priority !== 'EXCLUDE'
-              )
-              .map(assertionResult => ({
-                testResultId: testResult.id,
-                testIndex,
-                testTitle: testResult.test.title,
-                scenarioCommands: scenarioResult.scenario.commands
-                  .map(cmd => cmd.text)
-                  .join(', '),
-                assertionText: assertionResult.assertion.text,
-                priority: assertionResult.assertion.priority,
-                output: scenarioResult.output
-              }))
+          const commonResult = {
+            testResultId: testResult.id,
+            testIndex,
+            testTitle: testResult.test.title,
+            scenarioCommands: scenarioResult.scenario.commands
+              .map((cmd, index) => {
+                if (index === scenarioResult.scenario.commands.length - 1) {
+                  return cmd.text;
+                }
+                // Prevent instances of duplicated setting in brackets.
+                // eg. Down Arrow (virtual cursor active) then Down Arrow (virtual cursor active)
+                //
+                // Expectation is Down Arrow then Down Arrow (virtual cursor active), because the setting will always be
+                // the same for the listed key combination.
+                //
+                // Some revision of how that key combination + setting is rendered may be useful
+                return cmd.text.split(' (')[0];
+              })
+              .join(' then ')
+          };
+
+          const assertionResults = scenarioResult.assertionResults
+            .filter(assertionResult => !assertionResult.passed)
+            // We only want to show MUST and SHOULD assertions
+            .filter(
+              assertionResult =>
+                assertionResult.assertion.priority !== 'MAY' &&
+                assertionResult.assertion.priority !== 'EXCLUDE'
+            )
+            .map(assertionResult => ({
+              ...commonResult,
+              assertionText: assertionResult.assertion.text,
+              priority: assertionResult.assertion.priority,
+              output: scenarioResult.output
+            }));
+
+          const unexpectedResults = scenarioResult.unexpectedBehaviors.map(
+            unexpectedBehavior => ({
+              ...commonResult,
+              assertionText:
+                unexpectedBehavior.impact.toLowerCase() === 'moderate'
+                  ? 'Other behaviors that create moderate negative impacts are not exhibited'
+                  : unexpectedBehavior.impact.toLowerCase() === 'severe'
+                  ? 'Other behaviors that create severe negative impacts are not exhibited'
+                  : 'N/A',
+              priority:
+                unexpectedBehavior.impact.toLowerCase() === 'moderate'
+                  ? 'SHOULD'
+                  : unexpectedBehavior.impact.toLowerCase() === 'severe'
+                  ? 'MUST'
+                  : 'N/A',
+              output: unexpectedBehavior.text
+            })
           );
+          return [...assertionResults, ...unexpectedResults];
         });
       }
     );

--- a/client/tests/e2e/snapshots/saved/_candidate-review.html
+++ b/client/tests/e2e/snapshots/saved/_candidate-review.html
@@ -167,7 +167,7 @@
                           style="justify-content: center"
                           ><i
                             ><b>3 assertions</b> failed across
-                            <b>2 tests</b> run with <b>1 browser</b></i
+                            <b>3 tests</b> run with <b>1 browser</b></i
                           ></span
                         >
                       </td>
@@ -241,7 +241,7 @@
                           style="justify-content: center"
                           ><i
                             ><b>3 assertions</b> failed across
-                            <b>2 tests</b> run with <b>1 browser</b></i
+                            <b>3 tests</b> run with <b>1 browser</b></i
                           ></span
                         >
                       </td>
@@ -317,7 +317,7 @@
                           style="justify-content: center"
                           ><i
                             ><b>3 assertions</b> failed across
-                            <b>2 tests</b> run with <b>1 browser</b></i
+                            <b>3 tests</b> run with <b>1 browser</b></i
                           ></span
                         >
                       </td>

--- a/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1#summary.html
+++ b/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1#summary.html
@@ -305,7 +305,7 @@
                           <div
                             class="failing-assertions-summary-table-container">
                             <p>
-                              2 assertions failed across 26 commands in 2 tests.
+                              3 assertions failed across 26 commands in 3 tests.
                             </p>
                             <div class="table-responsive">
                               <table
@@ -343,6 +343,21 @@
                                     <td>MUST</td>
                                     <td>Role 'button' is conveyed</td>
                                     <td>automatically seeded sample output</td>
+                                  </tr>
+                                  <tr>
+                                    <td>
+                                      <a href="/candidate-test-plan/24/1#5"
+                                        >Close a modal dialog using a button in
+                                        reading mode</a
+                                      >
+                                    </td>
+                                    <td>Space</td>
+                                    <td>SHOULD</td>
+                                    <td>
+                                      Other behaviors that create moderate
+                                      negative impacts are not exhibited
+                                    </td>
+                                    <td>Other</td>
                                   </tr>
                                 </tbody>
                               </table>

--- a/client/tests/e2e/snapshots/saved/_report_67_targets_20.html
+++ b/client/tests/e2e/snapshots/saved/_report_67_targets_20.html
@@ -370,6 +370,39 @@
           <h2 id="failing-assertions-heading">
             Summary of Failing Assertions (0 must, 1 should)
           </h2>
+          <p>1 assertions failed across 28 commands in 1 tests.</p>
+          <div class="table-responsive">
+            <table
+              aria-labelledby="failing-assertions-heading"
+              class="table table-bordered">
+              <thead>
+                <tr>
+                  <th>Test Name</th>
+                  <th>Command</th>
+                  <th>Assertion Priority</th>
+                  <th>Assertion</th>
+                  <th>NVDA Response</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <a
+                      href="/report/67/targets/20#result-ODhiYeyIxMiI6MjB9TRkYW"
+                      >Navigate backwards to a mixed checkbox in reading mode</a
+                    >
+                  </td>
+                  <td>Shift+X</td>
+                  <td>SHOULD</td>
+                  <td>
+                    Other behaviors that create moderate negative impacts are
+                    not exhibited
+                  </td>
+                  <td>Other</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <div class="test-result-heading">
             <h2 id="result-NjAyYeyIxMiI6MjB92VjN2" tabindex="-1">
               Test 1: Navigate forwards to a mixed checkbox in reading

--- a/server/migrations/20250206165746-updateMetrics.js
+++ b/server/migrations/20250206165746-updateMetrics.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { recalculateMetrics, dumpTable } = require('./utils');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.transaction(async transaction => {
+      await dumpTable('TestPlanReport');
+      await recalculateMetrics(queryInterface, transaction);
+    });
+  },
+
+  async down() {
+    // Restore dumped TestPlanReport table if needed
+  }
+};

--- a/shared/getMetrics.js
+++ b/shared/getMetrics.js
@@ -11,9 +11,11 @@ const countTests = ({
 }) => {
   const countScenarioResult = scenarioResult => {
     return (
-      scenarioResult?.assertionResults?.every(
+      (scenarioResult?.assertionResults?.every(
         assertionResult => assertionResult.passed
-      ) || 0
+      ) &&
+        scenarioResult.unexpectedBehaviors.length === 0) ||
+      0
     );
   };
 
@@ -21,6 +23,24 @@ const countTests = ({
     if (passedOnly)
       return testResult?.scenarioResults?.every(countScenarioResult) ? 1 : 0;
     return testResult ? 1 : 0;
+  };
+  const countTestPlanReport = testPlanReport => {
+    return sum(
+      testPlanReport?.finalizedTestResults?.map(countTestResult) || []
+    );
+  };
+
+  if (testPlanReport) return countTestPlanReport(testPlanReport);
+  if (testResult) return countTestResult(testResult);
+  return countScenarioResult(scenarioResult);
+};
+
+const countAvailableData = (
+  countScenarioResult,
+  { testPlanReport, testResult, scenarioResult }
+) => {
+  const countTestResult = testResult => {
+    return sum(testResult?.scenarioResults?.map(countScenarioResult) || []);
   };
   const countTestPlanReport = testPlanReport => {
     return sum(
@@ -77,47 +97,33 @@ const countAssertions = ({
     if (passedOnly) return all.filter(each => each.passed).length;
     return all.length;
   };
-  const countTestResult = testResult => {
-    return sum(testResult?.scenarioResults?.map(countScenarioResult) || []);
-  };
-  const countTestPlanReport = testPlanReport => {
-    return sum(
-      testPlanReport?.finalizedTestResults?.map(countTestResult) || []
-    );
-  };
-
-  if (testPlanReport) return countTestPlanReport(testPlanReport);
-  if (testResult) return countTestResult(testResult);
-  return countScenarioResult(scenarioResult);
+  return countAvailableData(countScenarioResult, {
+    testPlanReport,
+    testResult,
+    scenarioResult
+  });
 };
 
 const countUnexpectedBehaviors = ({
-  scenarioResult, // Choose one to provide
+  testPlanReport, // Choose one to provide
   testResult, // Choose one to provide
-  testPlanReport // Choose one to provide
+  scenarioResult // Choose one to provide
 }) => {
   const countScenarioResult = scenarioResult => {
     return scenarioResult?.unexpectedBehaviors?.length || 0;
   };
-  const countTestResult = testResult => {
-    return sum(testResult?.scenarioResults?.map(countScenarioResult) || []);
-  };
-  const countTestPlanReport = testPlanReport => {
-    return sum(
-      testPlanReport?.finalizedTestResults?.map(countTestResult) || []
-    );
-  };
-
-  if (testPlanReport) return countTestPlanReport(testPlanReport);
-  if (testResult) return countTestResult(testResult);
-  return countScenarioResult(scenarioResult);
+  return countAvailableData(countScenarioResult, {
+    testPlanReport,
+    testResult,
+    scenarioResult
+  });
 };
 
 const countUnexpectedBehaviorsImpact = (
   {
-    scenarioResult, // Choose one to provide
+    testPlanReport, // Choose one to provide
     testResult, // Choose one to provide
-    testPlanReport // Choose one to provide
+    scenarioResult // Choose one to provide
   },
   impact
 ) => {
@@ -126,40 +132,26 @@ const countUnexpectedBehaviorsImpact = (
       ? 1
       : 0;
   };
-  const countTestResult = testResult => {
-    return sum(testResult?.scenarioResults?.map(countScenarioResult) || []);
-  };
-  const countTestPlanReport = testPlanReport => {
-    return sum(
-      testPlanReport?.finalizedTestResults?.map(countTestResult) || []
-    );
-  };
-
-  if (testPlanReport) return countTestPlanReport(testPlanReport);
-  if (testResult) return countTestResult(testResult);
-  return countScenarioResult(scenarioResult);
+  return countAvailableData(countScenarioResult, {
+    testPlanReport,
+    testResult,
+    scenarioResult
+  });
 };
 
 const countCommands = ({
-  scenarioResult, // Choose one to provide
+  testPlanReport, // Choose one to provide
   testResult, // Choose one to provide
-  testPlanReport // Choose one to provide
+  scenarioResult // Choose one to provide
 }) => {
   const countScenarioResult = scenarioResult => {
     return scenarioResult?.scenario?.commands?.length ? 1 : 0;
   };
-  const countTestResult = testResult => {
-    return sum(testResult?.scenarioResults?.map(countScenarioResult) || []);
-  };
-  const countTestPlanReport = testPlanReport => {
-    return sum(
-      testPlanReport?.finalizedTestResults?.map(countTestResult) || []
-    );
-  };
-
-  if (testPlanReport) return countTestPlanReport(testPlanReport);
-  if (testResult) return countTestResult(testResult);
-  return countScenarioResult(scenarioResult);
+  return countAvailableData(countScenarioResult, {
+    testPlanReport,
+    testResult,
+    scenarioResult
+  });
 };
 
 const calculateAssertionPriorityCounts = (result, priority) => {


### PR DESCRIPTION
Noticed that the description shared on the Candidate Review page for what failed wasn't matching the result when opening the Candidate Run page.

Example:

* Color Viewer Slider stating "16 assertions failed across 3 tests run with 1 browser" on the Candidate Review Page
![screenshot of the above description from the Candidate Review Page](https://github.com/user-attachments/assets/a79b39d4-f292-49db-96ac-291a84175cf1)

* but yet the Candidate Run Page states "10 assertions failed across 20 commands in 3 tests" so there was a discrepancy when it came to the number of assertions
![screenshot of the above description from the Candidate Run page](https://github.com/user-attachments/assets/9fbe271a-df50-43d0-9153-b0d83d182fb7)

Found this to be coming from no handling happening for the undesirable behaviors which are [derived failures](https://github.com/w3c/aria-at-app/blob/9c54e2d12e471c69f3bb5e79a11193df33c7fbe9/client/components/common/TestPlanResultsTable/index.jsx#L91:L120). This was also being missed in the overall getMetrics calculation so tests where only an undesirable behavior was listed, the test wasn't defined as "failed". So we could end up in situations where the summary would read "12 assertions failed across 0 tests run with 2 browsers"

 This PR now adjusts and recalculates for that.