### PR TITLE
Handle excluded then-able commands in `createTestResultSkeleton`

### DIFF
--- a/client/components/TestRun/index.jsx
+++ b/client/components/TestRun/index.jsx
@@ -678,7 +678,10 @@ const TestRun = () => {
         output,
         untestable,
         hasUnexpected,
-        unexpectedBehaviors
+        unexpectedBehaviors,
+        mustAssertionResults,
+        shouldAssertionResults,
+        mayAssertionResults
       }) => ({
         id,
         output: output,
@@ -699,6 +702,17 @@ const TestRun = () => {
           // excluded assertion, but it can be removed at this point before being passed
           // to the server
           .filter(el => !!el.id)
+          // Assertion results returned from assertionResultsResolver should never
+          // include 'EXCLUDED' assertions
+          .filter(el =>
+            [
+              ...mustAssertionResults,
+              ...shouldAssertionResults,
+              ...mayAssertionResults
+            ]
+              .map(({ id }) => id)
+              .includes(el.id)
+          )
           .map(({ id, passed }) => ({
             id,
             passed

--- a/server/resolvers/TestPlanRunOperations/createTestResultSkeleton.js
+++ b/server/resolvers/TestPlanRunOperations/createTestResultSkeleton.js
@@ -13,14 +13,16 @@ const {
  * @param {string} priority
  */
 const hasExceptionWithPriority = (assertion, scenario, priority) => {
-  return assertion.assertionExceptions?.some(
-    exception =>
-      scenario.commands.find(
-        command =>
-          command.id === exception.commandId &&
-          command.atOperatingMode === exception.settings
-      ) && exception.priority === priority
-  );
+  return assertion.assertionExceptions?.some(exception => {
+    const scenarioCommandId = scenario.commands.map(({ id }) => id).join(' ');
+    const scenarioAtOperatingMode = scenario.commands[0].atOperatingMode;
+
+    return (
+      scenarioCommandId === exception.commandId &&
+      scenarioAtOperatingMode === exception.settings &&
+      exception.priority === priority
+    );
+  });
 };
 
 const createTestResultSkeleton = ({


### PR DESCRIPTION
Address https://github.com/w3c/aria-at/issues/1273

Consider the following assertion and scenario which describes an exception set to EXCLUDE the assertion for the `down down` command:

<details>

<summary>expand assertion</summary>

```json
{
  "id": "NDllMeyIzIjoiWVdRMk1leUl5SWpvaU1UWXpOalV4SW4wVGRtTTIifQ2RiMj",
  "priority": "MAY",
  "rawAssertionId": "tabPanelText",
  "assertionPhrase": "convey text of tab panel, 'Peter Erasmus Lange-Müller (1 December 1850 – 26 February 1926) was a Danish composer and pianist. His compositional style was influenced by Danish folk music and by the work of Robert Schumann; Johannes Brahms; and his Danish countrymen, including J.P.E. Hartmann.'",
  "assertionStatement": "Text of the tab panel, 'Peter Erasmus Lange-Müller (1 December 1850 – 26 February 1926) was a Danish composer and pianist. His compositional style was influenced by Danish folk music and by the work of Robert Schumann; Johannes Brahms; and his Danish countrymen, including J.P.E. Hartmann.', is conveyed",
  "assertionExceptions": [
    {
       "priority": "EXCLUDE",
       "settings": "virtualCursor",
	   "commandId": "down down"
    }
  ],
  "text": "Text of the tab panel, 'Peter Erasmus Lange-Müller (1 December 1850 – 26 February 1926) was a Danish composer and pianist. His compositional style was influenced by Danish folk music and by the work of Robert Schumann; Johannes Brahms; and his Danish countrymen, including J.P.E. Hartmann.', is conveyed",
  "phrase": "convey text of tab panel, 'Peter Erasmus Lange-Müller (1 December 1850 – 26 February 1926) was a Danish composer and pianist. His compositional style was influenced by Danish folk music and by the work of Robert Schumann; Johannes Brahms; and his Danish countrymen, including J.P.E. Hartmann.'"
}
```

</details>

<details>

<summary>expand scenario</summary>

```json
{
  "id": "NWQ2ZeyIzIjoiWVdRMk1leUl5SWpvaU1UWXpOalV4SW4wVGRtTTIifQDZhMj",
  "atId": 1,
  "settings": "virtualCursor",
  "commandIds": [
    "down",
    "down"
  ],
  "at": {
    "id": 1,
    "name": "JAWS",
    "key": "jaws",
    "vendorId": 1,
    "defaultConfigurationInstructionsHTML": "Configure JAWS with default settings. For help, read &lt;a href=&quot;https://github.com/w3c/aria-at/wiki/Configuring-Screen-Readers-for-Testing&quot;&gt;Configuring Screen Readers for Testing&lt;/a&gt;.",
    "assertionTokens": {
       "screenReader": "JAWS",
       "interactionMode": "PC cursor active",
       "readingMode": "virtual cursor active",
       "readingCursor": "virtual cursor"
    },
    "settings": {
      "virtualCursor": {
        "screenText": "virtual cursor active",
        "instructions": [
          "Press &lt;kbd&gt;Alt&lt;/kbd&gt;+&lt;kbd&gt;Delete&lt;/kbd&gt; to determine which cursor is active.",
          "If the PC cursor is active, press &lt;kbd&gt;Escape&lt;/kbd&gt; to activate the virtual cursor."
        ]
      },
      "pcCursor": {
        "screenText": "PC cursor active",
        "instructions": [
          "Press &lt;kbd&gt;Alt&lt;/kbd&gt;+&lt;kbd&gt;Delete&lt;/kbd&gt; to determine which cursor is active.",
          "If the virtual cursor is active, press &lt;kbd&gt;Insert&lt;/kbd&gt;+&lt;kbd&gt;z&lt;/kbd&gt; to disable the virtual cursor."
        ]
      }
    }
  },
  "commands": [
    {
      "id": "down",
      "text": "Down Arrow (virtual cursor active)",
      "atOperatingMode": "virtualCursor"
    },
    {
      "id": "down",
      "text": "Down Arrow (virtual cursor active)",
      "atOperatingMode": "virtualCursor"
    }
  ]
}
```

</details>

The [`hasExceptionWithPriority` function](https://github.com/w3c/aria-at-app/blob/1381cc384c4b191bb3b726e4cc08ffa5a0989dae/server/resolvers/TestPlanRunOperations/createTestResultSkeleton.js#L15:L24) would never work in this case because `exception.commandId` expects `down down` but the `commands` array would only ever produce `down` when being looped across. This would prevent a testResult including such a condition from being saved.

That function should operate similar to [the `assertionResultsResolver`](https://github.com/w3c/aria-at-app/blob/b82ae74c6b07a5a099de14d4cb8213abd3ff6029/server/resolvers/ScenarioResult/assertionResultsResolver.js#L11:L27).

This was probably never caught because it would only happen in the case of a *then-able* command (eg. `key1 key2`, `down down` -> `Down Arrow then Down Arrow`) having an exception set to `EXCLUDE`. After going through all the `*-commands.csv`'s in w3c/aria-at, this is the first instance. Other cases used `key1` or `key1+key2` which would have been valid.