### PR TITLE
fix: Improve form UI for untestable assertions

### DIFF
--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import createIssueLink from '@client/utils/createIssueLink';
 import { AtOutputPropType, UntestablePropType } from '../../common/proptypes';
 import PropTypes from 'prop-types';
@@ -7,6 +7,8 @@ import AssertionsFieldset from '../AssertionsFieldset';
 import OutputTextArea from '../OutputTextArea';
 import UnexpectedBehaviorsFieldset from '../UnexpectedBehaviorsFieldset';
 import styles from '../TestRenderer.module.css';
+
+let tooltipCount = 0;
 
 const CommandResults = ({
   header,
@@ -26,6 +28,7 @@ const CommandResults = ({
     ...commonIssueContent,
     commandString
   });
+  const tooltipID = useMemo(() => `untestable-tooltip-${++tooltipCount}`, []);
 
   return (
     <>
@@ -43,8 +46,12 @@ const CommandResults = ({
           onChange={e => untestable.change(e.target.checked)}
           autoFocus={isSubmitted && untestable.focus}
           checked={untestable.value}
+          aria-describedby={tooltipID}
         />
-        {untestable.description[0]}
+        <span role="tooltip" id={tooltipID}>
+          {untestable.description[0]}
+        </span>
+        Command is untestable
         {isSubmitted && (
           <span
             className={clsx(

--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -42,7 +42,9 @@ const CommandResults = ({
       />
 
       <Tooltip>
-        <TooltipContent>{untestable.description[0]}</TooltipContent>
+        <TooltipContent id={tooltipID}>
+          {untestable.description[0]}
+        </TooltipContent>
         <TooltipTrigger asChild>
           <label className={styles.untestableLabel}>
             <input

--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import AssertionsFieldset from '../AssertionsFieldset';
 import OutputTextArea from '../OutputTextArea';
 import UnexpectedBehaviorsFieldset from '../UnexpectedBehaviorsFieldset';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../Tooltip';
 import styles from '../TestRenderer.module.css';
 
 let tooltipCount = 0;
@@ -40,32 +41,34 @@ const CommandResults = ({
         readOnly={isReviewingBot || isReadOnly}
       />
 
-      <label className={styles.untestableLabel}>
-        <input
-          type="checkbox"
-          onChange={e => untestable.change(e.target.checked)}
-          autoFocus={isSubmitted && untestable.focus}
-          checked={untestable.value}
-          aria-describedby={tooltipID}
-        />
-        <span role="tooltip" id={tooltipID}>
-          {untestable.description[0]}
-        </span>
-        Command is untestable
-        {isSubmitted && (
-          <span
-            className={clsx(
-              styles.testRendererFeedback,
-              styles.space,
-              'required',
-              untestable.description[1].highlightRequired &&
-                'highlight-required'
+      <Tooltip>
+        <TooltipContent>{untestable.description[0]}</TooltipContent>
+        <TooltipTrigger asChild>
+          <label className={styles.untestableLabel}>
+            <input
+              type="checkbox"
+              onChange={e => untestable.change(e.target.checked)}
+              autoFocus={isSubmitted && untestable.focus}
+              checked={untestable.value}
+              aria-describedby={tooltipID}
+            />
+            Command is untestable
+            {isSubmitted && (
+              <span
+                className={clsx(
+                  styles.testRendererFeedback,
+                  styles.space,
+                  'required',
+                  untestable.description[1].highlightRequired &&
+                    'highlight-required'
+                )}
+              >
+                {untestable.description[1].description}
+              </span>
             )}
-          >
-            {untestable.description[1].description}
-          </span>
-        )}
-      </label>
+          </label>
+        </TooltipTrigger>
+      </Tooltip>
 
       <AssertionsFieldset
         assertions={assertions}

--- a/client/components/TestRenderer/TestRenderer.module.css
+++ b/client/components/TestRenderer/TestRenderer.module.css
@@ -172,21 +172,6 @@ label {
     input {
       margin-right: var(--4px);
     }
-
-    &:hover [role='tooltip'],
-    input:focus + [role='tooltip'] {
-      visibility: visible;
-    }
-
-    [role='tooltip'] {
-      position: absolute;
-      top: 100%;
-
-      background-color: rgba(255, 255, 255, 0.9);
-      padding: 1em;
-      border-color: var(--border-gray);
-      visibility: hidden;
-    }
   }
 
   &.assertions-label {

--- a/client/components/TestRenderer/TestRenderer.module.css
+++ b/client/components/TestRenderer/TestRenderer.module.css
@@ -184,7 +184,7 @@ label {
 
       background-color: rgba(255, 255, 255, 0.9);
       padding: 1em;
-      border-color: #999;
+      border-color: var(--border-gray);
       visibility: hidden;
     }
   }

--- a/client/components/TestRenderer/TestRenderer.module.css
+++ b/client/components/TestRenderer/TestRenderer.module.css
@@ -167,9 +167,25 @@ label {
 
   &.untestable-label {
     margin-bottom: var(--8px);
+    position: relative;
 
     input {
       margin-right: var(--4px);
+    }
+
+    &:hover [role='tooltip'],
+    input:focus + [role='tooltip'] {
+      visibility: visible;
+    }
+
+    [role='tooltip'] {
+      position: absolute;
+      top: 100%;
+
+      background-color: rgba(255, 255, 255, 0.9);
+      padding: 1em;
+      border-color: #999;
+      visibility: hidden;
     }
   }
 

--- a/client/components/TestRenderer/UnexpectedBehaviorsFieldset/index.jsx
+++ b/client/components/TestRenderer/UnexpectedBehaviorsFieldset/index.jsx
@@ -135,6 +135,7 @@ const UnexpectedBehaviorsFieldset = ({
                   Impact:
                   <select
                     onChange={e => impactchange(e.target.value)}
+                    autoFocus={isSubmitted && more && more.focusImpact}
                     disabled={!checked}
                     defaultValue={impact}
                   >
@@ -167,7 +168,7 @@ const UnexpectedBehaviorsFieldset = ({
                       <input
                         type="text"
                         className={`undesirable-${descriptionId.toLowerCase()}-details`}
-                        autoFocus={isSubmitted && more.focus}
+                        autoFocus={isSubmitted && more.focusDetails}
                         value={more.value}
                         onChange={e => more.change(e.target.value)}
                         disabled={!checked}

--- a/client/components/Tooltip/Tooltip.module.css
+++ b/client/components/Tooltip/Tooltip.module.css
@@ -1,0 +1,14 @@
+.aria-at-tooltip-content {
+  padding: 1em;
+
+  max-width: 100vw;
+
+  background-color: rgba(255, 255, 255, 0.9);
+  border-color: var(--border-gray);
+  border-style: solid;
+  border-width: 1px;
+}
+
+.aria-at-tooltip-arrow {
+  fill: var(--border-gray);
+}

--- a/client/components/Tooltip/index.jsx
+++ b/client/components/Tooltip/index.jsx
@@ -1,0 +1,56 @@
+// Code adatped from the "manual" installation instructions on "Tooltip -
+// shadcn/ui"
+// https://ui.shadcn.com/docs/components/tooltip
+import React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import PropTypes from 'prop-types';
+import './Tooltip.module.css';
+
+function TooltipProvider({ delayDuration = 0, ...props }) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+TooltipProvider.propTypes = {
+  delayDuration: PropTypes.number
+};
+
+function Tooltip({ ...props }) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({ ...props }) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({ sideOffset = 0, children, ...props }) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className="aria-at-tooltip-content"
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="aria-at-tooltip-arrow" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+TooltipContent.propTypes = {
+  children: PropTypes.node.isRequired,
+  sideOffset: PropTypes.number
+};
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@radix-ui/react-tooltip": "^1.2.7",
     "bootstrap": "^5.3.3",
     "clsx": "^2.1.1",
     "core-js": "^3.37.1",

--- a/client/tests/e2e/TestRun.e2e.test.js
+++ b/client/tests/e2e/TestRun.e2e.test.js
@@ -489,7 +489,7 @@ describe('Test Run when signed in as tester', () => {
         failing: 3
       });
 
-      await page.click('label ::-p-text(untestable)');
+      await page.click('label ::-p-text(Command is untestable)');
 
       expect(await countChecked(page)).toEqual({
         passing: 2,

--- a/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
+++ b/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
@@ -399,16 +399,14 @@
                               </div>
                               <textarea id="speechoutput-0"></textarea>
                             </div>
-                            <label class="untestable-label"
+                            <label
+                              class="untestable-label"
+                              data-state="closed"
+                              data-slot="tooltip-trigger"
                               ><input
                                 type="checkbox"
-                                aria-describedby="untestable-tooltip-1" /><span
-                                role="tooltip"
-                                id="untestable-tooltip-1"
-                                >The response to 'Down Arrow' created conditions
-                                that made assertions untestable, e.g., focused
-                                the wrong element.</span
-                              >Command is untestable</label
+                                aria-describedby="untestable-tooltip-1" />Command
+                              is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-0-assertions-heading">
@@ -664,16 +662,14 @@
                               </div>
                               <textarea id="speechoutput-1"></textarea>
                             </div>
-                            <label class="untestable-label"
+                            <label
+                              class="untestable-label"
+                              data-state="closed"
+                              data-slot="tooltip-trigger"
                               ><input
                                 type="checkbox"
-                                aria-describedby="untestable-tooltip-2" /><span
-                                role="tooltip"
-                                id="untestable-tooltip-2"
-                                >The response to 'B' created conditions that
-                                made assertions untestable, e.g., focused the
-                                wrong element.</span
-                              >Command is untestable</label
+                                aria-describedby="untestable-tooltip-2" />Command
+                              is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-1-assertions-heading">
@@ -929,16 +925,14 @@
                               </div>
                               <textarea id="speechoutput-2"></textarea>
                             </div>
-                            <label class="untestable-label"
+                            <label
+                              class="untestable-label"
+                              data-state="closed"
+                              data-slot="tooltip-trigger"
                               ><input
                                 type="checkbox"
-                                aria-describedby="untestable-tooltip-3" /><span
-                                role="tooltip"
-                                id="untestable-tooltip-3"
-                                >The response to 'F' created conditions that
-                                made assertions untestable, e.g., focused the
-                                wrong element.</span
-                              >Command is untestable</label
+                                aria-describedby="untestable-tooltip-3" />Command
+                              is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-2-assertions-heading">
@@ -1194,16 +1188,14 @@
                               </div>
                               <textarea id="speechoutput-3"></textarea>
                             </div>
-                            <label class="untestable-label"
+                            <label
+                              class="untestable-label"
+                              data-state="closed"
+                              data-slot="tooltip-trigger"
                               ><input
                                 type="checkbox"
-                                aria-describedby="untestable-tooltip-4" /><span
-                                role="tooltip"
-                                id="untestable-tooltip-4"
-                                >The response to 'Tab' created conditions that
-                                made assertions untestable, e.g., focused the
-                                wrong element.</span
-                              >Command is untestable</label
+                                aria-describedby="untestable-tooltip-4" />Command
+                              is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-3-assertions-heading">

--- a/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
+++ b/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
@@ -400,10 +400,15 @@
                               <textarea id="speechoutput-0"></textarea>
                             </div>
                             <label class="untestable-label"
-                              ><input type="checkbox" />The response to 'Down
-                              Arrow' created conditions that made assertions
-                              untestable, e.g., focused the wrong
-                              element.</label
+                              ><input
+                                type="checkbox"
+                                aria-describedby="untestable-tooltip-1" /><span
+                                role="tooltip"
+                                id="untestable-tooltip-1"
+                                >The response to 'Down Arrow' created conditions
+                                that made assertions untestable, e.g., focused
+                                the wrong element.</span
+                              >Command is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-0-assertions-heading">
@@ -660,10 +665,15 @@
                               <textarea id="speechoutput-1"></textarea>
                             </div>
                             <label class="untestable-label"
-                              ><input type="checkbox" />The response to 'B'
-                              created conditions that made assertions
-                              untestable, e.g., focused the wrong
-                              element.</label
+                              ><input
+                                type="checkbox"
+                                aria-describedby="untestable-tooltip-2" /><span
+                                role="tooltip"
+                                id="untestable-tooltip-2"
+                                >The response to 'B' created conditions that
+                                made assertions untestable, e.g., focused the
+                                wrong element.</span
+                              >Command is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-1-assertions-heading">
@@ -920,10 +930,15 @@
                               <textarea id="speechoutput-2"></textarea>
                             </div>
                             <label class="untestable-label"
-                              ><input type="checkbox" />The response to 'F'
-                              created conditions that made assertions
-                              untestable, e.g., focused the wrong
-                              element.</label
+                              ><input
+                                type="checkbox"
+                                aria-describedby="untestable-tooltip-3" /><span
+                                role="tooltip"
+                                id="untestable-tooltip-3"
+                                >The response to 'F' created conditions that
+                                made assertions untestable, e.g., focused the
+                                wrong element.</span
+                              >Command is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-2-assertions-heading">
@@ -1180,10 +1195,15 @@
                               <textarea id="speechoutput-3"></textarea>
                             </div>
                             <label class="untestable-label"
-                              ><input type="checkbox" />The response to 'Tab'
-                              created conditions that made assertions
-                              untestable, e.g., focused the wrong
-                              element.</label
+                              ><input
+                                type="checkbox"
+                                aria-describedby="untestable-tooltip-4" /><span
+                                role="tooltip"
+                                id="untestable-tooltip-4"
+                                >The response to 'Tab' created conditions that
+                                made assertions untestable, e.g., focused the
+                                wrong element.</span
+                              >Command is untestable</label
                             >
                             <fieldset class="test-renderer-fieldset">
                               <legend id="command-3-assertions-heading">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,33 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@floating-ui/core@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.2.tgz#3d1c35263950b314b6d5a72c8bfb9e3c1551aefd"
+  integrity sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==
+  dependencies:
+    "@floating-ui/utils" "^0.2.10"
+
+"@floating-ui/dom@^1.7.2":
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.2.tgz#3540b051cf5ce0d4f4db5fb2507a76e8ea5b4a45"
+  integrity sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==
+  dependencies:
+    "@floating-ui/core" "^1.7.2"
+    "@floating-ui/utils" "^0.2.10"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.4.tgz#a0689be8978352fff2be2dfdd718cf668c488ec3"
+  integrity sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==
+  dependencies:
+    "@floating-ui/dom" "^1.7.2"
+
+"@floating-ui/utils@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
+  integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
+
 "@fortawesome/fontawesome-common-types@6.5.2":
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz#eaf2f5699f73cef198454ebc0c414e3688898179"
@@ -2880,6 +2907,168 @@
     tar-fs "^3.0.6"
     unbzip2-stream "^1.4.3"
     yargs "^17.7.2"
+
+"@radix-ui/primitive@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.2.tgz#83f415c4425f21e3d27914c12b3272a32e3dae65"
+  integrity sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==
+
+"@radix-ui/react-arrow@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz#e14a2657c81d961598c5e72b73dd6098acc04f09"
+  integrity sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+
+"@radix-ui/react-compose-refs@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
+  integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
+
+"@radix-ui/react-context@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
+  integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
+
+"@radix-ui/react-dismissable-layer@1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz#429b9bada3672c6895a5d6a642aca6ecaf4f18c3"
+  integrity sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-escape-keydown" "1.1.1"
+
+"@radix-ui/react-id@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"
+  integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-popper@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.7.tgz#531cf2eebb3d3270d58f7d8136e4517646429978"
+  integrity sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-rect" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+    "@radix-ui/rect" "1.1.1"
+
+"@radix-ui/react-portal@1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.9.tgz#14c3649fe48ec474ac51ed9f2b9f5da4d91c4472"
+  integrity sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-presence@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.4.tgz#253ac0ad4946c5b4a9c66878335f5cf07c967ced"
+  integrity sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-primitive@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz#db9b8bcff49e01be510ad79893fb0e4cda50f1bc"
+  integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.3"
+
+"@radix-ui/react-slot@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"
+  integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-tooltip@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.7.tgz#23612ac7a5e8e1f6829e46d0e0ad94afe3976c72"
+  integrity sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.2"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.10"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-popper" "1.2.7"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.4"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-visually-hidden" "1.2.3"
+
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
+
+"@radix-ui/react-use-controllable-state@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz#905793405de57d61a439f4afebbb17d0645f3190"
+  integrity sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==
+  dependencies:
+    "@radix-ui/react-use-effect-event" "0.0.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-effect-event@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz#090cf30d00a4c7632a15548512e9152217593907"
+  integrity sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-use-escape-keydown@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz#b3fed9bbea366a118f40427ac40500aa1423cc29"
+  integrity sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==
+  dependencies:
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+
+"@radix-ui/react-use-layout-effect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
+
+"@radix-ui/react-use-rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz#01443ca8ed071d33023c1113e5173b5ed8769152"
+  integrity sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==
+  dependencies:
+    "@radix-ui/rect" "1.1.1"
+
+"@radix-ui/react-use-size@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz#6de276ffbc389a537ffe4316f5b0f24129405b37"
+  integrity sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-visually-hidden@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz#a8c38c8607735dc9f05c32f87ab0f9c2b109efbf"
+  integrity sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+
+"@radix-ui/rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
+  integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
 
 "@react-aria/ssr@^3.5.0":
   version "3.9.4"


### PR DESCRIPTION
Addresses gh-1430. Depend on https://github.com/w3c/aria-at/pull/1264

I built my own tooltip. This statement ought to concern any reviewer, so here's my justification:

1. The three most popular React-compatible tooltip libraries do not suit our purposes:
   - [Tooltip from the "React Component" library](https://react-component.github.io/tooltip/) is not accessible
   - [Tooltip in Material UI](https://mui.com/material-ui/react-tooltip/) appears to be inseparable from Material UI itself, which is a very large dependency
   - [React Tooltip](https://react-tooltip.com/) is not accessible (it is documented as such, but [the implementation has a flaw which subverts the user experience](https://github.com/react-component/tooltip/issues/496))
2. The application is minimal (it entailing the display of a single element whose only content is text nodes)
3. The implementation is small and requires no JavaScript

But of course, I'm still open to trying a more robust solution!