### PR TITLE
fix: Correct type of metrics

### DIFF
--- a/shared/getMetrics.js
+++ b/shared/getMetrics.js
@@ -10,13 +10,11 @@ const countTests = ({
   passedOnly
 }) => {
   const countScenarioResult = scenarioResult => {
-    return (
-      (scenarioResult?.assertionResults?.every(
-        assertionResult => assertionResult.passed
-      ) &&
-        scenarioResult.unexpectedBehaviors.length === 0) ||
-      0
-    );
+    return scenarioResult?.assertionResults?.every(
+      assertionResult => assertionResult.passed
+    ) && scenarioResult.unexpectedBehaviors.length === 0
+      ? 1
+      : 0;
   };
 
   const countTestResult = testResult => {

--- a/shared/tests/getMetrics.test.js
+++ b/shared/tests/getMetrics.test.js
@@ -339,6 +339,42 @@ describe('getMetrics', () => {
     );
   });
 
+  it('returns expected metrics object for passing scenarioResult', () => {
+    const testPlanReport = generateTestPlanReport([
+      [{ must: [true], should: [], may: [true], unexpected: [] }]
+    ]);
+    const scenarioResult =
+      testPlanReport.finalizedTestResults[0].scenarioResults[0];
+    expect(getMetrics({ scenarioResult })).toEqual({
+      assertionsPassedCount: 4,
+      assertionsFailedCount: 0,
+      mustAssertionsPassedCount: 2,
+      mustAssertionsCount: 2,
+      mustAssertionsFailedCount: 0,
+      shouldAssertionsPassedCount: 1,
+      shouldAssertionsCount: 1,
+      shouldAssertionsFailedCount: 0,
+      mayAssertionsPassedCount: 1,
+      mayAssertionsCount: 1,
+      mayAssertionsFailedCount: 0,
+      testsPassedCount: 1,
+      testsCount: 1,
+      testsFailedCount: 0,
+      unexpectedBehaviorCount: 0,
+      severeImpactPassedAssertionCount: 1,
+      severeImpactFailedAssertionCount: 0,
+      moderateImpactPassedAssertionCount: 1,
+      moderateImpactFailedAssertionCount: 0,
+      commandsCount: 1,
+      mustFormatted: '2 of 2 passed',
+      shouldFormatted: '1 of 1 passed',
+      mayFormatted: '1 of 1 supported',
+      unexpectedBehaviorsFormatted: false,
+      supportLevel: 'FULL',
+      supportPercent: 100
+    });
+  });
+
   it('returns expected metrics object for failing testPlanReport without unexpected behaviors', () => {
     const testPlanReport = generateTestPlanReport([
       [{ must: [true], should: [true], may: [true], unexpected: [] }],


### PR DESCRIPTION
Ensure that the `testsCount` and `testsPassedCount` properties of the "metrics" object are always numeric values.

---

@howard-e The current behavior is causing propType failures on [my feature branch](https://github.com/w3c/aria-at-app/compare/development...bocoup:aria-at-app:gh-1352-test-blocked) for gh-1352.