### PR TITLE
feat: allow testers to start bot runs

### DIFF
--- a/client/components/ManageBotRunDialog/StartBotRunButton/index.jsx
+++ b/client/components/ManageBotRunDialog/StartBotRunButton/index.jsx
@@ -72,7 +72,8 @@ const StartBotRunButton = ({ testPlanReport, onChange }) => {
         actions={[
           {
             label: 'Start',
-            onClick: onConfirm
+            onClick: onConfirm,
+            testId: 'confirm-start-bot-run'
           }
         ]}
       />

--- a/client/components/ManageBotRunDialog/StartBotRunButton/index.jsx
+++ b/client/components/ManageBotRunDialog/StartBotRunButton/index.jsx
@@ -1,0 +1,107 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useApolloClient } from '@apollo/client';
+import { Button } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFileImport } from '@fortawesome/free-solid-svg-icons';
+import useConfirmationModal from '../../../hooks/useConfirmationModal';
+import { useTriggerLoad } from '../../common/LoadingStatus';
+import BasicModal from '../../common/BasicModal';
+import { SCHEDULE_COLLECTION_JOB_MUTATION } from '../../AddTestToQueueWithConfirmation/queries';
+import { TEST_QUEUE_PAGE_QUERY } from '../../TestQueue/queries';
+import { TEST_PLAN_REPORT_STATUS_DIALOG_QUERY } from '../../TestPlanReportStatusDialog/queries';
+
+const StartBotRunButton = ({ testPlanReport, onChange }) => {
+  const client = useApolloClient();
+  const { triggerLoad } = useTriggerLoad();
+  const { showConfirmationModal, hideConfirmationModal } =
+    useConfirmationModal();
+
+  const atLatestAutomationSupportedVersion = useMemo(() => {
+    const versions = testPlanReport?.at?.atVersions || [];
+    const supported = versions.filter(v => v.supportedByAutomation);
+    if (!supported.length) return null;
+    return supported.reduce((latest, v) =>
+      new Date(v.releasedAt) > new Date(latest.releasedAt) ? v : latest
+    );
+  }, [testPlanReport]);
+
+  // Shorten the AT name to the first word
+  // specifically needed for "VoiceOver for macOS"
+  const shortenedAtName = useMemo(() => {
+    return testPlanReport.at.name.split(' ')[0];
+  }, [testPlanReport]);
+
+  const onStart = () => {
+    const title = `Start ${testPlanReport.at.name} Bot Run`;
+    const content = (
+      <>
+        <p>
+          This will run the bot using {testPlanReport.at.name}{' '}
+          {atLatestAutomationSupportedVersion?.name ??
+            '(no automation-supported version found)'}
+          .
+        </p>
+      </>
+    );
+
+    const onConfirm = async () => {
+      await triggerLoad(async () => {
+        await client.mutate({
+          mutation: SCHEDULE_COLLECTION_JOB_MUTATION,
+          variables: { testPlanReportId: testPlanReport.id },
+          refetchQueries: [
+            TEST_QUEUE_PAGE_QUERY,
+            TEST_PLAN_REPORT_STATUS_DIALOG_QUERY
+          ],
+          awaitRefetchQueries: true
+        });
+      }, 'Scheduling Collection Job');
+      hideConfirmationModal();
+      if (onChange) await onChange();
+    };
+
+    showConfirmationModal(
+      <BasicModal
+        show
+        title={title}
+        content={content}
+        staticBackdrop={true}
+        handleClose={() => hideConfirmationModal()}
+        useOnHide={true}
+        actions={[
+          {
+            label: 'Start',
+            onClick: onConfirm
+          }
+        ]}
+      />
+    );
+  };
+
+  return (
+    <Button variant="secondary" onClick={onStart}>
+      <FontAwesomeIcon icon={faFileImport} />
+      {`Start ${shortenedAtName} Bot Run`}
+    </Button>
+  );
+};
+
+StartBotRunButton.propTypes = {
+  testPlanReport: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    at: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      atVersions: PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string.isRequired,
+          releasedAt: PropTypes.string.isRequired,
+          supportedByAutomation: PropTypes.bool
+        })
+      )
+    }).isRequired
+  }).isRequired,
+  onChange: PropTypes.func
+};
+
+export default StartBotRunButton;

--- a/client/components/ManageBotRunDialog/WithButton.jsx
+++ b/client/components/ManageBotRunDialog/WithButton.jsx
@@ -11,7 +11,8 @@ const ManageBotRunDialogWithButton = ({
   testPlanReportId,
   runnableTestsLength,
   testers,
-  onChange
+  onChange,
+  me
 }) => {
   const [showDialog, setShowDialog] = useState(false);
 
@@ -32,6 +33,7 @@ const ManageBotRunDialogWithButton = ({
           show={showDialog}
           setShow={setShowDialog}
           testers={testers}
+          me={me}
           testPlanReportId={testPlanReportId}
           runnableTestsLength={runnableTestsLength}
           onChange={async () => {
@@ -49,7 +51,8 @@ ManageBotRunDialogWithButton.propTypes = {
   testPlanReportId: PropTypes.string.isRequired,
   runnableTestsLength: PropTypes.number.isRequired,
   testers: PropTypes.arrayOf(UserPropType).isRequired,
-  onChange: PropTypes.func.isRequired
+  onChange: PropTypes.func.isRequired,
+  me: UserPropType
 };
 
 export default ManageBotRunDialogWithButton;

--- a/client/components/ManageBotRunDialog/index.jsx
+++ b/client/components/ManageBotRunDialog/index.jsx
@@ -152,7 +152,9 @@ const ManageBotRunDialog = ({
 
     if (isTester) {
       const AssignSelfButton = props => (
-        <Button {...props}>Assign Yourself</Button>
+        <Button {...props} data-testid="assign-self-bot-run">
+          Assign Yourself
+        </Button>
       );
       return [
         {

--- a/client/components/ManageBotRunDialog/index.jsx
+++ b/client/components/ManageBotRunDialog/index.jsx
@@ -18,12 +18,16 @@ import ViewLogsButton from './ViewLogsButton';
 import { TestPlanRunPropType, UserPropType } from '../common/proptypes';
 import { COLLECTION_JOB_STATUS } from '../../utils/collectionJobStatus';
 import styles from './ManageBotRunDialog.module.css';
+import { evaluateAuth } from '../../utils/evaluateAuth';
+import { ASSIGN_TESTER_MUTATION } from '../common/AssignTesterDropdown/queries';
+import { Button } from 'react-bootstrap';
 
 const ManageBotRunDialog = ({
   testPlanReportId,
   runnableTestsLength,
   testPlanRun,
   testers,
+  me,
   show,
   setShow,
   onChange
@@ -69,6 +73,10 @@ const ManageBotRunDialog = ({
     [testers, testPlanReportAssignedTestersQuery]
   );
 
+  const { isAdmin, isTester } = evaluateAuth(me);
+
+  const [assignTester] = useMutation(ASSIGN_TESTER_MUTATION);
+
   const isBotRunFinished = useMemo(() => {
     const status = collectionJobQuery?.collectionJobByTestPlanRunId?.status;
     if (!status) return false;
@@ -83,18 +91,7 @@ const ManageBotRunDialog = ({
   }, [collectionJobQuery]);
 
   const actions = useMemo(() => {
-    return [
-      {
-        component: AssignTesterDropdown,
-        props: {
-          testPlanReportId: testPlanReportId,
-          testPlanRun: testPlanRun,
-          possibleTesters: possibleReassignees,
-          label: 'Assign To ...',
-          disabled: !isBotRunFinished,
-          onChange
-        }
-      },
+    const baseActions = [
       {
         component: ViewLogsButton,
         props: {
@@ -135,12 +132,60 @@ const ManageBotRunDialog = ({
         }
       }
     ];
+
+    if (isAdmin) {
+      return [
+        {
+          component: AssignTesterDropdown,
+          props: {
+            testPlanReportId: testPlanReportId,
+            testPlanRun: testPlanRun,
+            possibleTesters: possibleReassignees,
+            label: 'Assign To ...',
+            disabled: !isBotRunFinished,
+            onChange
+          }
+        },
+        ...baseActions
+      ];
+    }
+
+    if (isTester) {
+      const AssignSelfButton = props => (
+        <Button {...props}>Assign Yourself</Button>
+      );
+      return [
+        {
+          component: AssignSelfButton,
+          props: {
+            variant: 'primary',
+            disabled: !isBotRunFinished,
+            onClick: async () => {
+              await assignTester({
+                variables: {
+                  testReportId: testPlanReportId,
+                  testerId: me.id,
+                  testPlanRunId: testPlanRun.id
+                }
+              });
+              await onChange();
+            }
+          }
+        },
+        ...baseActions
+      ];
+    }
+
+    return baseActions;
   }, [
     testPlanReportId,
     testPlanRun,
     possibleReassignees,
     onChange,
-    collectionJobQuery
+    collectionJobQuery,
+    isAdmin,
+    isTester,
+    isBotRunFinished
   ]);
 
   const deleteConfirmationContent = (
@@ -204,6 +249,7 @@ ManageBotRunDialog.propTypes = {
   show: PropTypes.bool.isRequired,
   setShow: PropTypes.func.isRequired,
   testers: PropTypes.arrayOf(UserPropType).isRequired,
+  me: UserPropType,
   testPlanReportId: PropTypes.string.isRequired,
   runnableTestsLength: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired

--- a/client/components/TestQueue/Actions.jsx
+++ b/client/components/TestQueue/Actions.jsx
@@ -21,6 +21,7 @@ import BasicThemedModal from '../common/BasicThemedModal';
 import { evaluateAuth } from '../../utils/evaluateAuth';
 import { TEST_PLAN_REPORT_STATUS_DIALOG_QUERY } from '../TestPlanReportStatusDialog/queries';
 import ManageBotRunDialogWithButton from '@components/ManageBotRunDialog/WithButton';
+import StartBotRunButton from '@components/ManageBotRunDialog/StartBotRunButton';
 import {
   TestPlanPropType,
   TestPlanReportPropType,
@@ -264,12 +265,19 @@ const Actions = ({
             ))}
           </Dropdown.Menu>
         </Dropdown>
-        {isAdmin && assignedBotRun && (
+        {(isAdmin || isTester) && assignedBotRun && (
           <ManageBotRunDialogWithButton
             testPlanRun={assignedBotRun}
             testPlanReportId={testPlanReport.id}
             runnableTestsLength={testPlanReport.runnableTestsLength}
             testers={testers}
+            me={me}
+            onChange={triggerUpdate}
+          />
+        )}
+        {(isAdmin || isTester) && !assignedBotRun && (
+          <StartBotRunButton
+            testPlanReport={testPlanReport}
             onChange={triggerUpdate}
           />
         )}

--- a/client/tests/e2e/TestQueue.e2e.test.js
+++ b/client/tests/e2e/TestQueue.e2e.test.js
@@ -635,4 +635,102 @@ describe('Test Queue tester traits when reports exist', () => {
       expect(postAssignValidTable).toBe(true);
     });
   });
+
+  it('starts a bot run and reassigns self after completion', async () => {
+    await getPage({ role: 'tester', url: '/test-queue' }, async page => {
+      const modalDialogSectionButtonSelector =
+        'button#disclosure-btn-modal-dialog-0';
+      const modalDialogTableSelector =
+        'table[aria-label="Reports for Modal Dialog Example V24.06.07 in draft phase"]';
+
+      await page.waitForSelector(modalDialogSectionButtonSelector);
+      await page.click(modalDialogSectionButtonSelector);
+      await page.waitForSelector(modalDialogTableSelector);
+
+      // Start NVDA bot run and confirm (use DOM click to avoid overlay issues)
+      await page.$eval(modalDialogTableSelector, el => {
+        const btn = Array.from(el.querySelectorAll('button')).find(b =>
+          b.innerText.includes('Start NVDA Bot Run')
+        );
+        if (btn) btn.click();
+      });
+      await page.waitForSelector('.modal-title ::-p-text(Start NVDA Bot Run)');
+      await page.waitForSelector('button[data-testid="confirm-start-bot-run"]');
+      await page.click('button[data-testid="confirm-start-bot-run"]');
+      await page.waitForNetworkIdle();
+      // Open Manage dialog and stop running to quickly mark job finished (CANCELLED counts as finished)
+      await page.$eval(modalDialogTableSelector, el => {
+        const btn = Array.from(el.querySelectorAll('button')).find(b =>
+          b.innerText.includes('Manage NVDA Bot Run')
+        );
+        if (btn) btn.click();
+      });
+      await page.waitForSelector('.modal-title ::-p-text(Manage NVDA Bot Run)');
+      await page.waitForSelector('button ::-p-text(Stop Running)');
+      await page.click('button ::-p-text(Stop Running)');
+      await page.waitForNetworkIdle();
+
+      // Re-open Manage dialog and assign self (enabled after job is finished)
+      await page.$eval(modalDialogTableSelector, el => {
+        const btn = Array.from(el.querySelectorAll('button')).find(b =>
+          b.innerText.includes('Manage NVDA Bot Run')
+        );
+        if (btn) btn.click();
+      });
+      await page.waitForSelector('.modal-dialog.manage-bot-run-dialog');
+      await page.waitForSelector(
+        '.modal-dialog.manage-bot-run-dialog button[data-testid="assign-self-bot-run"]',
+        { visible: true }
+      );
+      await page.waitForFunction(() => {
+        const btn = document.querySelector(
+          '.modal-dialog.manage-bot-run-dialog button[data-testid="assign-self-bot-run"]'
+        );
+        return !!btn && !btn.disabled;
+      });
+      // Was having issues with the button not being clickable, so using DOM click
+      await page.$eval(
+        '.modal-dialog.manage-bot-run-dialog button[data-testid="assign-self-bot-run"]',
+        el => {
+          el.scrollIntoView({ block: 'center', inline: 'center' });
+          el.click();
+        }
+      );
+      await page.waitForSelector('::-p-text(Unassign Yourself)');
+      await page.waitForSelector('a[role="button"] ::-p-text(Start Testing)');
+
+      // Validate that self-assignment is reflected in the table and Start Testing is enabled as a link
+      const postAssignChecks = await page.$eval(
+        modalDialogTableSelector,
+        el => {
+          const sanitizedText = text =>
+            text.replaceAll(String.fromCharCode(160), ' ').trim();
+
+          const cells = Array.from(el.querySelectorAll('td'));
+          const testersColumn = cells[2];
+          const actionsColumn = cells[4];
+
+          const testersText = sanitizedText(testersColumn.innerText);
+          const hasUnassignYourself = testersText.includes('Unassign Yourself');
+
+          const startTestingLink =
+            actionsColumn.querySelector('a[role="button"]');
+          const startTestingText = sanitizedText(
+            startTestingLink ? startTestingLink.innerText : ''
+          );
+
+          return {
+            hasUnassignYourself,
+            hasStartTestingLink: !!startTestingLink,
+            startTestingText
+          };
+        }
+      );
+      expect(postAssignChecks.hasUnassignYourself).toBe(true);
+      expect(postAssignChecks.hasStartTestingLink).toBe(true);
+      expect(postAssignChecks.startTestingText.includes('Start Testing')).toBe(
+        true
+      );
+    });
+  });
 });

--- a/client/tests/e2e/snapshots/saved/_test-queue.html
+++ b/client/tests/e2e/snapshots/saved/_test-queue.html
@@ -536,7 +536,21 @@
                                     >Open run as...
                                   </button>
                                 </div>
-                                <button
+                                <button type="button" class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start VoiceOver Bot Run</button
+                                ><button
                                   type="button"
                                   disabled=""
                                   class="btn btn-secondary">
@@ -760,7 +774,21 @@
                                     >Open run as...
                                   </button>
                                 </div>
-                                <button
+                                <button type="button" class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start VoiceOver Bot Run</button
+                                ><button
                                   type="button"
                                   disabled=""
                                   class="btn btn-secondary">
@@ -989,6 +1017,22 @@
                                     aria-hidden="true"
                                     focusable="false"
                                     data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start NVDA Bot Run</button
+                                ><button
+                                  type="button"
+                                  class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
                                     data-icon="square-check"
                                     class="svg-inline--fa fa-square-check"
                                     role="img"
@@ -1207,6 +1251,22 @@
                                     aria-hidden="true"
                                     focusable="false"
                                     data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start JAWS Bot Run</button
+                                ><button
+                                  type="button"
+                                  class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
                                     data-icon="square-check"
                                     class="svg-inline--fa fa-square-check"
                                     role="img"
@@ -1332,6 +1392,22 @@
                                   </button>
                                 </div>
                                 <button type="button" class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start NVDA Bot Run</button
+                                ><button
+                                  type="button"
+                                  class="btn btn-secondary">
                                   <svg
                                     aria-hidden="true"
                                     focusable="false"
@@ -1467,6 +1543,22 @@
                                     aria-hidden="true"
                                     focusable="false"
                                     data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start VoiceOver Bot Run</button
+                                ><button
+                                  type="button"
+                                  class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
                                     data-icon="square-check"
                                     class="svg-inline--fa fa-square-check"
                                     role="img"
@@ -1594,6 +1686,22 @@
                                   </button>
                                 </div>
                                 <button type="button" class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start VoiceOver Bot Run</button
+                                ><button
+                                  type="button"
+                                  class="btn btn-secondary">
                                   <svg
                                     aria-hidden="true"
                                     focusable="false"
@@ -1826,7 +1934,21 @@
                                     >Open run as...
                                   </button>
                                 </div>
-                                <button
+                                <button type="button" class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start NVDA Bot Run</button
+                                ><button
                                   type="button"
                                   disabled=""
                                   class="btn btn-secondary">
@@ -2060,7 +2182,21 @@
                                     >Open run as...
                                   </button>
                                 </div>
-                                <button
+                                <button type="button" class="btn btn-secondary">
+                                  <svg
+                                    aria-hidden="true"
+                                    focusable="false"
+                                    data-prefix="fas"
+                                    data-icon="file-import"
+                                    class="svg-inline--fa fa-file-import"
+                                    role="img"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 512 512">
+                                    <path
+                                      fill="currentColor"
+                                      d="M128 64c0-35.3 28.7-64 64-64H352V128c0 17.7 14.3 32 32 32H512V448c0 35.3-28.7 64-64 64H192c-35.3 0-64-28.7-64-64V336H302.1l-39 39c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l80-80c9.4-9.4 9.4-24.6 0-33.9l-80-80c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l39 39H128V64zm0 224v48H24c-13.3 0-24-10.7-24-24s10.7-24 24-24H128zM512 128H384V0L512 128z"></path></svg
+                                  >Start JAWS Bot Run</button
+                                ><button
                                   type="button"
                                   disabled=""
                                   class="btn btn-secondary">

--- a/client/utils/automation.js
+++ b/client/utils/automation.js
@@ -37,22 +37,27 @@ export const isSupportedByResponseCollector = ctx => {
     return false;
   }
 
-  // If there are version requirements, check if they are supported by automation
-  if (ctx.minimumAtVersion || ctx.exactAtVersion) {
-    return atVersionRequirementsSupportedByAutomation(ctx);
-  }
+  // Ignore report version requirements for automation eligibility; always allow if AT+browser supported
+  // This codeblock is left in for reference since this design is still in motion
+  // Please remove after automation at version selection stabilizes
+  // if (ctx.minimumAtVersion || ctx.exactAtVersion) {
+  //   return atVersionRequirementsSupportedByAutomation(ctx);
+  // }
+
   return true;
 };
 
 /**
  * Checks if the version requirements are supported by automation
+ * This is no longer used in the codebase but is kept in case a future
+ * design decision requires it.
  * @param {object} ctx
  * @param {object} ctx.at
  * @param {object} ctx.minimumAtVersion
  * @param {object} ctx.exactAtVersion
  * @returns {boolean}
  */
-const atVersionRequirementsSupportedByAutomation = ({
+export const atVersionRequirementsSupportedByAutomation = ({
   at,
   minimumAtVersion,
   exactAtVersion

--- a/server/models/services/CollectionJobService.js
+++ b/server/models/services/CollectionJobService.js
@@ -44,6 +44,7 @@ const getGraphQLContext = require('../../graphql-context');
 const { getBotUserByAtId } = require('./UserService');
 const {
   getAtVersionWithRequirements,
+  getLatestAutomationSupportedAtVersion,
   getRerunnableTestPlanReportsForVersion
 } = require('./AtVersionService');
 const { createUpdateEvent } = require('./UpdateEventService');
@@ -502,10 +503,8 @@ const retryCanceledCollections = async ({ collectionJob }, { transaction }) => {
     transaction
   });
 
-  const atVersion = await getAtVersionWithRequirements(
+  const atVersion = await getLatestAutomationSupportedAtVersion(
     testPlanReport.at.id,
-    testPlanReport.exactAtVersion,
-    testPlanReport.minimumAtVersion,
     transaction
   );
 
@@ -561,10 +560,8 @@ const scheduleCollectionJob = async (
   }
 
   if (!atVersion) {
-    atVersion = await getAtVersionWithRequirements(
+    atVersion = await getLatestAutomationSupportedAtVersion(
       report.at.id,
-      report.exactAtVersion,
-      report.minimumAtVersion,
       transaction
     );
   }
@@ -698,10 +695,8 @@ const restartCollectionJob = async ({ id }, { transaction }) => {
     transaction
   });
 
-  const atVersion = await getAtVersionWithRequirements(
+  const atVersion = await getLatestAutomationSupportedAtVersion(
     testPlanReport.at.id,
-    testPlanReport.exactAtVersion,
-    testPlanReport.minimumAtVersion,
     transaction
   );
 

--- a/server/resolvers/scheduleCollectionJobResolver.js
+++ b/server/resolvers/scheduleCollectionJobResolver.js
@@ -10,7 +10,9 @@ const scheduleCollectionJobResolver = async (
 ) => {
   const { user, transaction } = context;
 
-  if (!user?.roles.find(role => role.name === 'ADMIN')) {
+  if (
+    !user?.roles.find(role => role.name === 'ADMIN' || role.name === 'TESTER')
+  ) {
     throw new AuthenticationError();
   }
 


### PR DESCRIPTION
see #1513 

This PR expands permissions for initiating automated runs to the tester user role. Some UI updates outlined were required to support this; those were outlined in the linked issue.

A new end-to-end test was added to test this behavior.

Note that I left some of the code related to selecting the automation-supporting AT version based on report requirements in place despite no longer being used since this is a domain with ongoing design changes. 