### PR TITLE
feat: Add Key Metrics banner to homepage

### DIFF
--- a/client/components/Home/Home.jsx
+++ b/client/components/Home/Home.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import { Container } from 'react-bootstrap';
+import KeyMetricsBanner from '../KeyMetricsBanner';
 import clsx from 'clsx';
 import iconJoinCommunity from '../../assets/join-community.jpg';
 import iconWriteTests from '../../assets/write-tests.jpg';
@@ -20,6 +21,7 @@ const Home = () => {
       <Helmet>
         <title>Home | ARIA-AT</title>
       </Helmet>
+      <KeyMetricsBanner />
       <section className={styles.heroSection}>
         <h1>Enabling Interoperability for Assistive Technology Users</h1>
         <div className={styles.heroCopyAndVideo}>

--- a/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
+++ b/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
@@ -2,14 +2,14 @@ import React, { useState } from 'react';
 import { Alert } from 'react-bootstrap';
 
 const KeyMetricsBanner = () => {
-  const [showBanner, setShowBanner] = useState(true);
+  //   const [showBanner, setShowBanner] = useState(true);
 
   return (
     <Alert
       variant="primary"
-      show={showBanner}
-      onClose={() => setShowBanner(false)}
-      dismissible
+      //   show={showBanner}
+      //   onClose={() => setShowBanner(false)}
+      //   dismissible
     >
       As of <strong>Sep 4, 2025</strong>, <strong>20,455</strong> interop
       verdicts for <strong>799</strong> AT commands enabled by{' '}

--- a/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
+++ b/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
@@ -1,20 +1,34 @@
 import React, { useState } from 'react';
 import { Alert } from 'react-bootstrap';
+import { KEY_METRICS_QUERY } from './queries';
+import { useQuery } from '@apollo/client';
 
 const KeyMetricsBanner = () => {
-  //   const [showBanner, setShowBanner] = useState(true);
-
+  const { data: keyMetricsQuery } = useQuery(KEY_METRICS_QUERY);
+  const {
+    date,
+    verdictsCount,
+    commandsCount,
+    contributorsCount,
+    verdictsLast90Count
+  } = keyMetricsQuery?.keyMetrics ?? {};
   return (
     <Alert
       variant="primary"
-      //   show={showBanner}
+      show={keyMetricsQuery}
       //   onClose={() => setShowBanner(false)}
       //   dismissible
     >
-      As of <strong>Sep 4, 2025</strong>, <strong>20,455</strong> interop
-      verdicts for <strong>799</strong> AT commands enabled by{' '}
-      <strong>37</strong> contributors, <strong>1113</strong> verdicts in the
-      last 90 days.
+      {keyMetricsQuery && (
+        <>
+          As of <strong>{new Date(date).toDateString()}</strong>,{' '}
+          <strong>{verdictsCount.toLocaleString()}</strong> interop verdicts for{' '}
+          <strong>{commandsCount.toLocaleString()}</strong> AT commands enabled
+          by <strong>{contributorsCount.toLocaleString()}</strong> contributors,{' '}
+          <strong>{verdictsLast90Count.toLocaleString()}</strong> verdicts in
+          the last 90 days.
+        </>
+      )}
     </Alert>
   );
 };

--- a/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
+++ b/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import { Alert } from 'react-bootstrap';
+
+const KeyMetricsBanner = () => {
+  const [showBanner, setShowBanner] = useState(true);
+
+  return (
+    <Alert
+      variant="primary"
+      show={showBanner}
+      onClose={() => setShowBanner(false)}
+      dismissible
+    >
+      As of <strong>Sep 4, 2025</strong>, <strong>20,455</strong> interop
+      verdicts for <strong>799</strong> AT commands enabled by{' '}
+      <strong>37</strong> contributors, <strong>1113</strong> verdicts in the
+      last 90 days.
+    </Alert>
+  );
+};
+
+export default KeyMetricsBanner;

--- a/client/components/KeyMetricsBanner/index.jsx
+++ b/client/components/KeyMetricsBanner/index.jsx
@@ -1,0 +1,3 @@
+import KeyMetricsBanner from './KeyMetricsBanner';
+
+export default KeyMetricsBanner;

--- a/client/components/KeyMetricsBanner/queries.jsx
+++ b/client/components/KeyMetricsBanner/queries.jsx
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const KEY_METRICS_QUERY = gql`
+  query KeyMetricsQuery {
+    keyMetrics {
+      date
+      verdictsCount
+      commandsCount
+      contributorsCount
+      verdictsLast90Count
+    }
+  }
+`;

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1499,6 +1499,10 @@ const graphqlSchema = gql`
     Get a particular update event by ID
     """
     updateEvent(id: ID!): UpdateEvent
+    """
+    Get key metrics
+    """
+    keyMetrics: KeyMetrics!
   }
 
   # Mutation-specific types below
@@ -1806,6 +1810,14 @@ const graphqlSchema = gql`
   type CreateCollectionJobsFromPreviousVersionResponse {
     collectionJobs: [CollectionJob!]!
     message: String!
+  }
+
+  type KeyMetrics {
+    date: Timestamp!
+    verdictsCount: Int!
+    commandsCount: Int!
+    contributorsCount: Int!
+    verdictsLast90Count: Int!
   }
 `;
 

--- a/server/resolvers/index.js
+++ b/server/resolvers/index.js
@@ -35,6 +35,7 @@ const deleteCollectionJob = require('./deleteCollectionJobResolver');
 const scheduleCollectionJob = require('./scheduleCollectionJobResolver');
 const restartCollectionJob = require('./restartCollectionJobResolver');
 const collectionJobByTestPlanRunId = require('./collectionJobByTestPlanRunIdResolver');
+const keyMetrics = require('./keyMetricsResolver');
 const User = require('./User');
 const AtOperations = require('./AtOperations');
 const AtVersionOperations = require('./AtVersionOperations');
@@ -62,6 +63,7 @@ const resolvers = {
     users,
     ats,
     browsers,
+    keyMetrics,
     testPlan,
     testPlans,
     testPlanVersion,

--- a/server/resolvers/keyMetricsResolver.js
+++ b/server/resolvers/keyMetricsResolver.js
@@ -1,0 +1,11 @@
+const keyMetricsResolver = () => {
+  return {
+    date: Date.now(),
+    verdictsCount: 20455,
+    commandsCount: 699,
+    contributorsCount: 39,
+    verdictsLast90Count: 1113
+  };
+};
+
+module.exports = keyMetricsResolver;

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -196,6 +196,14 @@ describe('graphql', () => {
       gql`
         query {
           __typename
+          keyMetrics {
+            __typename
+            date
+            verdictsCount
+            commandsCount
+            contributorsCount
+            verdictsLast90Count
+          }
           browsers {
             __typename
             id


### PR DESCRIPTION
Haven't gotten very far with the SQL query itself yet, but this adds a key metrics banner to the homepage:

<img width="820" height="173" alt="screenshot example of key metrics banner" src="https://github.com/user-attachments/assets/d356f34e-1286-4bcd-98c4-1e9d7afee28c" />
