### PR TITLE
fix: Coerce `browserVersionId` and `atVersionId` to numbers for "expanded matching" migration

### DIFF
--- a/server/migrations/20250812000000-backfill-scenario-match-and-drop-historical-report.js
+++ b/server/migrations/20250812000000-backfill-scenario-match-and-drop-historical-report.js
@@ -60,15 +60,21 @@ module.exports = {
           const atVersionIds = Array.from(
             new Set(
               finalizedTestResults
-                .map(tr => tr?.atVersionId)
-                .filter(id => id != null)
+                .map(tr =>
+                  tr?.atVersionId != null ? Number(tr.atVersionId) : null
+                )
+                .filter(id => id != null && Number.isFinite(id))
             )
           );
           const browserVersionIds = Array.from(
             new Set(
               finalizedTestResults
-                .map(tr => tr?.browserVersionId)
-                .filter(id => id != null)
+                .map(tr =>
+                  tr?.browserVersionId != null
+                    ? Number(tr.browserVersionId)
+                    : null
+                )
+                .filter(id => id != null && Number.isFinite(id))
             )
           );
           const atVersionIdToName = new Map();
@@ -103,8 +109,12 @@ module.exports = {
                   { passed: a?.passed, failedReason: a?.failedReason }
                 ])
               );
-              const atVersionId = tr?.atVersionId ?? null;
-              const browserVersionId = tr?.browserVersionId ?? null;
+              const atVersionId =
+                tr?.atVersionId != null ? Number(tr.atVersionId) : null;
+              const browserVersionId =
+                tr?.browserVersionId != null
+                  ? Number(tr.browserVersionId)
+                  : null;
               const atVersionName =
                 (atVersionId != null && atVersionIdToName.get(atVersionId)) ||
                 '';


### PR DESCRIPTION
The lookup map was failing due to string <-> number type mismatch. This led to migrated reruns having empty strings for `source.match.atVersionName` and `source.match.browserVersionName`. The code may be overly defensive but I think it is fine for a migration.