### PR TITLE
chore: add workflow for automatically updating snapshots

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,40 @@
+name: 'Setup Test Environment'
+description: 'Sets up Node.js, PostgreSQL, and initializes the test database'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install NodeJS 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: yarn
+
+    - name: Setup PostgreSQL
+      shell: bash
+      run: |
+        sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y postgresql\*
+        sudo apt-get autoremove -y
+        sudo rm -rf /var/lib/postgresql/
+        sudo rm -rf /etc/postgresql/
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        sudo apt-get -y update
+        sudo apt-get -y install postgresql-12 postgresql-client-12
+        sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/12/main/postgresql.conf
+        sudo pg_ctlcluster 12 main restart
+
+    - name: Setup database
+      shell: bash
+      run: |
+        yarn --frozen-lockfile
+        npx patch-package
+        source config/test.env
+        sudo -u postgres createdb ${PGDATABASE}
+        sudo -u postgres psql -c "CREATE ROLE ${PGUSER} WITH LOGIN PASSWORD '${PGPASSWORD}'"
+        sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE ${PGDATABASE} to ${PGUSER};"
+        yarn sequelize:test db:migrate
+        yarn sequelize:test db:seed:all
+        yarn workspace server db-import-tests:test -c "${IMPORT_ARIA_AT_TESTS_COMMIT_1} ${IMPORT_ARIA_AT_TESTS_COMMIT_2} ${IMPORT_ARIA_AT_TESTS_COMMIT_3} ${IMPORT_ARIA_AT_TESTS_COMMIT_4}"
+        yarn workspace server db-import-tests:test
+        yarn workspace server db-populate-sample-data:test

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -8,45 +8,11 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
-      - name: Install NodeJS 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: yarn --version
-      - name: Remove pre-bundled versions of postgres to avoid version clashes
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y postgresql\*
-          sudo apt-get autoremove -y
-          sudo rm -rf /var/lib/postgresql/
-          sudo rm -rf /etc/postgresql/
-      - name: Install PostgreSQL 12
-        run: |
-          wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-          sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get -y update
-          sudo apt-get -y install postgresql-12
-          sudo apt-get -y install postgresql-client-12
-      - name: before_install
-        run: |
-          sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/12/main/postgresql.conf
-          sudo pg_ctlcluster 12 main restart
-      - name: before_script
-        run: |
-          yarn --frozen-lockfile
-          npx patch-package
-          source config/test.env
-          sudo -u postgres createdb ${PGDATABASE}
-          echo Created ${PGDATABASE}
-          sudo -u postgres psql -c "CREATE ROLE ${PGUSER} WITH LOGIN PASSWORD '${PGPASSWORD}'"
-          sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE ${PGDATABASE} to ${PGUSER};"
-          yarn sequelize:test db:migrate
-          yarn sequelize:test db:seed:all
-          yarn workspace server db-import-tests:test -c "${IMPORT_ARIA_AT_TESTS_COMMIT_1} ${IMPORT_ARIA_AT_TESTS_COMMIT_2} ${IMPORT_ARIA_AT_TESTS_COMMIT_3} ${IMPORT_ARIA_AT_TESTS_COMMIT_4}"
-          yarn workspace server db-import-tests:test
-          yarn workspace server db-populate-sample-data:test
-      # yarn test would run all of these in serial, however we split this up to allow it to continue
-      # in case of errors - all tests will still run even if lint fails for instance.
+
+      - name: Setup test environment
+        uses: ./.github/actions/setup
+
+      # Run tests
       - run: yarn workspace shared prettier
         if: always()
       - run: yarn workspace client prettier

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -1,0 +1,35 @@
+name: Update Test Snapshots
+on:
+  repository_dispatch:
+    types: [update-test-snapshots]
+
+jobs:
+  update-snapshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: development
+          fetch-depth: 0
+
+      - name: Setup test environment
+        uses: ./.github/actions/setup
+
+      - name: Update snapshots
+        run: yarn update-snapshots
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Commit and push changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            git add -A
+            git commit -m "chore: update snapshots from aria-at@${{ github.event.client_payload.ref }}"
+            git push origin development
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
This PR adds a workflow that can be triggered by the aria-at repo. The workflow sets up a test environment, updates the snapshots, and pushes to development. The test environment setup was created as a shared action for easier maintenance.

Leaving in `DRAFT` until the broader approach is agreed upon.

addresses #1319 