### PR TITLE
Correct exit code for development script

### DIFF
--- a/server/scripts/populate-test-data/index.js
+++ b/server/scripts/populate-test-data/index.js
@@ -227,6 +227,7 @@ const populateTestDatabase = async transaction => {
 if (require.main === module)
   sequelize.transaction(populateTestDatabase).catch(error => {
     console.error(error);
+    process.exitCode = 1;
   });
 
 module.exports = populateTestDatabase;


### PR DESCRIPTION
Prior to this patch, when the "populate test data" script failed, it simply printed the error object and exited with a successful exit code. This made recognizing the failure difficult because the error object includes hundreds of lines of context which do not obviously indicate a problem.

Signify an error has taken place using a non-zero exit code as per UNIX convention. This allows the caller to recognize the failure (and in particular, it causes the `npm` utility--which invokes this script on the user's behalf--to prominently describe the failure).