### PR TITLE
Render untestable assertions as indeterminate

### DIFF
--- a/client/components/TestRenderer/AssertionsFieldset/index.jsx
+++ b/client/components/TestRenderer/AssertionsFieldset/index.jsx
@@ -10,7 +10,7 @@ const AssertionsFieldset = ({
   commandIndex,
   assertionsHeader,
   readOnly = false,
-  disabled,
+  isUntestable,
   isSubmitted = false
 }) => {
   // Handle case where build process didn't include assertionResponseQuestion
@@ -46,7 +46,7 @@ const AssertionsFieldset = ({
               isSubmitted && isIncomplete && styles.incompleteFieldset
             )}
             key={`AssertionKey_${commandIndex}_${assertionIndex}`}
-            disabled={disabled}
+            disabled={isUntestable}
             aria-invalid={isSubmitted && isIncomplete ? 'true' : undefined}
             aria-describedby={isSubmitted && isIncomplete ? errorId : undefined}
           >
@@ -56,7 +56,7 @@ const AssertionsFieldset = ({
                 type="radio"
                 id={`pass-${commandIndex}-${assertionIndex}-yes`}
                 name={`assertion-${commandIndex}-${assertionIndex}`}
-                checked={passed === true}
+                checked={!isUntestable && passed === true}
                 onChange={() => (!readOnly ? click(true) : false)}
                 data-testid={`radio-yes-${commandIndex}-${assertionIndex}`}
                 aria-describedby={
@@ -70,7 +70,7 @@ const AssertionsFieldset = ({
                 type="radio"
                 id={`pass-${commandIndex}-${assertionIndex}-no`}
                 name={`assertion-${commandIndex}-${assertionIndex}`}
-                checked={passed === false}
+                checked={!isUntestable && passed === false}
                 onChange={() => (!readOnly ? click(false) : false)}
                 data-testid={`radio-no-${commandIndex}-${assertionIndex}`}
                 aria-describedby={
@@ -91,7 +91,7 @@ AssertionsFieldset.propTypes = {
   commandIndex: PropTypes.number.isRequired,
   assertionsHeader: PropTypes.object.isRequired,
   readOnly: PropTypes.bool,
-  disabled: PropTypes.bool.isRequired,
+  isUntestable: PropTypes.bool.isRequired,
   isSubmitted: PropTypes.bool
 };
 

--- a/client/components/TestRenderer/CommandResults/index.jsx
+++ b/client/components/TestRenderer/CommandResults/index.jsx
@@ -109,7 +109,7 @@ const CommandResults = ({
         commandIndex={commandIndex}
         assertionsHeader={assertionsHeader}
         readOnly={isReadOnly}
-        disabled={untestable.value}
+        isUntestable={untestable.value}
         isSubmitted={isSubmitted}
       />
       <UnexpectedBehaviorsFieldset


### PR DESCRIPTION
Prior to this commit, the form fields corresponding to untestable assertions were displayed as though a failing verdict had been assigned. Although the form fields were also disabled in this case, the value was nonetheless misleading because untestable assertions do not contribute to passing/failing scores.

Render form fields for untestable assertions in the non-determinant state. Rename the React component property named "disabled" to accommodate its expanded purpose in this new implementation.

---

This partially resolves gh-1486.