### PR TITLE
fix: different calculation for rerun jobs

### DIFF
--- a/client/components/TestQueueRunCompletionStatus/index.js
+++ b/client/components/TestQueueRunCompletionStatus/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faRobot } from '@fortawesome/free-solid-svg-icons';
@@ -43,21 +43,38 @@ const TestQueueRunCompletionStatus = ({
   ]);
 
   const isScenarioResultCompleted = scenarioResult =>
+    typeof scenarioResult.output === 'string' && scenarioResult.output !== '';
+
+  const isScenarioResultCompletedRerun = scenarioResult =>
+    isScenarioResultCompleted(scenarioResult) &&
     scenarioResult.negativeSideEffects !== null &&
     scenarioResult.assertionResults.every(
       assertionResult => assertionResult.passed !== null
     );
 
   const getNumCompletedOutputs = result => {
+    const isRerun = !!testPlanReport.isRerun;
     return result.scenarioResults.reduce((acc, scenario) => {
-      return acc + (isScenarioResultCompleted(scenario) ? 1 : 0);
+      return (
+        acc +
+        (isRerun
+          ? isScenarioResultCompletedRerun(scenario)
+          : isScenarioResultCompleted(scenario)
+          ? 1
+          : 0)
+      );
     }, 0);
   };
 
-  // Calculate completed responses (number of commands with outputs && complete verdicts)
-  const completedResponses = testPlanRun?.testResults?.reduce(
-    (acc, result) => acc + getNumCompletedOutputs(result),
-    0
+  // Calculate completed responses
+  // Different calculation used for reruns
+  const completedResponses = useMemo(
+    () =>
+      testPlanRun?.testResults?.reduce(
+        (acc, result) => acc + getNumCompletedOutputs(result),
+        0
+      ),
+    [testPlanRun?.testResults]
   );
 
   // Scenarios, even on a runnable test, may have different ATs than the report
@@ -68,9 +85,13 @@ const TestQueueRunCompletionStatus = ({
       0
     );
 
-  const totalResponses = testPlanReport.runnableTests.reduce(
-    (acc, test) => acc + getNumScenariosTest(test),
-    0
+  const totalResponses = useMemo(
+    () =>
+      testPlanReport.runnableTests.reduce(
+        (acc, test) => acc + getNumScenariosTest(test),
+        0
+      ),
+    [testPlanReport.runnableTests]
   );
 
   let info;


### PR DESCRIPTION
see title

Now jobs that were not started as "rerun" jobs will count "responses" as complete if they have output. 