### PR TITLE
feat: Copy historical results between reports when run with previous automatable version

### DIFF
--- a/server/models/services/AtVersionService.js
+++ b/server/models/services/AtVersionService.js
@@ -456,5 +456,5 @@ module.exports = {
   removeAtVersionById,
   findOrCreateAtVersion,
   getUniqueAtVersionsForReport,
-  getRefreshableTestPlanReports: getRefreshableTestPlanReportsForVersion
+  getRefreshableTestPlanReportsForVersion
 };

--- a/server/models/services/CollectionJobService.js
+++ b/server/models/services/CollectionJobService.js
@@ -37,7 +37,7 @@ const getGraphQLContext = require('../../graphql-context');
 const { getBotUserByAtId } = require('./UserService');
 const {
   getAtVersionWithRequirements,
-  getRefreshableTestPlanReports
+  getRefreshableTestPlanReportsForVersion
 } = require('./AtVersionService');
 
 // association helpers to be included with Models' results
@@ -739,7 +739,7 @@ const createCollectionJobsFromPreviousAtVersion = async ({
   transaction
 }) => {
   const { currentVersion, refreshableReports } =
-    await getRefreshableTestPlanReports({
+    await getRefreshableTestPlanReportsForVersion({
       currentAtVersionId: atVersionId,
       transaction
     });


### PR DESCRIPTION
This is an extension of #1320 and adds historical assertion verdict copying between reports for "refresh" runs