### PR TITLE
fix: focus incomplete radios instead of fieldsets

### DIFF
--- a/client/components/TestRenderer/AssertionsFieldset/index.jsx
+++ b/client/components/TestRenderer/AssertionsFieldset/index.jsx
@@ -49,7 +49,6 @@ const AssertionsFieldset = ({
             disabled={disabled}
             aria-invalid={isSubmitted && isIncomplete ? 'true' : undefined}
             aria-describedby={isSubmitted && isIncomplete ? errorId : undefined}
-            tabIndex={isSubmitted && isIncomplete ? 0 : -1}
           >
             <legend>{description[0]}</legend>
             <label className={styles.assertionsLabel}>
@@ -60,6 +59,9 @@ const AssertionsFieldset = ({
                 checked={passed === true}
                 onChange={() => (!readOnly ? click(true) : false)}
                 data-testid={`radio-yes-${commandIndex}-${assertionIndex}`}
+                aria-describedby={
+                  isSubmitted && isIncomplete ? errorId : undefined
+                }
               />
               Yes
             </label>
@@ -71,6 +73,9 @@ const AssertionsFieldset = ({
                 checked={passed === false}
                 onChange={() => (!readOnly ? click(false) : false)}
                 data-testid={`radio-no-${commandIndex}-${assertionIndex}`}
+                aria-describedby={
+                  isSubmitted && isIncomplete ? errorId : undefined
+                }
               />
               No
             </label>

--- a/client/components/TestRenderer/UnexpectedBehaviorsFieldset/index.jsx
+++ b/client/components/TestRenderer/UnexpectedBehaviorsFieldset/index.jsx
@@ -34,7 +34,6 @@ const UnexpectedBehaviorsFieldset = ({
       id={`cmd-${commandIndex}-problems`}
       aria-invalid={hasError ? 'true' : undefined}
       aria-describedby={hasError ? errorId : undefined}
-      tabIndex={hasError ? 0 : -1}
     >
       <legend>{unexpectedBehaviors.description[0]}</legend>
       {hasError && <RequiredWarning id={errorId} />}
@@ -47,6 +46,7 @@ const UnexpectedBehaviorsFieldset = ({
           checked={unexpectedBehaviors.passChoice.checked}
           onChange={handleUnexpectedBehaviorsExistRadioClick}
           disabled={forceYes}
+          aria-describedby={hasError ? errorId : undefined}
         />
         <label
           id={`problem-${commandIndex}-true-label`}
@@ -63,6 +63,7 @@ const UnexpectedBehaviorsFieldset = ({
           name={`problem-${commandIndex}`}
           checked={unexpectedBehaviors.failChoice.checked}
           onChange={handleUnexpectedBehaviorsExistRadioClick}
+          aria-describedby={hasError ? errorId : undefined}
         />
         <label
           id={`problem-${commandIndex}-false-label`}

--- a/client/hooks/useTestRendererFocus.js
+++ b/client/hooks/useTestRendererFocus.js
@@ -29,11 +29,11 @@ const useTestRendererFocus = (isSubmitted, pageContent) => {
         assertion => assertion.passed === null
       );
       if (incompleteAssertionIndex >= 0) {
-        const assertionFieldset = document.getElementById(
-          `assertion-fieldset-${commandIndex}-${incompleteAssertionIndex}`
+        const firstRadioButton = document.querySelector(
+          `input[data-testid="radio-yes-${commandIndex}-${incompleteAssertionIndex}"]`
         );
-        if (assertionFieldset) {
-          assertionFieldset.focus();
+        if (firstRadioButton) {
+          firstRadioButton.focus();
           return true;
         }
       }
@@ -41,11 +41,11 @@ const useTestRendererFocus = (isSubmitted, pageContent) => {
       // Check if unexpected behaviors section needs focus
       const unexpectedBehaviors = command.unexpectedBehaviors;
       if (unexpectedBehaviors.description[1].highlightRequired) {
-        const unexpectedFieldset = document.getElementById(
-          `cmd-${commandIndex}-problems`
+        const firstUnexpectedRadio = document.getElementById(
+          `problem-${commandIndex}-true`
         );
-        if (unexpectedFieldset) {
-          unexpectedFieldset.focus();
+        if (firstUnexpectedRadio) {
+          firstUnexpectedRadio.focus();
           return true;
         }
       }

--- a/client/tests/e2e/snapshots/saved/_account_settings.html
+++ b/client/tests/e2e/snapshots/saved/_account_settings.html
@@ -98,7 +98,7 @@
             <button type="button" class="btn btn-primary">
               Import Latest Test Plan Versions
             </button>
-            <p>Date of latest test plan version: July 24, 2025 18:08 UTC</p>
+            <p>Date of latest test plan version: July 30, 2025 13:25 UTC</p>
           </section>
         </main>
       </div>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -278,9 +278,10 @@
                       <option value="59">Rating Slider</option>
                       <option value="7">Select Only Combobox Example</option>
                       <option value="61">Switch Example</option>
+                      <option value="96">Tabs with Automatic Activation</option>
                       <option value="62">Tabs with Manual Activation</option>
-                      <option value="96">Toggle Button</option>
-                      <option value="97">Vertical Temperature Slider</option>
+                      <option value="97">Toggle Button</option>
+                      <option value="98">Vertical Temperature Slider</option>
                     </select>
                   </div>
                   <div class="form-group">
@@ -380,7 +381,7 @@
                 data-testid="filter-all"
                 aria-pressed="true"
                 class="filter-button btn active btn-secondary">
-                All Plans (37)
+                All Plans (38)
               </button>
             </li>
             <li>
@@ -389,7 +390,7 @@
                 data-testid="filter-rd"
                 aria-pressed="false"
                 class="filter-button btn btn-secondary">
-                R&amp;D Complete (33)
+                R&amp;D Complete (34)
               </button>
             </li>
             <li>
@@ -423,7 +424,7 @@
           <div class="table-responsive">
             <table
               aria-label="Test Plans Status Summary Table"
-              aria-rowcount="37"
+              aria-rowcount="38"
               class="data-management table table-bordered table-hover">
               <thead>
                 <tr>
@@ -1193,7 +1194,7 @@
                   <td>
                     <div class="phase-cell" role="list" aria-setsize="2">
                       <span class="styled-pill full-width auto-width"
-                        ><a href="/test-review/96"
+                        ><a href="/test-review/97"
                           ><span
                             ><svg
                               aria-hidden="true"
@@ -2718,6 +2719,60 @@
                 </tr>
                 <tr aria-rowindex="35">
                   <th>
+                    <a href="/data-management/tabs-automatic-activation"
+                      ><b>Tabs with Automatic Activation</b></a
+                    >
+                  </th>
+                  <td>
+                    <div>
+                      <b>JAWS</b><span>, </span><b>NVDA</b><span> and </span
+                      ><b>VoiceOver for macOS</b>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="status-cell">
+                      <span class="pill full-width rd">R&amp;D</span>
+                      <p class="review-text">Complete <b>Jul 30, 2025</b></p>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="phase-cell" role="list" aria-setsize="2">
+                      <span class="styled-pill full-width auto-width"
+                        ><a href="/test-review/96"
+                          ><span
+                            ><svg
+                              aria-hidden="true"
+                              focusable="false"
+                              data-prefix="fas"
+                              data-icon="circle-check"
+                              class="svg-inline--fa fa-circle-check check"
+                              role="img"
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 512 512"
+                              color="var(--positive-green)">
+                              <path
+                                fill="currentColor"
+                                d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                            ><b>V25.07.30</b></span
+                          ></a
+                        ></span
+                      ><button
+                        type="button"
+                        class="advance-button btn btn-secondary">
+                        Advance to Draft
+                      </button>
+                    </div>
+                  </td>
+                  <td>
+                    <span class="none centered absolute">Not Started</span>
+                  </td>
+                  <td>
+                    <span class="none centered absolute">Not Started</span>
+                  </td>
+                  <td><span class="none centered absolute">None Yet</span></td>
+                </tr>
+                <tr aria-rowindex="36">
+                  <th>
                     <a href="/data-management/tabs-manual-activation"
                       ><b>Tabs with Manual Activation</b></a
                     >
@@ -2770,7 +2825,7 @@
                   </td>
                   <td><span class="none centered absolute">None Yet</span></td>
                 </tr>
-                <tr aria-rowindex="36">
+                <tr aria-rowindex="37">
                   <th>
                     <a href="/data-management/vertical-temperature-slider"
                       ><b>Vertical Temperature Slider</b></a
@@ -2791,7 +2846,7 @@
                   <td>
                     <div class="phase-cell" role="list" aria-setsize="2">
                       <span class="styled-pill full-width auto-width"
-                        ><a href="/test-review/97"
+                        ><a href="/test-review/98"
                           ><span
                             ><svg
                               aria-hidden="true"

--- a/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
+++ b/client/tests/e2e/snapshots/saved/_test-plan-report_1.html
@@ -415,8 +415,7 @@
                               </legend>
                               <fieldset
                                 id="assertion-fieldset-0-0"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Role 'button' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -434,8 +433,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-0-1"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Name 'Mute' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -453,8 +451,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-0-2"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>State 'not pressed' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -473,8 +470,7 @@
                             </fieldset>
                             <fieldset
                               class="test-renderer-fieldset"
-                              id="cmd-0-problems"
-                              tabindex="-1">
+                              id="cmd-0-problems">
                               <legend>Did negative side effects occur?</legend>
                               <div>
                                 <input
@@ -688,8 +684,7 @@
                               </legend>
                               <fieldset
                                 id="assertion-fieldset-1-0"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Role 'button' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -707,8 +702,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-1-1"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Name 'Mute' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -726,8 +720,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-1-2"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>State 'not pressed' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -746,8 +739,7 @@
                             </fieldset>
                             <fieldset
                               class="test-renderer-fieldset"
-                              id="cmd-1-problems"
-                              tabindex="-1">
+                              id="cmd-1-problems">
                               <legend>Did negative side effects occur?</legend>
                               <div>
                                 <input
@@ -961,8 +953,7 @@
                               </legend>
                               <fieldset
                                 id="assertion-fieldset-2-0"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Role 'button' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -980,8 +971,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-2-1"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Name 'Mute' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -999,8 +989,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-2-2"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>State 'not pressed' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -1019,8 +1008,7 @@
                             </fieldset>
                             <fieldset
                               class="test-renderer-fieldset"
-                              id="cmd-2-problems"
-                              tabindex="-1">
+                              id="cmd-2-problems">
                               <legend>Did negative side effects occur?</legend>
                               <div>
                                 <input
@@ -1234,8 +1222,7 @@
                               </legend>
                               <fieldset
                                 id="assertion-fieldset-3-0"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Role 'button' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -1253,8 +1240,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-3-1"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>Name 'Mute' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -1272,8 +1258,7 @@
                               </fieldset>
                               <fieldset
                                 id="assertion-fieldset-3-2"
-                                class="test-renderer-fieldset"
-                                tabindex="-1">
+                                class="test-renderer-fieldset">
                                 <legend>State 'not pressed' is conveyed</legend>
                                 <label class="assertions-label"
                                   ><input
@@ -1292,8 +1277,7 @@
                             </fieldset>
                             <fieldset
                               class="test-renderer-fieldset"
-                              id="cmd-3-problems"
-                              tabindex="-1">
+                              id="cmd-3-problems">
                               <legend>Did negative side effects occur?</legend>
                               <div>
                                 <input


### PR DESCRIPTION
see title

This addresses the [additional feedback](https://github.com/w3c/aria-at-app/issues/1464#issuecomment-3148850012) in #1464. Originally, the fieldset was chosen as the focus point because in my testing on VO, I felt that the best orientation to the required input needed was from the top level so as not to imply that any one radio response was required, also to give a sense of the query to which the radio button is replying. Feedback disagrees with this design so this PR shifted to focusing the first radio button under the fieldset instead.

