### PR TITLE
count unsubmitted assertion verdicts as "assigned"

### DIFF
--- a/client/hooks/useTestPlanRunValidatedAssertionCounts.js
+++ b/client/hooks/useTestPlanRunValidatedAssertionCounts.js
@@ -58,11 +58,15 @@ export const useTestPlanRunValidatedAssertionCounts = (
     return testResults.reduce((acc, test) => {
       return (
         acc +
-        (test.completedAt
-          ? test.scenarioResults.reduce((acc, scenario) => {
-              return acc + scenario.assertionResults.length;
-            }, 0)
-          : 0)
+        test.scenarioResults.reduce((acc, scenario) => {
+          return (
+            acc +
+            scenario.assertionResults.reduce(
+              (acc, assertion) => acc + (assertion.passed !== null ? 1 : 0),
+              0
+            )
+          );
+        }, 0)
       );
     }, 0);
   }, [testPlanRunAssertionsQueryResult]);


### PR DESCRIPTION
see title

With assertion verdict copying, currently test results are only being submitted when all outputs match. This PR changes the calculation for "X of Y assertions assigned" to include verdicts that have been assigned but not submitted.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210859735312703