### PR TITLE
fix: Update text in Test Queue's Rerun Reports Tab

### DIFF
--- a/client/components/ReportRerun/RerunDashboard.jsx
+++ b/client/components/ReportRerun/RerunDashboard.jsx
@@ -17,7 +17,7 @@ const RerunDashboard = ({ activeRuns, onRerunClick }) => {
   return (
     <>
       <h2 id="rerun-heading" className={styles.rerunHeader}>
-        Available Updates
+        Reports with Available Updates
       </h2>
       {activeRuns.map(run => {
         const totalReports = run.reportGroups.reduce(
@@ -50,8 +50,8 @@ const RerunDashboard = ({ activeRuns, onRerunClick }) => {
             {run.botName} {run.newVersion}
             <span className={styles.reportCount}>
               {' '}
-              ({totalReports} {totalReports === 1 ? 'Report' : 'Reports'}{' '}
-              Available)
+              ({totalReports} {totalReports === 1 ? 'report' : 'reports'} to
+              update)
             </span>
           </span>
         );

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -2106,7 +2106,7 @@
               class="tab-panel">
               <div>
                 <h2 id="rerun-heading" class="rerun-header">
-                  Available Updates
+                  Reports with Available Updates
                 </h2>
                 <div class="rerun-opportunity">
                   <div class="disclosure-container">
@@ -2119,7 +2119,7 @@
                         aria-controls="disclosure-btn-controls-rerun-disclosure-4-0">
                         <span class="bot-name">
                           NVDA Bot 2023.3.3<span class="report-count">
-                            (1 Report Available)</span
+                            (1 report to update)</span
                           ></span
                         ><svg
                           aria-hidden="true"
@@ -2195,7 +2195,7 @@
                         <span class="bot-name">
                           VoiceOver for macOS Bot 14.0<span
                             class="report-count">
-                            (4 Reports Available)</span
+                            (4 reports to update)</span
                           ></span
                         ><svg
                           aria-hidden="true"


### PR DESCRIPTION
* Updates `<h2>` on page from "Available Updates" to "Reports with Available Updates"
* Updates disclosure `<h3`s from "x Report Available" to "x report to update"
  * Same applies for plural: "x Reports Available" to "x reports to update"