### PR TITLE
fix: `releasedAt` attribute-related fixes

### DIFF
--- a/client/components/common/UpdateVersionModal/index.jsx
+++ b/client/components/common/UpdateVersionModal/index.jsx
@@ -102,7 +102,7 @@ const UpdateVersionModal = ({
     }
 
     handleAction(actionType, {
-      updatedVersionText,
+      updatedVersionText: updatedVersionText.trim(),
       updatedDateAvailabilityText
     });
   };

--- a/client/tests/e2e/AtVersions.e2e.test.js
+++ b/client/tests/e2e/AtVersions.e2e.test.js
@@ -17,17 +17,17 @@ describe('AT Version UI', () => {
       await page.waitForSelector('.modal-title ::-p-text(Add a New Version for JAWS)');
       await page.waitForSelector('.modal-body .form-group:nth-child(1) ::-p-text(Version Number)');
       await page.waitForSelector('.modal-body .form-group:nth-child(2) ::-p-text(Approximate date of availability)');
-      await page.type('.modal-body .form-group:nth-child(1) input', '99.0.1');
+      await page.type('.modal-body .form-group:nth-child(1) input', '2020.0.1');
       await page.type('.modal-body .form-group:nth-child(2) input', '01-01-2000');
       await page.click('.modal-footer button ::-p-text(Add Version)');
       await page.waitForNetworkIdle({ idleTime: 5000 });
       await page.click('.modal-footer button ::-p-text(Ok)');
-      await page.waitForSelector('.at-versions-container option:nth-child(2) ::-p-text(99.0.1)');
+      await page.waitForSelector('.at-versions-container option:nth-child(2) ::-p-text(2020.0.1)');
       const optionValue = await page.$eval('.at-versions-container option:nth-child(2)', option => option.value);
       await page.select('.at-versions-container select', optionValue);
       await page.click('.at-versions-container button ::-p-text(Edit)');
       const input = await page.waitForSelector('.modal-body .form-group:nth-child(1) input');
-      for (let i = 0; i < 6; i += 1) {
+      for (let i = 0; i < 8; i += 1) {
         await input.press('Backspace');
       }
       await page.type('.modal-body .form-group:nth-child(1) input', '99.0.99');

--- a/server/models/loaders/AtLoader.js
+++ b/server/models/loaders/AtLoader.js
@@ -1,4 +1,5 @@
 const { getAts } = require('../services/AtService');
+const { utils } = require('shared');
 
 const AtLoader = () => {
   let ats;
@@ -18,8 +19,8 @@ const AtLoader = () => {
         // Sort date of atVersions subarray in desc order by releasedAt date
         ats
           .sort((a, b) => a.name.localeCompare(b.name))
-          .forEach(item =>
-            item.atVersions.sort((a, b) => b.releasedAt - a.releasedAt)
+          .forEach(
+            item => (item.atVersions = utils.sortAtVersions(item.atVersions))
           );
 
         ats = ats.map(at => ({

--- a/server/scripts/populate-test-data/populateFakeTestResults.js
+++ b/server/scripts/populate-test-data/populateFakeTestResults.js
@@ -231,7 +231,12 @@ const getFake = async ({
 
   const atVersion = await getAtVersionByQuery({
     where: { atId: testPlanReport.at.id },
-    pagination: { order: [['releasedAt', 'DESC']] },
+    pagination: {
+      order: [
+        ['name', 'DESC'],
+        ['releasedAt', 'DESC']
+      ]
+    },
     transaction
   });
 

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -955,7 +955,12 @@ const getMutationInputs = async () => {
 
   const atVersion = await getAtVersionByQuery({
     where: { atId: at.id },
-    pagination: { order: [['releasedAt', 'DESC']] },
+    pagination: {
+      order: [
+        ['name', 'DESC'],
+        ['releasedAt', 'DESC']
+      ]
+    },
     transaction: false
   });
 

--- a/server/util/getAtVersionWithRequirements.js
+++ b/server/util/getAtVersionWithRequirements.js
@@ -28,8 +28,13 @@ const getAtVersionWithRequirements = async (
         atId,
         releasedAt: { [Op.gte]: minimumAtVersion.releasedAt }
       },
+      // If there is ever a significant shift in how the ATs' versions we're
+      // collecting changes, this has to be revisited
       pagination: {
-        order: [['releasedAt', 'ASC']]
+        order: [
+          ['name', 'DESC'],
+          ['releasedAt', 'DESC']
+        ]
       },
       transaction
     });
@@ -41,7 +46,7 @@ const getAtVersionWithRequirements = async (
 
     const latestSupportedAtVersion = matchingAtVersions.find(
       atv =>
-        supportedVersions.includes(atv.name) &&
+        supportedVersions.includes(atv.name.trim()) &&
         new Date(atv.releasedAt) >= new Date(minimumAtVersion.releasedAt)
     );
 

--- a/shared/index.js
+++ b/shared/index.js
@@ -2,5 +2,12 @@ const calculations = require('./calculations');
 const convertAssertionPriority = require('./convertAssertionPriority');
 const dates = require('./dates');
 const getMetrics = require('./getMetrics');
+const utils = require('./utils');
 
-module.exports = { calculations, convertAssertionPriority, getMetrics, dates };
+module.exports = {
+  calculations,
+  convertAssertionPriority,
+  dates,
+  getMetrics,
+  utils
+};

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Sort AtVersions by major version, then by releasedAt date, both in descending
+ * order by default.
+ *
+ * @param {AtVersion[]} atVersions
+ * @returns {*[]}
+ */
+const sortAtVersions = (atVersions = []) => {
+  return atVersions.sort((a, b) => {
+    // Compare versions as strings in descending order
+    const versionCompare = b.name.localeCompare(a.name);
+    if (versionCompare !== 0) return versionCompare;
+
+    // Compare by release date
+    const dateA = new Date(a.releasedAt);
+    const dateB = new Date(b.releasedAt);
+    return dateB - dateA;
+  });
+};
+
+module.exports = {
+  sortAtVersions
+};


### PR DESCRIPTION
Address #1355 

* Sorts the list of AtVersions also by the version name, instead of just the `releasedAt`.
* Ensures the latest (by semantic version and released date) atVersion is being selected when a minimum version is set for a report and has automation triggered for it.