### PR TITLE
fix: only count responses recorded if job also has verdicts

### DIFF
--- a/client/components/TestQueue/queries.js
+++ b/client/components/TestQueue/queries.js
@@ -82,6 +82,12 @@ export const TEST_QUEUE_PAGE_QUERY = gql`
               ...TestResultFields
               scenarioResults {
                 output
+                assertionResults {
+                  passed
+                }
+                negativeSideEffects {
+                  id
+                }
               }
             }
           }

--- a/client/components/TestQueueRunCompletionStatus/index.js
+++ b/client/components/TestQueueRunCompletionStatus/index.js
@@ -42,15 +42,19 @@ const TestQueueRunCompletionStatus = ({
     testPlanReport.runnableTestsLength
   ]);
 
-  const getNumCompletedOutputs = result =>
-    result.scenarioResults.reduce((acc, scenario) => {
-      return (
-        acc +
-        (typeof scenario.output === 'string' && scenario.output !== '' ? 1 : 0)
-      );
-    }, 0);
+  const isScenarioResultCompleted = scenarioResult =>
+    scenarioResult.negativeSideEffects !== null &&
+    scenarioResult.assertionResults.every(
+      assertionResult => assertionResult.passed !== null
+    );
 
-  // Calculate completed responses (number of commands with outputs)
+  const getNumCompletedOutputs = result => {
+    return result.scenarioResults.reduce((acc, scenario) => {
+      return acc + (isScenarioResultCompleted(scenario) ? 1 : 0);
+    }, 0);
+  };
+
+  // Calculate completed responses (number of commands with outputs && complete verdicts)
   const completedResponses = testPlanRun?.testResults?.reduce(
     (acc, result) => acc + getNumCompletedOutputs(result),
     0


### PR DESCRIPTION
see title

Now a response must have complete assertion verdicts and negative side effects info to count as recorded.