### PR TITLE
fix: Account for `referencePage` update during copy process

### DIFF
--- a/client/tests/e2e/snapshots/saved/_account_settings.html
+++ b/client/tests/e2e/snapshots/saved/_account_settings.html
@@ -99,7 +99,7 @@
               <button type="button" class="btn btn-primary">
                 Import Latest Test Plan Versions
               </button>
-              <p>Date of latest test plan version: March 6, 2025 19:25 UTC</p>
+              <p>Date of latest test plan version: March 14, 2025 18:33 UTC</p>
             </section>
           </div>
         </main>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -2210,7 +2210,7 @@
                 <td>
                   <div class="css-bpz90">
                     <span class="rd full-width css-be9e2a">R&amp;D</span>
-                    <p class="review-text">Complete <b>Mar 6, 2025</b></p>
+                    <p class="review-text">Complete <b>Mar 14, 2025</b></p>
                   </div>
                 </td>
                 <td>
@@ -2233,7 +2233,7 @@
                             <path
                               fill="currentColor"
                               d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                          ><b>V25.03.06</b></span
+                          ><b>V25.03.14</b></span
                         ></a
                       ></span
                     ><button

--- a/server/resolvers/helpers/processCopiedReports.js
+++ b/server/resolvers/helpers/processCopiedReports.js
@@ -329,6 +329,11 @@ const processCopiedReports = async ({
     );
 
     for (const oldTestPlanRun of oldTestPlanReport.testPlanRuns) {
+      // Don't create a new test plan run if previous run was for a bot to avoid unexpected assignment results
+      // Bot assignments orchestrated and controlled by separate system
+      const isBotIdRegex = /^9\d{3}$/; // Currently, user ids for bots are in the format '9XXX'
+      if (isBotIdRegex.test(oldTestPlanRun.testerUserId)) continue;
+
       const oldTestPlanRunVendorReviewStatus =
         oldTestPlanReport.vendorReviewStatus;
 

--- a/server/util/aria.js
+++ b/server/util/aria.js
@@ -28,6 +28,7 @@ const testWithModifiedAttributes = (test, { forUpdateCompare }) => {
     // The updated settings, instructions or references should be shown when
     // the copy process is done
     propertiesToOmit.push('renderableContent.target.at.settings');
+    propertiesToOmit.push('renderableContent.target.referencePage');
     propertiesToOmit.push('renderableContent.instructions');
     propertiesToOmit.push('renderableContent.info.references');
     // for v1 format since structure is:


### PR DESCRIPTION
In reviewing the newly imported result of https://github.com/w3c/aria-at/pull/1208, the referencePage name update was unnecessarily tossing away old results which shouldn't happen.

This also doesn't create new bot assignments if they were assigned to an old test plan run (and were not yet assigned to be evaluated). The bot assignemnt orchestration is done by a separate system which may cause unexpected issues during the copy (today, every new run undergoes a bot assignment as well)