### PR TITLE
fix: use divs instead of spans for status list

### DIFF
--- a/client/components/BotRunTestStatusList/index.js
+++ b/client/components/BotRunTestStatusList/index.js
@@ -79,39 +79,37 @@ const BotRunTestStatusList = ({ testPlanReportId }) => {
   }
 
   return (
-    <>
-      <div className={clsx(styles.botRunTestContainer, 'text-secondary')}>
-        Bot Status:
-        <ul>
-          {RUNNING > 0 && (
-            <li>
-              <ReportStatusDot status={REPORT_STATUSES.TESTS_RUNNING} />
-              {testCountString(RUNNING, 'Running')}
-            </li>
-          )}
-          {ERROR > 0 && (
-            <li>
-              <ReportStatusDot status={REPORT_STATUSES.TESTS_ERROR} />
-              {testCountString(ERROR, 'Error')}
-            </li>
-          )}
+    <div className={clsx(styles.botRunTestContainer, 'text-secondary')}>
+      <div>Bot Status:</div>
+      <ul>
+        {RUNNING > 0 && (
           <li>
-            <ReportStatusDot status={REPORT_STATUSES.TESTS_COMPLETE} />
-            {testCountString(COMPLETED, 'Completed')}
+            <ReportStatusDot status={REPORT_STATUSES.TESTS_RUNNING} />
+            {testCountString(RUNNING, 'Running')}
           </li>
+        )}
+        {ERROR > 0 && (
           <li>
-            <ReportStatusDot status={REPORT_STATUSES.TESTS_QUEUED} />
-            {testCountString(QUEUED, 'Queued')}
+            <ReportStatusDot status={REPORT_STATUSES.TESTS_ERROR} />
+            {testCountString(ERROR, 'Error')}
           </li>
-          {CANCELLED > 0 && (
-            <li>
-              <ReportStatusDot status={REPORT_STATUSES.TESTS_CANCELLED} />
-              {testCountString(CANCELLED, 'Cancelled')}
-            </li>
-          )}
-        </ul>
-      </div>
-    </>
+        )}
+        <li>
+          <ReportStatusDot status={REPORT_STATUSES.TESTS_COMPLETE} />
+          {testCountString(COMPLETED, 'Completed')}
+        </li>
+        <li>
+          <ReportStatusDot status={REPORT_STATUSES.TESTS_QUEUED} />
+          {testCountString(QUEUED, 'Queued')}
+        </li>
+        {CANCELLED > 0 && (
+          <li>
+            <ReportStatusDot status={REPORT_STATUSES.TESTS_CANCELLED} />
+            {testCountString(CANCELLED, 'Cancelled')}
+          </li>
+        )}
+      </ul>
+    </div>
   );
 };
 

--- a/client/components/common/ReportStatusSummary/index.jsx
+++ b/client/components/common/ReportStatusSummary/index.jsx
@@ -45,13 +45,13 @@ const ReportStatusSummary = ({
     switch (draftTestPlanRuns?.length) {
       case 0:
         return fromTestQueue ? (
-          <span>No testers assigned</span>
+          <div>No testers assigned</div>
         ) : (
-          <span>In test queue with no testers assigned</span>
+          <div>In test queue with no testers assigned</div>
         );
       case 1:
         return (
-          <span>
+          <div>
             {testPlanReport.percentComplete || 0}% complete by&nbsp;
             <a
               href={`https://github.com/${draftTestPlanRuns[0].tester.username}`}
@@ -60,15 +60,15 @@ const ReportStatusSummary = ({
             </a>
             &nbsp;
             {getConflictsAnchor(conflictsCount)}
-          </span>
+          </div>
         );
       default:
         return (
-          <span>
+          <div>
             {testPlanReport.percentComplete || 0}% complete by&nbsp;
             {draftTestPlanRuns.length} testers&nbsp;
             {getConflictsAnchor(conflictsCount)}
-          </span>
+          </div>
         );
     }
   };
@@ -82,7 +82,7 @@ const ReportStatusSummary = ({
     }
   }
 
-  return <span className={styles.incompleteStatusReport}>Missing</span>;
+  return <div className={styles.incompleteStatusReport}>Missing</div>;
 };
 
 ReportStatusSummary.propTypes = {


### PR DESCRIPTION
see title

This PR addresses #1426 by swapping `<span>`s for `<div>`s in the bot status list per the recommendation in that issue. Reviewers should review with JAWS.