### PR TITLE
Fix test on windows

### DIFF
--- a/client/utils/createIssueLink.js
+++ b/client/utils/createIssueLink.js
@@ -91,7 +91,9 @@ const createIssueLink = ({
   if (hasTest) {
     // TODO: fix renderedUrl
     let modifiedRenderedUrl = testRenderedUrl.replace(
-      /.+(?=\/tests)/,
+      // replace the path to the tests up to the "tests" folder with the netlify url
+      // ensure original path matches both / and \ path separators
+      /.+(?=[/\\]tests)/,
       'https://aria-at.netlify.app'
     );
 


### PR DESCRIPTION
I haven't been able to verify this works because I've been running the consistency report, and some node process is bound to the test http port that I can't `killall` without testing... However... I think we might want to add windows to the github PR testing as well to ensure future similar problems don't sneak in because no one tests it.  These problems are usually really easy to fix when they happen.