### PR TITLE
Refactor code into dedicated component

### DIFF
--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import createIssueLink from '@client/utils/createIssueLink';
+import { AtOutputPropType } from '../../common/proptypes';
+import PropTypes from 'prop-types';
+import AssertionsFieldset from '../AssertionsFieldset';
+import OutputTextArea from '../OutputTextArea';
+import UnexpectedBehaviorsFieldset from '../UnexpectedBehaviorsFieldset';
+
+const CommandResults = ({
+  header,
+  atOutput,
+  assertions,
+  unexpectedBehaviors,
+  assertionsHeader,
+  commonIssueContent,
+  commandIndex,
+  isSubmitted,
+  isReviewingBot,
+  isReadOnly
+}) => {
+  const commandString = header.replace('After ', '');
+  const issueLink = createIssueLink({
+    ...commonIssueContent,
+    commandString
+  });
+
+  return (
+    <>
+      <h3>{header}</h3>
+      <OutputTextArea
+        commandIndex={commandIndex}
+        atOutput={atOutput}
+        isSubmitted={isSubmitted}
+        readOnly={isReviewingBot || isReadOnly}
+      />
+      <AssertionsFieldset
+        assertions={assertions}
+        commandIndex={commandIndex}
+        assertionsHeader={assertionsHeader}
+        readOnly={isReadOnly}
+      />
+      <UnexpectedBehaviorsFieldset
+        commandIndex={commandIndex}
+        unexpectedBehaviors={unexpectedBehaviors}
+        isSubmitted={isSubmitted}
+        readOnly={isReadOnly}
+      />
+      <a href={issueLink} target="_blank" rel="noreferrer">
+        Raise an issue for {commandString}
+      </a>
+    </>
+  );
+};
+
+CommandResults.propTypes = {
+  header: PropTypes.string.isRequired,
+  atOutput: AtOutputPropType.isRequired,
+  assertions: PropTypes.array.isRequired,
+  unexpectedBehaviors: PropTypes.object.isRequired,
+  assertionsHeader: PropTypes.object.isRequired,
+  commonIssueContent: PropTypes.object.isRequired,
+  commandIndex: PropTypes.number.isRequired,
+  isSubmitted: PropTypes.bool.isRequired,
+  isReviewingBot: PropTypes.bool.isRequired,
+  isReadOnly: PropTypes.bool.isRequired
+};
+
+export default CommandResults;

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -1,10 +1,4 @@
-import React, {
-  Fragment,
-  useEffect,
-  useLayoutEffect,
-  useState,
-  useRef
-} from 'react';
+import React, { useEffect, useLayoutEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { unescape } from 'lodash';
@@ -21,13 +15,10 @@ import {
 } from '../../resources/aria-at-test-io-format.mjs';
 import { TestWindow } from '../../resources/aria-at-test-window.mjs';
 import { evaluateAtNameKey } from '../../utils/aria';
-import OutputTextArea from './OutputTextArea';
-import AssertionsFieldset from './AssertionsFieldset';
-import UnexpectedBehaviorsFieldset from './UnexpectedBehaviorsFieldset';
+import CommandResults from './CommandResults';
 import supportJson from '../../resources/support.json';
 import commandsJson from '../../resources/commands.json';
 import { AtPropType, TestResultPropType } from '../common/proptypes/index.js';
-import createIssueLink from '@client/utils/createIssueLink';
 import styles from './TestRenderer.module.css';
 
 const ErrorComponent = ({ hasErrors = false }) => {
@@ -438,45 +429,20 @@ const TestRenderer = ({
               {pageContent.results.header.description}
             </p>
             {pageContent.results.commands.map((value, commandIndex) => {
-              const {
-                header,
-                atOutput,
-                assertions,
-                unexpectedBehaviors,
-                assertionsHeader
-              } = value;
-
-              const commandString = header.replace('After ', '');
-              const issueLink = createIssueLink({
-                ...commonIssueContent,
-                commandString
-              });
-
               return (
-                <Fragment key={`AtOutputKey_${commandIndex}`}>
-                  <h3>{header}</h3>
-                  <OutputTextArea
-                    commandIndex={commandIndex}
-                    atOutput={atOutput}
-                    isSubmitted={isSubmitted}
-                    readOnly={isReviewingBot || isReadOnly}
-                  />
-                  <AssertionsFieldset
-                    assertions={assertions}
-                    commandIndex={commandIndex}
-                    assertionsHeader={assertionsHeader}
-                    readOnly={isReadOnly}
-                  />
-                  <UnexpectedBehaviorsFieldset
-                    commandIndex={commandIndex}
-                    unexpectedBehaviors={unexpectedBehaviors}
-                    isSubmitted={isSubmitted}
-                    readOnly={isReadOnly}
-                  />
-                  <a href={issueLink} target="_blank" rel="noreferrer">
-                    Raise an issue for {commandString}
-                  </a>
-                </Fragment>
+                <CommandResults
+                  key={commandIndex}
+                  header={value.header}
+                  atOutput={value.atOutput}
+                  assertions={value.assertions}
+                  unexpectedBehaviors={value.unexpectedBehaviors}
+                  assertionsHeader={value.assertionsHeader}
+                  commonIssueContent={commonIssueContent}
+                  commandIndex={commandIndex}
+                  isSubmitted={isSubmitted}
+                  isReviewingBot={isReviewingBot}
+                  isReadOnly={isReadOnly}
+                />
               );
             })}
           </section>


### PR DESCRIPTION
This factoring reduces the responsibilities of an existing component by relocating logic to a new component. That new component will serve as a basis for further extension in a forthcoming feature patch.

---

@howard-e Just trying to lighten the review load a bit by factoring out some non-substantive changes that can meaningfully stand alone.