### PR TITLE
feat: Link rerun reports to updated historical report

### DIFF
--- a/client/components/ReportRerun/RerunDashboard.jsx
+++ b/client/components/ReportRerun/RerunDashboard.jsx
@@ -79,11 +79,6 @@ const RerunDashboard = ({ activeRuns, onRerunClick }) => {
                         : 'earlier versions'}{' '}
                       of {run.botName} can be automatically updated with the
                       &quot;Start Generating Reports&quot; button below.
-                      {/* TODO: Remove below when https://github.com/w3c/aria-at-app/issues/1417 is addressed */}
-                      <br />
-                      <br />
-                      Note: The button is temporarily disabled while we work on
-                      upcoming feature updates.
                     </p>
                   </div>
 
@@ -91,7 +86,7 @@ const RerunDashboard = ({ activeRuns, onRerunClick }) => {
                     {/* TODO: Re-enable when https://github.com/w3c/aria-at-app/issues/1417 is addressed */}
                     <button
                       className={styles.rerunButton}
-                      disabled={true /* totalReports === 0 */}
+                      disabled={totalReports === 0}
                       onClick={() => onRerunClick(run)}
                       aria-label={buttonAriaLabel}
                     >

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -26,10 +26,16 @@ import FilterButtons from '../common/FilterButtons';
 import styles from './TestQueue.module.css';
 import commonStyles from '../common/styles.module.css';
 
+const FILTER_KEYS = {
+  ALL: 'all',
+  MANUAL: 'manual',
+  AUTOMATED: 'automated'
+};
+
 const TestQueue = () => {
   const client = useApolloClient();
   const [totalAutomatedRuns, setTotalAutomatedRuns] = useState(null);
-  const [activeFilter, setActiveFilter] = useState('manual');
+  const [activeFilter, setActiveFilter] = useState(FILTER_KEYS.MANUAL);
   const { data, error, refetch } = useQuery(TEST_QUEUE_PAGE_QUERY, {
     fetchPolicy: 'cache-and-network'
   });
@@ -152,15 +158,15 @@ const TestQueue = () => {
     calculateFilterCounts(testPlans);
 
   const filterOptions = {
-    all: `All test runs (${allCount})`,
-    manual: `Manual test runs (${manualCount})`,
+    [FILTER_KEYS.ALL]: `All test runs (${allCount})`,
+    [FILTER_KEYS.MANUAL]: `Manual test runs (${manualCount})`,
     ...(automatedCount > 0 && {
-      automated: `Automated updates with run failures (${automatedCount})`
+      [FILTER_KEYS.AUTOMATED]: `Automated updates with run failures (${automatedCount})`
     })
   };
 
   const applyFilter = (testPlans, filter) => {
-    if (filter === 'all') return testPlans;
+    if (filter === FILTER_KEYS.ALL) return testPlans;
 
     return testPlans
       .map(testPlan => ({
@@ -174,8 +180,12 @@ const TestQueue = () => {
                   ({ tester }) => tester.isBot
                 );
 
-                if (filter === 'manual') return !hasBotRun;
-                if (filter === 'automated') return hasBotRun;
+                const isRerun = !!testPlanReport.historicalReport;
+
+                if (filter === FILTER_KEYS.MANUAL)
+                  return !hasBotRun || !isRerun;
+                if (filter === FILTER_KEYS.AUTOMATED)
+                  return hasBotRun && isRerun;
                 return true;
               }
             )

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -351,7 +351,10 @@ const TestQueue = () => {
 
               // Refocus on testers assignment dropdown button
               const selector = `#assign-testers-${testPlanReport.id} button`;
-              document.querySelector(selector).focus();
+              const element = document.querySelector(selector);
+              if (element) {
+                element.focus();
+              }
             }}
           />
         </td>

--- a/client/components/TestQueueCompletionStatusListItem/queries.js
+++ b/client/components/TestQueueCompletionStatusListItem/queries.js
@@ -8,6 +8,7 @@ export const TEST_PLAN_RUN_ASSERTION_RESULTS_QUERY = gql`
         id
         completedAt
         scenarioResults {
+          output
           assertionResults {
             passed
             failedReason

--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -37,19 +37,16 @@ const CommandResults = ({
   });
   const tooltipID = useMemo(() => `untestable-tooltip-${++tooltipCount}`, []);
 
-  // Check if assertions have null verdicts (indicating mismatched output requiring human review)
   const hasUnresolvedAssertions = assertions.some(
     assertion => assertion.passed === null
   );
 
-  // Only show error state and historical output when assertions are null (require human review)
   const hasConflictingOutput = isRerunReport && hasUnresolvedAssertions;
 
   const errorMessage = hasConflictingOutput
     ? `This output differs from output reported for ${historicalAtName} ${historicalAtVersion}`
     : null;
 
-  // Only show historical output when assertions are null (need human review)
   const shouldShowHistoricalOutput =
     hasConflictingOutput && historicalOutput !== null;
 

--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -3,6 +3,8 @@ import createIssueLink from '@client/utils/createIssueLink';
 import { AtOutputPropType, UntestablePropType } from '../../common/proptypes';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import AssertionsFieldset from '../AssertionsFieldset';
 import OutputTextArea from '../OutputTextArea';
 import UnexpectedBehaviorsFieldset from '../UnexpectedBehaviorsFieldset';
@@ -22,7 +24,11 @@ const CommandResults = ({
   commandIndex,
   isSubmitted,
   isReviewingBot,
-  isReadOnly
+  isReadOnly,
+  isRerunReport = false,
+  historicalOutput = null,
+  historicalAtName = null,
+  historicalAtVersion = null
 }) => {
   const commandString = header.replace('After ', '');
   const issueLink = createIssueLink({
@@ -31,14 +37,40 @@ const CommandResults = ({
   });
   const tooltipID = useMemo(() => `untestable-tooltip-${++tooltipCount}`, []);
 
+  // Check if output differs from historical output for rerun reports
+  const hasConflictingOutput =
+    isRerunReport &&
+    historicalOutput !== null &&
+    atOutput.value !== historicalOutput &&
+    atOutput.value &&
+    historicalOutput;
+
+  const errorMessage = hasConflictingOutput
+    ? `This output differs from output reported for ${historicalAtName} ${historicalAtVersion}`
+    : null;
+
   return (
     <>
-      <h3>{header}</h3>
+      <h3>
+        {hasConflictingOutput && (
+          <FontAwesomeIcon
+            icon={faExclamationTriangle}
+            style={{ color: '#ce1b4c', marginRight: '8px' }}
+            aria-label="Conflicting Output"
+          />
+        )}
+        {header}
+      </h3>
       <OutputTextArea
         commandIndex={commandIndex}
         atOutput={atOutput}
         isSubmitted={isSubmitted}
         readOnly={isReviewingBot || isReadOnly}
+        errorMessage={errorMessage}
+        isRerunReport={isRerunReport}
+        historicalOutput={historicalOutput}
+        historicalAtName={historicalAtName}
+        historicalAtVersion={historicalAtVersion}
       />
 
       <Tooltip>
@@ -104,7 +136,11 @@ CommandResults.propTypes = {
   commandIndex: PropTypes.number.isRequired,
   isSubmitted: PropTypes.bool.isRequired,
   isReviewingBot: PropTypes.bool.isRequired,
-  isReadOnly: PropTypes.bool.isRequired
+  isReadOnly: PropTypes.bool.isRequired,
+  isRerunReport: PropTypes.bool,
+  historicalOutput: PropTypes.string,
+  historicalAtName: PropTypes.string,
+  historicalAtVersion: PropTypes.string
 };
 
 export default CommandResults;

--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -37,17 +37,21 @@ const CommandResults = ({
   });
   const tooltipID = useMemo(() => `untestable-tooltip-${++tooltipCount}`, []);
 
-  // Check if output differs from historical output for rerun reports
-  const hasConflictingOutput =
-    isRerunReport &&
-    historicalOutput !== null &&
-    atOutput.value !== historicalOutput &&
-    atOutput.value &&
-    historicalOutput;
+  // Check if assertions have null verdicts (indicating mismatched output requiring human review)
+  const hasUnresolvedAssertions = assertions.some(
+    assertion => assertion.passed === null
+  );
+
+  // Only show error state and historical output when assertions are null (require human review)
+  const hasConflictingOutput = isRerunReport && hasUnresolvedAssertions;
 
   const errorMessage = hasConflictingOutput
     ? `This output differs from output reported for ${historicalAtName} ${historicalAtVersion}`
     : null;
+
+  // Only show historical output when assertions are null (need human review)
+  const shouldShowHistoricalOutput =
+    hasConflictingOutput && historicalOutput !== null;
 
   return (
     <>
@@ -68,7 +72,7 @@ const CommandResults = ({
         readOnly={isReviewingBot || isReadOnly}
         errorMessage={errorMessage}
         isRerunReport={isRerunReport}
-        historicalOutput={historicalOutput}
+        historicalOutput={shouldShowHistoricalOutput ? historicalOutput : null}
         historicalAtName={historicalAtName}
         historicalAtVersion={historicalAtVersion}
       />

--- a/client/components/TestRenderer/OutputTextArea/index.jsx
+++ b/client/components/TestRenderer/OutputTextArea/index.jsx
@@ -10,7 +10,12 @@ const OutputTextArea = ({
   commandIndex,
   atOutput,
   isSubmitted,
-  readOnly = false
+  readOnly = false,
+  errorMessage = null,
+  isRerunReport = false,
+  historicalOutput = null,
+  historicalAtName = null,
+  historicalAtVersion = null
 }) => {
   const [noOutput, setNoOutput] = useState(atOutput.value === NO_OUTPUT_STRING);
 
@@ -35,8 +40,18 @@ const OutputTextArea = ({
   const isNoOutputCheckboxDisabled =
     (atOutput.value && atOutput.value !== NO_OUTPUT_STRING) || readOnly;
 
+  const errorId = errorMessage ? `output-error-${commandIndex}` : null;
+
   return (
     <div className={styles.outputTextContainer}>
+      {isRerunReport && historicalOutput && (
+        <div className={styles.historicalOutput}>
+          <p>
+            Output recorded for {historicalAtName} {historicalAtVersion}:
+          </p>
+          <blockquote>{historicalOutput}</blockquote>
+        </div>
+      )}
       <label htmlFor={`speechoutput-${commandIndex}`}>
         {atOutput.description[0]}
         {isSubmitted && (
@@ -72,7 +87,14 @@ const OutputTextArea = ({
         onChange={e => atOutput.change(e.target.value)}
         disabled={noOutput}
         readOnly={readOnly}
+        aria-describedby={errorId}
+        className={errorMessage ? styles.errorState : ''}
       />
+      {errorMessage && (
+        <div id={errorId} className={styles.errorMessage} role="alert">
+          {errorMessage}
+        </div>
+      )}
     </div>
   );
 };
@@ -81,7 +103,12 @@ OutputTextArea.propTypes = {
   commandIndex: PropTypes.number.isRequired,
   atOutput: AtOutputPropType.isRequired,
   readOnly: PropTypes.bool,
-  isSubmitted: PropTypes.bool.isRequired
+  isSubmitted: PropTypes.bool.isRequired,
+  errorMessage: PropTypes.string,
+  isRerunReport: PropTypes.bool,
+  historicalOutput: PropTypes.string,
+  historicalAtName: PropTypes.string,
+  historicalAtVersion: PropTypes.string
 };
 
 export default OutputTextArea;

--- a/client/components/TestRenderer/TestRenderer.module.css
+++ b/client/components/TestRenderer/TestRenderer.module.css
@@ -30,7 +30,42 @@ div.output-text-container {
   > textarea {
     width: 100%;
     height: 3.5rem;
+
+    &.error-state {
+      border-color: var(--report-status-error);
+      box-shadow: 0 0 0 0.2rem rgba(206, 27, 76, 0.25);
+    }
   }
+}
+
+.historical-output {
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  background-color: var(--bg-lighter-gray);
+  border-radius: var(--4px);
+  border-left: 4px solid var(--primary-color);
+
+  p {
+    margin: 0 0 0.5rem 0;
+    font-weight: var(--font-weight-medium);
+  }
+
+  blockquote {
+    margin: 0;
+    padding: 0.5rem;
+    background-color: white;
+    border-radius: var(--4px);
+    border: 1px solid var(--border-gray);
+    font-family: monospace;
+    white-space: pre-wrap;
+  }
+}
+
+.error-message {
+  margin-top: 0.25rem;
+  color: var(--report-status-error);
+  font-size: var(--14px);
+  font-weight: var(--font-weight-medium);
 }
 
 .no-output-checkbox {

--- a/client/components/TestRenderer/index.jsx
+++ b/client/components/TestRenderer/index.jsx
@@ -52,7 +52,11 @@ const TestRenderer = ({
   isReadOnly = false,
   isEdit = false,
   setIsRendererReady = false,
-  commonIssueContent
+  commonIssueContent,
+  isRerunReport = false,
+  historicalTestResult = null,
+  historicalAtName = null,
+  historicalAtVersion = null
 }) => {
   const { scenarioResults, test = {}, completedAt } = testResult;
   const { renderableContent } = test;
@@ -441,6 +445,13 @@ const TestRenderer = ({
               {pageContent.results.header.description}
             </p>
             {pageContent.results.commands.map((value, commandIndex) => {
+              // Get historical output for this command from historicalTestResult
+              const historicalOutput =
+                (isRerunReport &&
+                  historicalTestResult?.scenarioResults?.[commandIndex]
+                    ?.output) ||
+                null;
+
               return (
                 <CommandResults
                   key={commandIndex}
@@ -455,6 +466,10 @@ const TestRenderer = ({
                   isSubmitted={isSubmitted}
                   isReviewingBot={isReviewingBot}
                   isReadOnly={isReadOnly}
+                  isRerunReport={isRerunReport}
+                  historicalOutput={historicalOutput}
+                  historicalAtName={historicalAtName}
+                  historicalAtVersion={historicalAtVersion}
                 />
               );
             })}
@@ -496,7 +511,11 @@ TestRenderer.propTypes = {
   isEdit: PropTypes.bool,
   isReviewingBot: PropTypes.bool,
   setIsRendererReady: PropTypes.func,
-  commonIssueContent: PropTypes.object
+  commonIssueContent: PropTypes.object,
+  isRerunReport: PropTypes.bool,
+  historicalTestResult: PropTypes.object,
+  historicalAtName: PropTypes.string,
+  historicalAtVersion: PropTypes.string
 };
 
 export default TestRenderer;

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -1098,10 +1098,9 @@ const TestRun = () => {
                   }
                   historicalAtVersion={
                     testPlanReport.isRerun && testPlanReport.historicalReport
-                      ? (
-                          testPlanReport.historicalReport.exactAtVersion ||
-                          testPlanReport.historicalReport.minimumAtVersion
-                        )?.name
+                      ? testPlanReport.historicalReport.finalizedTestResults?.find(
+                          result => result.test.id === currentTest.id
+                        )?.atVersion?.name
                       : null
                   }
                 />

--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -1083,6 +1083,27 @@ const TestRun = () => {
                   isEdit={isTestEditClicked}
                   setIsRendererReady={setIsRendererReady}
                   commonIssueContent={commonIssueContent}
+                  isRerunReport={testPlanReport.isRerun}
+                  historicalTestResult={
+                    testPlanReport.isRerun && testPlanReport.historicalReport
+                      ? testPlanReport.historicalReport.finalizedTestResults?.find(
+                          result => result.test.id === currentTest.id
+                        )
+                      : null
+                  }
+                  historicalAtName={
+                    testPlanReport.isRerun && testPlanReport.historicalReport
+                      ? testPlanReport.historicalReport.at.name
+                      : null
+                  }
+                  historicalAtVersion={
+                    testPlanReport.isRerun && testPlanReport.historicalReport
+                      ? (
+                          testPlanReport.historicalReport.exactAtVersion ||
+                          testPlanReport.historicalReport.minimumAtVersion
+                        )?.name
+                      : null
+                  }
                 />
               </Row>
               {isRendererReady && (

--- a/client/components/TestRun/queries.js
+++ b/client/components/TestRun/queries.js
@@ -56,6 +56,7 @@ export const TEST_RUN_PAGE_QUERY = gql`
       }
       testPlanReport {
         id
+        isRerun
         conflicts {
           ...TestPlanReportConflictFields
         }
@@ -83,6 +84,36 @@ export const TEST_RUN_PAGE_QUERY = gql`
         runnableTests {
           ...TestFieldsAll
           renderableContent
+        }
+        historicalReport {
+          id
+          at {
+            ...AtFields
+          }
+          browser {
+            ...BrowserFields
+          }
+          exactAtVersion {
+            ...AtVersionFields
+          }
+          minimumAtVersion {
+            ...AtVersionFields
+          }
+          finalizedTestResults {
+            ...TestResultFields
+            test {
+              ...TestFieldsSimple
+            }
+            scenarioResults {
+              ...ScenarioResultFieldsAll
+            }
+            atVersion {
+              ...AtVersionFields
+            }
+            browserVersion {
+              ...BrowserVersionFields
+            }
+          }
         }
       }
     }
@@ -115,6 +146,7 @@ export const TEST_RUN_PAGE_ANON_QUERY = gql`
   query TestPlanRunAnonPage($testPlanReportId: ID!) {
     testPlanReport(id: $testPlanReportId) {
       id
+      isRerun
       conflicts {
         ...TestPlanReportConflictFields
       }
@@ -136,6 +168,36 @@ export const TEST_RUN_PAGE_ANON_QUERY = gql`
       runnableTests {
         ...TestFieldsAll
         renderableContent
+      }
+      historicalReport {
+        id
+        at {
+          ...AtFields
+        }
+        browser {
+          ...BrowserFields
+        }
+        exactAtVersion {
+          ...AtVersionFields
+        }
+        minimumAtVersion {
+          ...AtVersionFields
+        }
+        finalizedTestResults {
+          ...TestResultFields
+          test {
+            ...TestFieldsSimple
+          }
+          scenarioResults {
+            ...ScenarioResultFieldsAll
+          }
+          atVersion {
+            ...AtVersionFields
+          }
+          browserVersion {
+            ...BrowserVersionFields
+          }
+        }
       }
     }
   }
@@ -194,6 +256,7 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
           }
           testPlanReport {
             id
+            isRerun
             conflicts {
               ...TestPlanReportConflictFields
             }
@@ -220,6 +283,36 @@ export const FIND_OR_CREATE_TEST_RESULT_MUTATION = gql`
             }
             runnableTests {
               ...TestFieldsAll
+            }
+            historicalReport {
+              id
+              at {
+                ...AtFields
+              }
+              browser {
+                ...BrowserFields
+              }
+              exactAtVersion {
+                ...AtVersionFields
+              }
+              minimumAtVersion {
+                ...AtVersionFields
+              }
+              finalizedTestResults {
+                ...TestResultFields
+                test {
+                  ...TestFieldsSimple
+                }
+                scenarioResults {
+                  ...ScenarioResultFieldsAll
+                }
+                atVersion {
+                  ...AtVersionFields
+                }
+                browserVersion {
+                  ...BrowserVersionFields
+                }
+              }
             }
           }
         }
@@ -284,6 +377,7 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
           }
           testPlanReport {
             id
+            isRerun
             conflicts {
               ...TestPlanReportConflictFields
             }
@@ -310,6 +404,36 @@ export const SAVE_TEST_RESULT_MUTATION = gql`
             }
             runnableTests {
               ...TestFieldsAll
+            }
+            historicalReport {
+              id
+              at {
+                ...AtFields
+              }
+              browser {
+                ...BrowserFields
+              }
+              exactAtVersion {
+                ...AtVersionFields
+              }
+              minimumAtVersion {
+                ...AtVersionFields
+              }
+              finalizedTestResults {
+                ...TestResultFields
+                test {
+                  ...TestFieldsSimple
+                }
+                scenarioResults {
+                  ...ScenarioResultFieldsAll
+                }
+                atVersion {
+                  ...AtVersionFields
+                }
+                browserVersion {
+                  ...BrowserVersionFields
+                }
+              }
             }
           }
         }
@@ -374,6 +498,7 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
           }
           testPlanReport {
             id
+            isRerun
             conflicts {
               ...TestPlanReportConflictFields
             }
@@ -400,6 +525,36 @@ export const SUBMIT_TEST_RESULT_MUTATION = gql`
             }
             runnableTests {
               ...TestFieldsAll
+            }
+            historicalReport {
+              id
+              at {
+                ...AtFields
+              }
+              browser {
+                ...BrowserFields
+              }
+              exactAtVersion {
+                ...AtVersionFields
+              }
+              minimumAtVersion {
+                ...AtVersionFields
+              }
+              finalizedTestResults {
+                ...TestResultFields
+                test {
+                  ...TestFieldsSimple
+                }
+                scenarioResults {
+                  ...ScenarioResultFieldsAll
+                }
+                atVersion {
+                  ...AtVersionFields
+                }
+                browserVersion {
+                  ...BrowserVersionFields
+                }
+              }
             }
           }
         }

--- a/client/components/TestRun/queries.js
+++ b/client/components/TestRun/queries.js
@@ -140,9 +140,12 @@ export const TEST_RUN_PAGE_ANON_QUERY = gql`
   ${AT_VERSION_FIELDS}
   ${BROWSER_FIELDS}
   ${BROWSER_VERSION_FIELDS}
+  ${SCENARIO_RESULT_FIELDS('all')}
+  ${TEST_FIELDS()}
   ${TEST_FIELDS('all')}
   ${TEST_PLAN_REPORT_CONFLICT_FIELDS}
   ${TEST_PLAN_VERSION_FIELDS}
+  ${TEST_RESULT_FIELDS}
   query TestPlanRunAnonPage($testPlanReportId: ID!) {
     testPlanReport(id: $testPlanReportId) {
       id

--- a/client/components/common/fragments/TestPlanReport.js
+++ b/client/components/common/fragments/TestPlanReport.js
@@ -6,10 +6,28 @@ const TEST_PLAN_REPORT_FIELDS = gql`
     id
     metrics
     isFinal
+    isRerun
     createdAt
     markedFinalAt
     conflictsLength
     runnableTestsLength
+    historicalReport {
+      id
+      createdAt
+      markedFinalAt
+      at {
+        id
+        name
+      }
+      exactAtVersion {
+        id
+        name
+      }
+      minimumAtVersion {
+        id
+        name
+      }
+    }
   }
 `;
 

--- a/client/tests/e2e/snapshots/saved/_account_settings.html
+++ b/client/tests/e2e/snapshots/saved/_account_settings.html
@@ -98,7 +98,7 @@
             <button type="button" class="btn btn-primary">
               Import Latest Test Plan Versions
             </button>
-            <p>Date of latest test plan version: June 23, 2025 03:09 UTC</p>
+            <p>Date of latest test plan version: July 14, 2025 23:44 UTC</p>
           </section>
         </main>
       </div>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -1271,7 +1271,7 @@
                   <td>
                     <div class="status-cell">
                       <span class="pill full-width rd">R&amp;D</span>
-                      <p class="review-text">Complete <b>Jun 23, 2025</b></p>
+                      <p class="review-text">Complete <b>Jul 14, 2025</b></p>
                     </div>
                   </td>
                   <td>
@@ -1292,7 +1292,7 @@
                               <path
                                 fill="currentColor"
                                 d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                            ><b>V25.06.23</b></span
+                            ><b>V25.07.14</b></span
                           ></a
                         ></span
                       ><button

--- a/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
+++ b/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
@@ -397,7 +397,7 @@
                                   >No output</label
                                 >
                               </div>
-                              <textarea id="speechoutput-0"></textarea>
+                              <textarea id="speechoutput-0" class=""></textarea>
                             </div>
                             <label
                               class="untestable-label"
@@ -660,7 +660,7 @@
                                   >No output</label
                                 >
                               </div>
-                              <textarea id="speechoutput-1"></textarea>
+                              <textarea id="speechoutput-1" class=""></textarea>
                             </div>
                             <label
                               class="untestable-label"
@@ -923,7 +923,7 @@
                                   >No output</label
                                 >
                               </div>
-                              <textarea id="speechoutput-2"></textarea>
+                              <textarea id="speechoutput-2" class=""></textarea>
                             </div>
                             <label
                               class="untestable-label"
@@ -1186,7 +1186,7 @@
                                   >No output</label
                                 >
                               </div>
-                              <textarea id="speechoutput-3"></textarea>
+                              <textarea id="speechoutput-3" class=""></textarea>
                             </div>
                             <label
                               class="untestable-label"

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -116,6 +116,30 @@
                   Manage the test plans, assign yourself a test plan or start
                   executing one that is already assigned to you.
                 </p>
+                <ul
+                  class="d-flex align-items-center my-3"
+                  aria-label="Filter test runs by type"
+                  role="group">
+                  <li aria-hidden="true">Filter test runs by type</li>
+                  <li>
+                    <button
+                      type="button"
+                      data-testid="filter-all"
+                      aria-pressed="false"
+                      class="filter-button btn btn-secondary">
+                      All test runs (9)
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      type="button"
+                      data-testid="filter-manual"
+                      aria-pressed="true"
+                      class="filter-button btn active btn-secondary">
+                      Manual test runs (9)
+                    </button>
+                  </li>
+                </ul>
                 <div class="disclosure-container stacked">
                   <h3 class="disclosure-heading">
                     <button
@@ -240,16 +264,8 @@
                           <label class="disclosure-form-label form-label"
                             >Test Plan</label
                           ><select class="form-select">
-                            <option value="89">
-                              Action Menu Button Example Using
-                              aria-activedescendant
-                            </option>
                             <option value="1">Alert Example</option>
-                            <option value="67">
-                              Checkbox Example (Mixed-State)
-                            </option>
                             <option value="85">Color Viewer Slider</option>
-                            <option value="68">Command Button Example</option>
                             <option value="91">Modal Dialog Example</option>
                             <option value="7">
                               Select Only Combobox Example
@@ -261,10 +277,9 @@
                           <label class="disclosure-form-label form-label"
                             >Test Plan Version</label
                           ><select aria-disabled="false" class="form-select">
-                            <option value="89">
-                              Feb 13, 2025 Menu button test plans: Change
-                              priority of assertion stateCollapsed from 1 to 2
-                              (pull #1196) (bac64bf)
+                            <option value="1">
+                              Apr 14, 2022 Create updated tests for APG design
+                              pattern example: Alert (#685) (c665367)
                             </option>
                           </select>
                         </div>
@@ -2149,15 +2164,12 @@
                         <p>
                           The following 1 report generated with 1 earlier
                           version of NVDA Bot can be automatically updated with
-                          the "Start Generating Reports" button below.<br /><br />Note:
-                          The button is temporarily disabled while we work on
-                          upcoming feature updates.
+                          the "Start Generating Reports" button below.
                         </p>
                       </div>
                       <div class="action-header">
                         <button
                           class="rerun-button"
-                          disabled=""
                           aria-label="Start generating reports for 1 reports with NVDA Bot 2023.3.3">
                           Start Generating Reports
                         </button>
@@ -2229,15 +2241,12 @@
                           The following 4 reports generated with 2 earlier
                           versions of VoiceOver for macOS Bot can be
                           automatically updated with the "Start Generating
-                          Reports" button below.<br /><br />Note: The button is
-                          temporarily disabled while we work on upcoming feature
-                          updates.
+                          Reports" button below.
                         </p>
                       </div>
                       <div class="action-header">
                         <button
                           class="rerun-button"
-                          disabled=""
                           aria-label="Start generating reports for 4 reports with VoiceOver for macOS Bot 14.0">
                           Start Generating Reports
                         </button>

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -287,11 +287,11 @@ const updateOrCreateTestResultWithResponses = async ({
                 passed: outputMatches
                   ? historicalTestResult.scenarioResults[i].assertionResults[j]
                       .passed
-                  : false,
+                  : null,
                 failedReason: outputMatches
                   ? historicalTestResult.scenarioResults[i].assertionResults[j]
                       .failedReason
-                  : 'AUTOMATED_OUTPUT'
+                  : 'AUTOMATED_OUTPUT_DIFFERS'
               })
             ),
             unexpectedBehaviors: outputMatches

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1220,6 +1220,14 @@ const graphqlSchema = gql`
     TestPlanVersion.earliestAtVersion as a default.
     """
     recommendedAtVersion: AtVersion
+    """
+    The historical report that this report is based on (for rerun reports).
+    """
+    historicalReport: TestPlanReport
+    """
+    Whether this report is a rerun of a previous report.
+    """
+    isRerun: Boolean!
   }
 
   """
@@ -1265,6 +1273,7 @@ const graphqlSchema = gql`
     minimumAtVersionId: ID
     browserId: ID!
     copyResultsFromTestPlanVersionId: ID
+    historicalReportId: ID
   }
 
   """

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -860,6 +860,7 @@ const graphqlSchema = gql`
     INCORRECT_OUTPUT
     NO_OUTPUT
     AUTOMATED_OUTPUT
+    AUTOMATED_OUTPUT_DIFFERS
   }
 
   """

--- a/server/migrations/20250207000000-add-historical-report-id.js
+++ b/server/migrations/20250207000000-add-historical-report-id.js
@@ -1,7 +1,7 @@
 const { DataTypes } = require('sequelize');
 
 module.exports = {
-  up: async (queryInterface, Sequelize) => {
+  up: async queryInterface => {
     await queryInterface.addColumn('TestPlanReport', 'historicalReportId', {
       type: DataTypes.INTEGER,
       allowNull: true,
@@ -18,7 +18,7 @@ module.exports = {
     });
   },
 
-  down: async (queryInterface, Sequelize) => {
+  down: async queryInterface => {
     await queryInterface.removeIndex(
       'TestPlanReport',
       'idx_test_plan_report_historical_report_id'

--- a/server/migrations/20250207000000-add-historical-report-id.js
+++ b/server/migrations/20250207000000-add-historical-report-id.js
@@ -1,0 +1,28 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('TestPlanReport', 'historicalReportId', {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'TestPlanReport',
+        key: 'id'
+      },
+      onDelete: 'SET NULL',
+      onUpdate: 'CASCADE'
+    });
+
+    await queryInterface.addIndex('TestPlanReport', ['historicalReportId'], {
+      name: 'idx_test_plan_report_historical_report_id'
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex(
+      'TestPlanReport',
+      'idx_test_plan_report_historical_report_id'
+    );
+    await queryInterface.removeColumn('TestPlanReport', 'historicalReportId');
+  }
+};

--- a/server/models/TestPlanReport.js
+++ b/server/models/TestPlanReport.js
@@ -35,6 +35,10 @@ module.exports = function (sequelize, DataTypes) {
         type: DataTypes.DATE,
         defaultValue: null,
         allowNull: true
+      },
+      historicalReportId: {
+        type: DataTypes.INTEGER,
+        allowNull: true
       }
     },
     {
@@ -92,6 +96,11 @@ module.exports = function (sequelize, DataTypes) {
       ...Model.TEST_PLAN_RUN_ASSOCIATION,
       foreignKey: 'testPlanReportId',
       sourceKey: 'id'
+    });
+
+    Model.belongsTo(models.TestPlanReport, {
+      as: 'historicalReport',
+      foreignKey: 'historicalReportId'
     });
   };
 

--- a/server/models/services/TestPlanReportService.js
+++ b/server/models/services/TestPlanReportService.js
@@ -228,7 +228,8 @@ const createTestPlanReport = async ({
     atId,
     exactAtVersionId,
     minimumAtVersionId,
-    browserId
+    browserId,
+    historicalReportId
   },
   testPlanReportAttributes = TEST_PLAN_REPORT_ATTRIBUTES,
   testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
@@ -250,6 +251,7 @@ const createTestPlanReport = async ({
       browserId,
       exactAtVersionId,
       minimumAtVersionId,
+      historicalReportId,
       testPlanId: testPlanVersion.testPlanId
     },
     transaction
@@ -453,6 +455,7 @@ const cloneTestPlanReportWithNewAtVersion = async (
     exactAtVersionId: currentVersion.id,
     minimumAtVersionId: null,
     browserId: historicalReport.browserId,
+    historicalReportId: historicalReport.id,
     markedFinalAt: null
   };
   const newReport = await createTestPlanReport({

--- a/server/resolvers/TestPlanReport/historicalReportResolver.js
+++ b/server/resolvers/TestPlanReport/historicalReportResolver.js
@@ -1,0 +1,22 @@
+const {
+  getTestPlanReportById
+} = require('../../models/services/TestPlanReportService');
+
+const historicalReportResolver = async (
+  testPlanReport,
+  args, // eslint-disable-line no-unused-vars
+  context
+) => {
+  const { transaction } = context;
+
+  if (!testPlanReport.historicalReportId) {
+    return null;
+  }
+
+  return getTestPlanReportById({
+    id: testPlanReport.historicalReportId,
+    transaction
+  });
+};
+
+module.exports = historicalReportResolver;

--- a/server/resolvers/TestPlanReport/index.js
+++ b/server/resolvers/TestPlanReport/index.js
@@ -11,6 +11,8 @@ const browser = require('./browserResolver');
 const latestAtVersionReleasedAt = require('./latestAtVersionReleasedAtResolver');
 const recommendedAtVersion = require('./recommendedAtVersionResolver');
 const isFinal = require('./isFinalResolver');
+const isRerun = require('./isRerunResolver');
+const historicalReport = require('./historicalReportResolver');
 const exactAtVersion = require('./exactAtVersionResolver');
 const minimumAtVersion = require('./minimumAtVersionResolver');
 const vendorReviewStatus = require('./vendorReviewStatusResolver');
@@ -31,5 +33,7 @@ module.exports = {
   latestAtVersionReleasedAt,
   recommendedAtVersion,
   isFinal,
+  isRerun,
+  historicalReport,
   vendorReviewStatus
 };

--- a/server/resolvers/TestPlanReport/isRerunResolver.js
+++ b/server/resolvers/TestPlanReport/isRerunResolver.js
@@ -1,0 +1,9 @@
+const isRerunResolver = async (
+  testPlanReport,
+  args, // eslint-disable-line no-unused-vars
+  context // eslint-disable-line no-unused-vars
+) => {
+  return !!testPlanReport.historicalReportId;
+};
+
+module.exports = isRerunResolver;

--- a/server/tests/integration/automation-scheduler.test.js
+++ b/server/tests/integration/automation-scheduler.test.js
@@ -674,8 +674,10 @@ describe('Automation controller', () => {
         testResult.scenarioResults.forEach(scenarioResult => {
           expect(scenarioResult.output).toEqual(automatedTestResponse);
           scenarioResult.assertionResults.forEach(assertionResult => {
-            expect(assertionResult.passed).toEqual(false);
-            expect(assertionResult.failedReason).toEqual('AUTOMATED_OUTPUT');
+            expect(assertionResult.passed).toEqual(null);
+            expect(assertionResult.failedReason).toEqual(
+              'AUTOMATED_OUTPUT_DIFFERS'
+            );
           });
           scenarioResult.unexpectedBehaviors?.forEach(unexpectedBehavior => {
             expect(unexpectedBehavior.id).toEqual('OTHER');
@@ -765,8 +767,10 @@ describe('Automation controller', () => {
         testResult.scenarioResults.forEach(scenarioResult => {
           expect(scenarioResult.output).toEqual(automatedTestResponse);
           scenarioResult.assertionResults.forEach(assertionResult => {
-            expect(assertionResult.passed).toEqual(false);
-            expect(assertionResult.failedReason).toEqual('AUTOMATED_OUTPUT');
+            expect(assertionResult.passed).toEqual(null);
+            expect(assertionResult.failedReason).toEqual(
+              'AUTOMATED_OUTPUT_DIFFERS'
+            );
           });
           scenarioResult.unexpectedBehaviors?.forEach(unexpectedBehavior => {
             expect(unexpectedBehavior.id).toEqual('OTHER');

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -154,6 +154,7 @@ describe('graphql', () => {
       ['PopulatedData', 'atVersion'],
       ['PopulatedData', 'browserVersion'],
       ['TestPlanReport', 'issues'],
+      ['TestPlanReport', 'historicalReport'],
       ['TestPlanReport', 'vendorReviewStatus'],
       ['Command', 'atOperatingMode'], // TODO: Include when v2 test format CI tests are done
       ['CollectionJob', 'testPlanRun'],
@@ -575,6 +576,7 @@ describe('graphql', () => {
               startedAt
               completedAt
             }
+            isRerun
             metrics
             conflictsLength
             atVersions {

--- a/server/util/outputNormalization.js
+++ b/server/util/outputNormalization.js
@@ -1,9 +1,27 @@
 const { NO_OUTPUT_STRING } = require('./constants');
 
+const NORMALIZE_PUNCTUATION_CAPITALIZATION = true;
+const REMOVE_JAWS_SEPARATOR_TOKENS = true;
+
 const normalizeScreenreaderOutput = output => {
   if (!output || output === NO_OUTPUT_STRING) return output;
 
-  return output.replace(/\s+/g, ' ').trim();
+  let normalized = output.replace(/\s+/g, ' ').trim();
+
+  if (NORMALIZE_PUNCTUATION_CAPITALIZATION) {
+    normalized = normalized
+      .replace(/\s*-\s*/g, '-')
+      .replace(/[^\w\s-]/g, '')
+      .replace(/\b[A-Z](?=[a-z])/g, match => match.toLowerCase())
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  if (REMOVE_JAWS_SEPARATOR_TOKENS) {
+    normalized = normalized.replace(/[\u001d\u001e]/g, '');
+  }
+
+  return normalized;
 };
 
 const outputsMatch = (output1, output2) => {


### PR DESCRIPTION
This PR adds a new property in `TestPlanReport` that connects any report created with the rerun feature to the historical report that it updates. This enables additional UI feedback on differences in output between a rerun report and the report it is updating. 

Notes:
- Testing is easiest if you used the actual workflows and a prod dump of the database (available in internal channels)
- Apologies for the rearrangement in the `TestQueue`. It was necessary to memoize
- There is also a regrettable amount of prop drilling with `historicalReport` values. Open to alternatives but this seemed easiest for the time being.
