### PR TITLE
Add migration to remove automated reports

### DIFF
--- a/client/components/ReportRerun/RerunDashboard.jsx
+++ b/client/components/ReportRerun/RerunDashboard.jsx
@@ -79,13 +79,19 @@ const RerunDashboard = ({ activeRuns, onRerunClick }) => {
                         : 'earlier versions'}{' '}
                       of {run.botName} can be automatically updated with the
                       &quot;Start Generating Reports&quot; button below.
+                      {/* TODO: Remove below when https://github.com/w3c/aria-at-app/issues/1417 is addressed */}
+                      <br />
+                      <br />
+                      Note: The button is temporarily disabled while we work on
+                      upcoming feature updates.
                     </p>
                   </div>
 
                   <div className={styles.actionHeader}>
+                    {/* TODO: Re-enable when https://github.com/w3c/aria-at-app/issues/1417 is addressed */}
                     <button
                       className={styles.rerunButton}
-                      disabled={totalReports === 0}
+                      disabled={true /* totalReports === 0 */}
                       onClick={() => onRerunClick(run)}
                       aria-label={buttonAriaLabel}
                     >

--- a/server/migrations/20250603160126-removeAutomatedReportRuns.js
+++ b/server/migrations/20250603160126-removeAutomatedReportRuns.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.transaction(async transaction => {
+      // Removing to support needs of https://github.com/w3c/aria-at-app/issues/1417
+      // before running Automated Report Collection again
+      await queryInterface.sequelize.query(
+        `
+          delete
+          from "TestPlanReport"
+          where id in (399, 400, 401, 402, 403, 404, 405, 406, 407, 408)
+            and "atId" = 2
+            and "createdAt" between '2025-05-29 19:00' and '2025-05-29 19:01'
+        `,
+        { transaction }
+      );
+
+      await queryInterface.sequelize.query(
+        `
+          delete
+          from "UpdateEvent"
+          where id = 1
+        `,
+        { transaction }
+      );
+    });
+  },
+
+  async down() {
+    // Note: This migration cannot be reversed as it deletes data
+    // We could potentially restore from a backup if needed
+  }
+};


### PR DESCRIPTION
This PR:

* Removes the automated reports that were generated on May 29, 2025
* Disable the admin's 'Start Generating [Automated] Reports' button

This follows discussions from the [recent CG meeting](https://www.w3.org/2025/05/29-aria-at-minutes.html#6fd3) which now depends on #1417 to be resolved.