### PR TITLE
Fix build issue and address date issue with snapshots

### DIFF
--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -8,16 +8,22 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
-      - name: Install NodeJS 18
+      - name: Install NodeJS 20
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'npm'
+          node-version: 20
+          cache: npm
       - run: yarn --version
+      - name: Remove pre-bundled versions of postgres to avoid version clashes
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y postgresql\*
+          sudo apt-get autoremove -y
+          sudo rm -rf /var/lib/postgresql/
+          sudo rm -rf /etc/postgresql/
       - name: Install PostgreSQL 12
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |sudo tee  /etc/apt/sources.list.d/pgdg.list
+          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get -y update
           sudo apt-get -y install postgresql-12
           sudo apt-get -y install postgresql-client-12

--- a/.github/workflows/version-changelog-update.yml
+++ b/.github/workflows/version-changelog-update.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
-      - name: Install NodeJS 18
+      - name: Install NodeJS 20
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
       - name: Conventional Changelog Action
         uses: TriPSs/conventional-changelog-action@v3

--- a/client/components/ManageTestQueue/AddTestPlans.jsx
+++ b/client/components/ManageTestQueue/AddTestPlans.jsx
@@ -162,7 +162,7 @@ const AddTestPlans = ({
             {matchingTestPlanVersions.length ? (
               matchingTestPlanVersions.map(item => (
                 <option key={`${item.gitSha}-${item.id}`} value={item.id}>
-                  {dates.gitUpdatedDateToString(item.updatedAt)}{' '}
+                  {dates.convertDateToString(item.updatedAt, 'MMM D, YYYY')}{' '}
                   {item.gitMessage} ({item.gitSha.substring(0, 7)})
                 </option>
               ))

--- a/client/tests/e2e/snapshots/saved/_account_settings.html
+++ b/client/tests/e2e/snapshots/saved/_account_settings.html
@@ -100,7 +100,7 @@
                 Import Latest Test Plan Versions
               </button>
               <p>
-                Date of latest test plan version: February 12, 2025 02:25 UTC
+                Date of latest test plan version: February 13, 2025 01:40 UTC
               </p>
             </section>
           </div>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -286,9 +286,9 @@
                       >Test Plan Version</label
                     ><select aria-disabled="false" class="form-select">
                       <option value="88">
-                        Feb 12, 2025 at 1:40:16 am UTC Menu button test plans:
-                        Change priority of assertion stateCollapsed from 1 to 2
-                        (pull #1196) (bac64bf)
+                        Feb 13, 2025 Menu button test plans: Change priority of
+                        assertion stateCollapsed from 1 to 2 (pull #1196)
+                        (bac64bf)
                       </option>
                     </select>
                   </div>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -286,8 +286,9 @@
                       >Test Plan Version</label
                     ><select aria-disabled="false" class="form-select">
                       <option value="88">
-                        Sep 18, 2024 at 6:30:36 pm UTC Add quick nav instruction
-                        for test 9 with VoiceOver (#1127) (122e07a)
+                        Feb 12, 2025 at 1:40:16 am UTC Menu button test plans:
+                        Change priority of assertion stateCollapsed from 1 to 2
+                        (pull #1196) (bac64bf)
                       </option>
                     </select>
                   </div>
@@ -537,7 +538,7 @@
                           <path
                             fill="currentColor"
                             d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                        ><b>V24.09.18</b></span
+                        ><b>V25.02.13</b></span
                       ></span
                     ><span role="listitem" class="review-complete"
                       >Review Completed&nbsp;<b>Sep 22, 2024</b></span
@@ -563,7 +564,7 @@
                           <path
                             fill="currentColor"
                             d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                        ><b>V24.09.18</b></span
+                        ><b>V25.02.13</b></span
                       ></span
                     ><span role="listitem" class="review-complete"
                       >Review Completed&nbsp;<b>Sep 23, 2024</b></span
@@ -590,7 +591,7 @@
                             <path
                               fill="currentColor"
                               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V24.09.18</b></span
+                          ><b>V25.02.13</b></span
                         ></a
                       ></span
                     ><span role="listitem"
@@ -1270,7 +1271,7 @@
                 <td>
                   <div class="css-bpz90">
                     <span class="rd full-width css-be9e2a">R&amp;D</span>
-                    <p class="review-text">Complete <b>Oct 31, 2024</b></p>
+                    <p class="review-text">Complete <b>Feb 13, 2025</b></p>
                   </div>
                 </td>
                 <td>
@@ -1293,7 +1294,7 @@
                             <path
                               fill="currentColor"
                               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V24.10.31</b></span
+                          ><b>V25.02.13</b></span
                         ></a
                       ></span
                     ><button
@@ -2311,7 +2312,7 @@
                 <td>
                   <div class="css-bpz90">
                     <span class="rd full-width css-be9e2a">R&amp;D</span>
-                    <p class="review-text">Complete <b>Oct 12, 2024</b></p>
+                    <p class="review-text">Complete <b>Feb 13, 2025</b></p>
                   </div>
                 </td>
                 <td>
@@ -2334,7 +2335,7 @@
                             <path
                               fill="currentColor"
                               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V24.10.12</b></span
+                          ><b>V25.02.13</b></span
                         ></a
                       ></span
                     ><button

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -230,8 +230,9 @@
                       >Test Plan Version</label
                     ><select aria-disabled="false" class="form-select">
                       <option value="88">
-                        Sep 18, 2024 at 6:30:36 pm UTC Add quick nav instruction
-                        for test 9 with VoiceOver (#1127) (122e07a)
+                        Feb 12, 2025 at 1:40:16 am UTC Menu button test plans:
+                        Change priority of assertion stateCollapsed from 1 to 2
+                        (pull #1196) (bac64bf)
                       </option>
                     </select>
                   </div>

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -230,9 +230,9 @@
                       >Test Plan Version</label
                     ><select aria-disabled="false" class="form-select">
                       <option value="88">
-                        Feb 12, 2025 at 1:40:16 am UTC Menu button test plans:
-                        Change priority of assertion stateCollapsed from 1 to 2
-                        (pull #1196) (bac64bf)
+                        Feb 13, 2025 Menu button test plans: Change priority of
+                        assertion stateCollapsed from 1 to 2 (pull #1196)
+                        (bac64bf)
                       </option>
                     </select>
                   </div>

--- a/shared/dates.js
+++ b/shared/dates.js
@@ -1,19 +1,24 @@
+// TODO: momentjs is no longer supported. Replace with another date utility/practice. See https://momentjs.com/docs/#/-project-status/.
 const moment = require('moment');
 
-const convertDateToString = (date, format = 'DD-MM-YYYY') => {
+const convertDateToString = (date, format = 'DD-MM-YYYY', { locale } = {}) => {
   if (!date) return '';
+  if (locale) setLocale(locale);
   return moment.utc(date).format(format);
 };
 
-const convertStringToDate = (date, format = 'DD-MM-YYYY') => {
+const convertStringToDate = (date, format = 'DD-MM-YYYY', { locale } = {}) => {
+  if (locale) setLocale(locale);
   return moment.utc(date, format).toDate();
 };
 
 const convertStringFormatToAnotherFormat = (
   date,
   fromFormat = 'DD-MM-YYYY',
-  toFormat = 'MM-DD-YYYY'
+  toFormat = 'MM-DD-YYYY',
+  { locale } = {}
 ) => {
+  if (locale) setLocale(locale);
   return moment.utc(date, fromFormat).format(toFormat);
 };
 
@@ -32,24 +37,7 @@ const checkDaysBetweenDates = (date, otherDate) => {
   return Math.ceil(hours / 24);
 };
 
-const gitUpdatedDateToString = (dateString, locale = 'default') => {
-  const lc = (pattern, string) =>
-    string.replace(pattern, pattern.toLowerCase());
-  const timeZone = 'UTC';
-  const options = { month: 'short' };
-
-  const date = new Date(dateString);
-  const month = date.toLocaleString(locale, options);
-  const day = date.getDate();
-  const year = date.getFullYear();
-  const time = date
-    .toLocaleTimeString(locale, { timeZone: timeZone })
-    .replace(/\s/g, ' ');
-
-  const timeStamp = `${month} ${day}, ${year} at ${time} ${timeZone}`;
-
-  return lc('PM', lc('AM', timeStamp));
-};
+const setLocale = (locale = 'en') => moment.locale(locale);
 
 module.exports = {
   convertDateToString,
@@ -57,6 +45,5 @@ module.exports = {
   convertStringFormatToAnotherFormat,
   isValidDate,
   isAfterYear,
-  checkDaysBetweenDates,
-  gitUpdatedDateToString
+  checkDaysBetweenDates
 };

--- a/shared/tests/dates.test.js
+++ b/shared/tests/dates.test.js
@@ -1,28 +1,51 @@
-const { gitUpdatedDateToString } = require('../dates');
+const { convertDateToString } = require('../dates');
 
-describe('gitUpdatedDateToString', () => {
-  it('returns a formatted string AM', () => {
+describe('convertDateToString', () => {
+  const outputFormat = 'MMM D, YYYY [at] h:mm:ss a z';
+
+  it('returns the correctly parsed date for a timestamp', () => {
+    const date = '2025-02-03T01:40:16.000Z';
+    const formattedDate1 = convertDateToString(date, outputFormat);
+    const formattedDate2 = convertDateToString(date, 'DD-MM-YYYY');
+    const formattedDate3 = convertDateToString(date, 'MMM D, YYYY');
+    const formattedDate4 = convertDateToString(date, 'MMMM [the] Do [of] YYYY');
+
+    expect(formattedDate1).toBe('Feb 3, 2025 at 1:40:16 am UTC');
+    expect(formattedDate2).toBe('03-02-2025');
+    expect(formattedDate3).toBe('Feb 3, 2025');
+    expect(formattedDate4).toBe('February the 3rd of 2025');
+  });
+
+  it('returns a formatted string AM (English)', () => {
     const date = '2021-11-30T09:51:28.000Z';
-    const formattedDate = gitUpdatedDateToString(date, 'en-US');
+    const formattedDate = convertDateToString(date, outputFormat, {
+      locale: 'en'
+    });
     expect(formattedDate).toBe('Nov 30, 2021 at 9:51:28 am UTC');
   });
 
-  it('returns a formatted string PM', () => {
+  it('returns a formatted string PM (English)', () => {
     const date = '2021-11-30T14:51:28.000Z';
-    const formattedDate = gitUpdatedDateToString(date, 'en-US');
+    const formattedDate = convertDateToString(date, outputFormat, {
+      locale: 'en'
+    });
     expect(formattedDate).toBe('Nov 30, 2021 at 2:51:28 pm UTC');
   });
 
   it('returns a formatted string when using 24-hour notation in a different locale (French)', () => {
     const date = '2021-11-30T14:51:28.000Z';
-    const formattedDate = gitUpdatedDateToString(date, 'fr-FR');
+    const formattedDate = convertDateToString(date, outputFormat, {
+      locale: 'fr'
+    });
     // French time uses a lowercase month notation
-    expect(formattedDate).toBe('nov. 30, 2021 at 14:51:28 UTC');
+    expect(formattedDate).toBe('nov. 30, 2021 at 2:51:28 pm UTC');
   });
 
   it('returns a formatted string when using a different locale (Korean)', () => {
     const date = '2021-11-30T14:51:28.000Z';
-    const formattedDate = gitUpdatedDateToString(date, 'ko-KR');
-    expect(formattedDate).toBe('11월 30, 2021 at 오후 2:51:28 UTC');
+    const formattedDate = convertDateToString(date, outputFormat, {
+      locale: 'ko'
+    });
+    expect(formattedDate).toBe('11월 30, 2021 at 2:51:28 오후 UTC');
   });
 });

--- a/shared/tests/dates.test.js
+++ b/shared/tests/dates.test.js
@@ -16,6 +16,19 @@ describe('convertDateToString', () => {
     expect(formattedDate4).toBe('February the 3rd of 2025');
   });
 
+  it('returns the correctly parsed UTC date for a non-UTC timestamp', () => {
+    const date = '2025-02-02T20:40:16.000-05:00';
+    const formattedDate1 = convertDateToString(date, outputFormat);
+    const formattedDate2 = convertDateToString(date, 'DD-MM-YYYY');
+    const formattedDate3 = convertDateToString(date, 'MMM D, YYYY');
+    const formattedDate4 = convertDateToString(date, 'MMMM [the] Do [of] YYYY');
+
+    expect(formattedDate1).toBe('Feb 3, 2025 at 1:40:16 am UTC');
+    expect(formattedDate2).toBe('03-02-2025');
+    expect(formattedDate3).toBe('Feb 3, 2025');
+    expect(formattedDate4).toBe('February the 3rd of 2025');
+  });
+
   it('returns a formatted string AM (English)', () => {
     const date = '2021-11-30T09:51:28.000Z';
     const formattedDate = convertDateToString(date, outputFormat, {


### PR DESCRIPTION
This PR does the following:

**Build Issue**
The [Postgres 16.8](https://github.com/actions/runner-images/blob/ubuntu24/20250302.1/images/ubuntu/Ubuntu2404-Readme.md#postgresql) bundled in the latest `ubuntu-24` image is unexpectedly unable to be ignored during the build process. It cannot be overwritten or have another postgres version installed alongside it. The last successful build's image used [Postgres 16.6](https://github.com/actions/runner-images/blob/ubuntu24/20250209.1/images/ubuntu/Ubuntu2404-Readme.md#postgresql) bundled so I can only assume it's because of the version or some permissions issue but not completely sure.

So this PR removes any instances of pre-bundled postgres pacakges first then installs our instance. It is a less than ideal but it eliminates this current blocker. Will continue to investigate with a lower priority.

**Snapshots Timestamp Issue**
Removes an outdated utility in favor of our standard UTC-based date utilities.