### PR TITLE
Allow admins to approve Candidate Reports

### DIFF
--- a/client/components/CandidateReview/CandidateModals/ProvideFeedbackModal/index.jsx
+++ b/client/components/CandidateReview/CandidateModals/ProvideFeedbackModal/index.jsx
@@ -16,8 +16,7 @@ const ProvideFeedbackModal = ({
   changesRequestedIssues = [],
   changesRequestedGithubUrl = '',
   testPlan = '',
-  username = '',
-  isAdmin = false
+  username = ''
 }) => {
   const [selectedRadio, setSelectedRadio] = useState('not-approved-input');
 
@@ -71,8 +70,6 @@ const ProvideFeedbackModal = ({
                   name="radio-feedback"
                   id="approve-input"
                   type="radio"
-                  disabled={isAdmin}
-                  aria-disabled={isAdmin}
                 />
                 <FormCheck.Label htmlFor="approve-input">
                   Approve
@@ -124,8 +121,7 @@ ProvideFeedbackModal.propTypes = {
   feedbackGithubUrl: PropTypes.string,
   show: PropTypes.bool,
   testPlan: PropTypes.string,
-  username: PropTypes.string,
-  isAdmin: PropTypes.bool
+  username: PropTypes.string
 };
 
 export default ProvideFeedbackModal;

--- a/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
+++ b/client/components/CandidateReview/CandidateTestPlanRun/index.jsx
@@ -827,7 +827,6 @@ const CandidateTestPlanRun = () => {
           changesRequestedGithubUrl={changesRequestedGithubUrl}
           handleAction={submitApproval}
           handleHide={() => setFeedbackModalShowing(false)}
-          isAdmin={isAdmin}
         />
       )}
       {!!confirmationModal && confirmationModal}

--- a/server/resolvers/TestPlanReportOperations/promoteVendorReviewStatusResolver.js
+++ b/server/resolvers/TestPlanReportOperations/promoteVendorReviewStatusResolver.js
@@ -18,18 +18,19 @@ const promoteVendorReviewStatusResolver = async (
     throw new AuthenticationError();
   }
 
-  if (user.vendorId || user.company?.id) {
-    await updateReviewerStatusByIds({
-      testPlanReportId,
-      userId: user.id,
-      vendorId: user.vendorId || user.company?.id,
-      values: {
-        reviewStatus: 'APPROVED',
-        approvedAt: new Date()
-      },
-      transaction
-    });
-  }
+  // This being null means approval is from admin
+  const vendorId = user.vendorId || user.company?.id;
+
+  await updateReviewerStatusByIds({
+    testPlanReportId,
+    userId: user.id,
+    vendorId,
+    values: {
+      reviewStatus: 'APPROVED',
+      approvedAt: new Date()
+    },
+    transaction
+  });
   return populateData({ testPlanReportId }, { context });
 };
 


### PR DESCRIPTION
Address #1410

This comes from a recent discussion which highlighted there may be an eventual need for an admin to approve a candidate test plan report on behalf of a vendor.