### PR TITLE
fix: calculate unique commands for failing assertions in failing assertions summary table subheader

### DIFF
--- a/client/components/FailingAssertionsSummary/Table.jsx
+++ b/client/components/FailingAssertionsSummary/Table.jsx
@@ -21,7 +21,8 @@ const FailingAssertionsSummaryTable = ({
     <>
       <p>
         {failingAssertions.length} assertions failed across{' '}
-        {metrics.commandsCount} commands in {metrics.testsFailedCount} tests.
+        {failingAssertions.uniqueCommandsCount} commands in{' '}
+        {metrics.testsFailedCount} tests.
       </p>
 
       <Table bordered responsive aria-labelledby="failing-assertions-heading">

--- a/client/components/common/fragments/ScenarioResult.js
+++ b/client/components/common/fragments/ScenarioResult.js
@@ -29,6 +29,7 @@ const SCENARIO_RESULT_FIELDS = (type = 'simple') => {
           id
           output
           scenario {
+            id
             commands {
               id
               text

--- a/client/hooks/useFailingAssertions.js
+++ b/client/hooks/useFailingAssertions.js
@@ -6,7 +6,7 @@ export const useFailingAssertions = testPlanReport => {
       return [];
     }
 
-    return testPlanReport.finalizedTestResults.flatMap(
+    const failingAssertions = testPlanReport.finalizedTestResults.flatMap(
       (testResult, testIndex) => {
         return testResult.scenarioResults.flatMap(scenarioResult => {
           const commonResult = {
@@ -27,7 +27,10 @@ export const useFailingAssertions = testPlanReport => {
                 // Some revision of how that key combination + setting is rendered may be useful
                 return cmd.text.split(' (')[0];
               })
-              .join(' then ')
+              .join(' then '),
+            commandId: `${
+              scenarioResult.scenario.id
+            }_${scenarioResult.scenario.commands.map(cmd => cmd.id).join('_')}`
           };
 
           /**
@@ -72,5 +75,12 @@ export const useFailingAssertions = testPlanReport => {
         });
       }
     );
+
+    const uniqueCommandsWithFailures = new Set(
+      failingAssertions.map(a => a.commandId)
+    );
+    failingAssertions.uniqueCommandsCount = uniqueCommandsWithFailures.size;
+
+    return failingAssertions;
   }, [testPlanReport]);
 };

--- a/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1#summary.html
+++ b/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1#summary.html
@@ -300,7 +300,7 @@
                           <div
                             class="failing-assertions-summary-table-container">
                             <p>
-                              3 assertions failed across 26 commands in 3 tests.
+                              3 assertions failed across 3 commands in 3 tests.
                             </p>
                             <div class="table-responsive">
                               <table

--- a/client/tests/e2e/snapshots/saved/_report_67_targets_20.html
+++ b/client/tests/e2e/snapshots/saved/_report_67_targets_20.html
@@ -370,7 +370,7 @@
           <h2 id="failing-assertions-heading">
             Summary of Failing Assertions (0 must, 1 should)
           </h2>
-          <p>1 assertions failed across 28 commands in 1 tests.</p>
+          <p>1 assertions failed across 1 commands in 1 tests.</p>
           <div class="table-responsive">
             <table
               aria-labelledby="failing-assertions-heading"


### PR DESCRIPTION
see title

addresses #1351 

The previous number for commands used in this element was [the source of discussion during initial review](https://github.com/w3c/aria-at-app/pull/1288#discussion_r1907855493). There was uncertainty on the intention. It is now understood that this number should represent unique commands for which there is a failing assertion.