### PR TITLE
fixes candidate test plan run page titles

### DIFF
--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -312,6 +312,10 @@ const CandidateTestPlanRun = () => {
   const { testPlanVersion } = testPlanReport;
   const { recommendedPhaseTargetDate } = testPlanVersion;
 
+  const pageTitle = `${currentTestIndex + 1}. ${currentTest?.title} | ${
+    testPlanVersion.title
+  } | Candidate Review | ARIA-AT`;
+
   const reviewStatusText = vendorReviewStatusMap[reviewStatus];
 
   const targetCompletionDate = dates.convertDateToString(
@@ -647,7 +651,7 @@ const CandidateTestPlanRun = () => {
   return (
     <Container>
       <Helmet>
-        <title>Candidate Test Run Page | ARIA-AT</title>
+        <title>{pageTitle}</title>
       </Helmet>
       <Row>
         <TestNavigator

--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -312,9 +312,11 @@ const CandidateTestPlanRun = () => {
   const { testPlanVersion } = testPlanReport;
   const { recommendedPhaseTargetDate } = testPlanVersion;
 
-  const pageTitle = `${currentTestIndex + 1}. ${currentTest?.title} | ${
-    testPlanVersion.title
-  } | Candidate Review | ARIA-AT`;
+  const pageTitlePrefix = isSummaryView
+    ? 'Summary of Failing Assertions'
+    : `${currentTestIndex + 1}. ${currentTest?.title}`;
+
+  const pageTitle = `${pageTitlePrefix} | ${testPlanVersion.title} | Candidate Review | ARIA-AT`;
 
   const reviewStatusText = vendorReviewStatusMap[reviewStatus];
 

--- a/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1#summary.html
+++ b/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1#summary.html
@@ -6,7 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
-    <title>Candidate Test Run Page | ARIA-AT</title>
+    <title>
+      Summary of Failing Assertions | Modal Dialog Example | Candidate Review |
+      ARIA-AT
+    </title>
   </head>
   <body>
     <div id="root">

--- a/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1.html
+++ b/client/tests/e2e/snapshots/saved/_candidate-test-plan_24_1.html
@@ -6,7 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
-    <title>Candidate Test Run Page | ARIA-AT</title>
+    <title>
+      1. Open a Modal Dialog in reading mode | Modal Dialog Example | Candidate
+      Review | ARIA-AT
+    </title>
   </head>
   <body>
     <div id="root">


### PR DESCRIPTION
Page titles for candidate test plans runs now have the format:
> TEST_TITLE | TEST_PLAN_TITLE | Candidate Review | ARIA-AT

Specific example: 
> 1. Navigate forwards to a menu button | Action Menu Button Example Using aria-activedescendant | Candidate Review | ARIA-AT

If user navigates to the failed assertion summary, the title reads: 
> Summary of Failing Assertions | TEST_PLAN_TITLE | Candidate Review | ARIA-AT

If I have a little more time this week I may modify the candidate review e2e tests to reflect this change, but they are captured in updated e2e snapshots so that may be good enough...

Closes #1388 