### PR TITLE
Improve accuracy of rendered form

### DIFF
--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -138,6 +138,7 @@ export const TEST_QUEUE_CONFLICTS_PAGE_QUERY = gql`
           }
           scenarioResult {
             output
+            hasUnexpected
             unexpectedBehaviors {
               text
               details

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -156,7 +156,19 @@ const TestRenderer = ({
           highlightRequired;
       }
 
-      commands[i].unexpected.hasUnexpected = hasUnexpected || 'notSet';
+      // Historically, the value of `hasUnexpected` was not persisted in the
+      // database and instead inferred from the presence of elements in the
+      // `unexpectedBehaviors` array. Preserve the legacy behavior for test
+      // plan runs which do not specify a value for `hasUnexpected`.
+      if (hasUnexpected) {
+        commands[i].unexpected.hasUnexpected = hasUnexpected;
+      } else if (unexpectedBehaviors) {
+        commands[i].unexpected.hasUnexpected = unexpectedBehaviors.length
+          ? 'hasUnexpected'
+          : 'doesNotHaveUnexpected';
+      } else {
+        commands[i].unexpected.hasUnexpected = 'notSet';
+      }
 
       if (unexpectedBehaviors) {
         for (let k = 0; k < unexpectedBehaviors.length; k++) {

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -155,7 +155,7 @@ const TestRenderer = ({
           highlightRequired;
       }
 
-      if (unexpectedBehaviors && unexpectedBehaviors.length) {
+      if (unexpectedBehaviors) {
         commands[i].unexpected.hasUnexpected = 'hasUnexpected';
 
         for (let k = 0; k < unexpectedBehaviors.length; k++) {
@@ -180,10 +180,7 @@ const TestRenderer = ({
           commands[i].unexpected.behaviors[index].more.highlightRequired =
             highlightRequired;
         }
-      } else if (unexpectedBehaviors)
-        // but not populated
-        commands[i].unexpected.hasUnexpected = 'doesNotHaveUnexpected';
-      else commands[i].unexpected.hasUnexpected = 'notSet';
+      } else commands[i].unexpected.hasUnexpected = 'notSet';
 
       commands[i].unexpected.highlightRequired =
         unexpectedBehaviorHighlightRequired;

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -132,6 +132,7 @@ const TestRenderer = ({
       let {
         output,
         assertionResults,
+        hasUnexpected,
         unexpectedBehaviors,
         highlightRequired = false, // atOutput
         unexpectedBehaviorHighlightRequired = false
@@ -155,9 +156,9 @@ const TestRenderer = ({
           highlightRequired;
       }
 
-      if (unexpectedBehaviors) {
-        commands[i].unexpected.hasUnexpected = 'hasUnexpected';
+      commands[i].unexpected.hasUnexpected = hasUnexpected || 'notSet';
 
+      if (unexpectedBehaviors) {
         for (let k = 0; k < unexpectedBehaviors.length; k++) {
           /**
            * 0 = EXCESSIVELY_VERBOSE
@@ -180,7 +181,7 @@ const TestRenderer = ({
           commands[i].unexpected.behaviors[index].more.highlightRequired =
             highlightRequired;
         }
-      } else commands[i].unexpected.hasUnexpected = 'notSet';
+      }
 
       commands[i].unexpected.highlightRequired =
         unexpectedBehaviorHighlightRequired;

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -470,6 +470,7 @@ const TestRun = () => {
       if (captureHighlightRequired)
         scenarioResult.highlightRequired = atOutput.highlightRequired;
       scenarioResult.assertionResults = [...assertionResults];
+      scenarioResult.hasUnexpected = hasUnexpected;
       scenarioResult.unexpectedBehaviors = unexpectedBehaviors
         ? [...unexpectedBehaviors]
         : null;
@@ -653,6 +654,7 @@ const TestRun = () => {
      * ....},
      * ....other assertionResults,
      * ..],
+     * ..hasUnexpected,
      * ..unexpectedBehaviors: [
      * ....{
      * ......id
@@ -664,9 +666,16 @@ const TestRun = () => {
      * }
      * */
     const formattedScenarioResults = scenarioResults.map(
-      ({ assertionResults, id, output, unexpectedBehaviors }) => ({
+      ({
+        assertionResults,
+        id,
+        output,
+        hasUnexpected,
+        unexpectedBehaviors
+      }) => ({
         id,
         output: output,
+        hasUnexpected,
         unexpectedBehaviors: unexpectedBehaviors?.map(
           ({ id, impact, details }) => ({
             id,

--- a/client/components/common/fragments/ScenarioResult.js
+++ b/client/components/common/fragments/ScenarioResult.js
@@ -48,6 +48,7 @@ const SCENARIO_RESULT_FIELDS = (type = 'simple') => {
           mayAssertionResults: assertionResults(priority: MAY) {
             ...AssertionResultFields
           }
+          hasUnexpected
           unexpectedBehaviors {
             id
             text

--- a/client/components/common/fragments/TestPlanReportConflict.js
+++ b/client/components/common/fragments/TestPlanReportConflict.js
@@ -33,6 +33,7 @@ const TEST_PLAN_REPORT_CONFLICT_FIELDS = gql`
       }
       scenarioResult {
         output
+        hasUnexpected
         unexpectedBehaviors {
           id
           text

--- a/client/tests/e2e/TestRun.e2e.test.js
+++ b/client/tests/e2e/TestRun.e2e.test.js
@@ -395,6 +395,65 @@ describe('Test Run when signed in as tester', () => {
     });
   });
 
+  it('persists the presence of unexpected behaviors', async () => {
+    const countChecked = page => {
+      return page.evaluate(() => {
+        return Array.from(document.querySelectorAll('input[id^=problem-]')).map(
+          el => el.checked
+        );
+      });
+    };
+    await getPage({ role: 'tester', url: '/test-queue' }, async page => {
+      await assignSelfAndNavigateToRun(page, {
+        testPlanSectionButtonSelector: 'button#disclosure-btn-alert-0',
+        testPlanTableSelector:
+          'table[aria-label="Reports for Alert Example V22.04.14 in draft phase"]'
+      });
+
+      await page.waitForSelector('h1 ::-p-text(Test 1:)');
+      await page.waitForSelector('button ::-p-text(Submit Results)');
+
+      expect(await countChecked(page)).toEqual([
+        false,
+        false,
+        false,
+        false,
+        false,
+        false
+      ]);
+
+      await page.evaluate(() => {
+        document.querySelector('#problem-1-true').click();
+        document.querySelector('#problem-2-false').click();
+      });
+
+      expect(await countChecked(page)).toEqual([
+        false,
+        false,
+        true,
+        false,
+        false,
+        true
+      ]);
+
+      await page.click(
+        'button[class="btn btn-primary"] ::-p-text(Submit Results)'
+      );
+
+      await page.waitForSelector('h1 ::-p-text(Test 1:)');
+      await page.waitForSelector('button ::-p-text(Submit Results)');
+
+      expect(await countChecked(page)).toEqual([
+        false,
+        false,
+        true,
+        false,
+        false,
+        true
+      ]);
+    });
+  });
+
   it('inputs results and successfully submits', async () => {
     await getPage(
       { role: 'tester', url: '/test-queue' },

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -790,6 +790,13 @@ const graphqlSchema = gql`
     """
     assertionResults(priority: AssertionPriority): [AssertionResult]!
     """
+    Whether or not the Tester observed unexpected behaviors. This is generally
+    reinforced by the value of "unexpectedBehaviors", but it is tracked as a
+    distinct value in order to preserve the state of incomplete test results.
+    Submitted test results require this field to be filled in.
+    """
+    hasUnexpected: String
+    """
     Failure states like "AT became excessively sluggish" which would count
     as a failure for any scenario, even when the assertions otherwise pass.
     Submitted test results require this field to be filled in.
@@ -813,6 +820,10 @@ const graphqlSchema = gql`
     See ScenarioResult type for more information.
     """
     assertionResults: [AssertionResultInput]!
+    """
+    See ScenarioResult type for more information.
+    """
+    hasUnexpected: String
     """
     See ScenarioResult type for more information.
     """


### PR DESCRIPTION
Prior to this commit, if the user indicated that there were unexpected behaviors without specifying any particular behaviors, their subsequent submission would be rejected, and the form would be rendered as though they had not indicated the presence of unexpected behaviors.

Update the rendering logic to more accurately describe the user's input following a failed submission.

---

@howard-e I think the current behavior is counter-intuitive in its own right (see above), but it will become more confusing when we implement the "untestable" checkbox. [That feature is spec'd to set the "unexpected behaviors" checkbox when enabled.](https://github.com/w3c/aria-at-app/issues/1352) If the user sets "untestable" without changing anything further and submits, then (with the current behavior) the form will return to them in an invalid state: "untestable" checked and "unexpected behaviors" unset.