### PR TITLE
fix: Update JAWS supported versions

### DIFF
--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -404,14 +404,15 @@ const updateJobResults = async (req, res) => {
         throw new Error(`Browser not found with name: ${browserName}`);
       }
 
+      let parsedAtVersion = atVersionName;
       if (atName == 'JAWS') {
         // remove the reported 4th number in the version string.
-        atVersionName = atVersionName.split('.').slice(0, 3).join('.');
+        parsedAtVersion = atVersionName.split('.').slice(0, 3).join('.');
       }
 
       const [atVersion, browserVersion] = await Promise.all([
         findOrCreateAtVersion({
-          where: { atId: at.id, name: atVersionName },
+          where: { atId: at.id, name: parsedAtVersion },
           transaction
         }),
         findOrCreateBrowserVersion({

--- a/server/controllers/AutomationController.js
+++ b/server/controllers/AutomationController.js
@@ -404,6 +404,11 @@ const updateJobResults = async (req, res) => {
         throw new Error(`Browser not found with name: ${browserName}`);
       }
 
+      if (atName == 'JAWS') {
+        // remove the reported 4th number in the version string.
+        atVersionName = atVersionName.split('.').slice(0, 3).join('.');
+      }
+
       const [atVersion, browserVersion] = await Promise.all([
         findOrCreateAtVersion({
           where: { atId: at.id, name: atVersionName },

--- a/server/services/GithubWorkflowService.js
+++ b/server/services/GithubWorkflowService.js
@@ -183,6 +183,7 @@ const createGithubWorkflow = async ({ job, directory, gitSha, atVersion }) => {
   }
   if (atKey === 'jaws') {
     inputs.browser = browser;
+    inputs.jaws_version = atVersion?.name ?? 'latest';
   }
   const axiosConfig = {
     method: 'POST',

--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -9,6 +9,8 @@ const AT_VERSIONS_SUPPORTED_BY_COLLECTION_JOBS = {
   'VoiceOver for macOS': ['13.0', '14.0', '15.0'],
   // These are tracked with the https://github.com/bocoup/aria-at-automation-nvda-builds/releases
   NVDA: ['2024.4.1', '2024.1', '2023.3.3', '2023.3'],
+  // These are tracked and assigned URLs in
+  // https://github.com/bocoup/aria-at-gh-actions-helper/blob/main/JAWS/InstallJAWSUnattended.ps1
   JAWS: ['2025.2507.149']
 };
 

--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -9,7 +9,7 @@ const AT_VERSIONS_SUPPORTED_BY_COLLECTION_JOBS = {
   'VoiceOver for macOS': ['13.0', '14.0', '15.0'],
   // These are tracked with the https://github.com/bocoup/aria-at-automation-nvda-builds/releases
   NVDA: ['2024.4.1', '2024.1', '2023.3.3', '2023.3'],
-  JAWS: ['2025.2506.168.400']
+  JAWS: ['2025.2507.149']
 };
 
 const VENDOR_NAME_TO_AT_MAPPING = {


### PR DESCRIPTION
Stripping the .400 from the version number in the ingest section of the JAWS bot.  Set supported versions to the only currently supported version.

Also now supports passing the selected JAWS version - https://github.com/bocoup/aria-at-gh-actions-helper/blob/83f787e75815556a582126394e8ca5d21cd8ff57/JAWS/InstallJAWSUnattended.ps1#L3 currently only supports the one version