### PR TITLE
Update automation bot versions (NVDA and JAWS)

### DIFF
--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -8,10 +8,10 @@ const AT_VERSIONS_SUPPORTED_BY_COLLECTION_JOBS = {
   // https://github.com/bocoup/aria-at-gh-actions-helper/blob/main/.github/workflows/self-hosted-macos-15.yml
   'VoiceOver for macOS': ['13.0', '14.0', '15.0'],
   // These are tracked with the https://github.com/bocoup/aria-at-automation-nvda-builds/releases
-  NVDA: ['2024.4.1', '2024.1', '2023.3.3', '2023.3'],
+  NVDA: ['2025.2', '2024.4.1', '2024.1', '2023.3.3', '2023.3'],
   // These are tracked and assigned URLs in
   // https://github.com/bocoup/aria-at-gh-actions-helper/blob/main/JAWS/InstallJAWSUnattended.ps1
-  JAWS: ['2025.2507.149']
+  JAWS: ['2025.2508.120']
 };
 
 const VENDOR_NAME_TO_AT_MAPPING = {


### PR DESCRIPTION
I've added both of these versions manually to live and staging servers.