### PR TITLE
fix: `isRerun` exclusively assigned by UI

### DIFF
--- a/client/components/AddTestToQueueWithConfirmation/queries.js
+++ b/client/components/AddTestToQueueWithConfirmation/queries.js
@@ -1,8 +1,11 @@
 import { gql } from '@apollo/client';
 
 export const SCHEDULE_COLLECTION_JOB_MUTATION = gql`
-  mutation ScheduleCollectionJob($testPlanReportId: ID!) {
-    scheduleCollectionJob(testPlanReportId: $testPlanReportId) {
+  mutation ScheduleCollectionJob($testPlanReportId: ID!, $isRerun: Boolean) {
+    scheduleCollectionJob(
+      testPlanReportId: $testPlanReportId
+      isRerun: $isRerun
+    ) {
       id
       status
     }

--- a/client/components/TestQueue/index.jsx
+++ b/client/components/TestQueue/index.jsx
@@ -117,10 +117,11 @@ const TestQueue = () => {
     return { testPlans, testers };
   }, [data]);
 
-  const shouldShowReport = (testPlanReport, filter) => {
-    const isRerun = !!testPlanReport.isRerun;
+  const reportHasRunsMatchingFilter = (testPlanReport, filter) => {
     if (filter === FILTER_KEYS.ALL) return true;
-    return filter === FILTER_KEYS.AUTOMATED ? isRerun : !isRerun;
+    const anyRerun = testPlanReport.draftTestPlanRuns?.some(r => !!r.isRerun);
+    const anyManual = testPlanReport.draftTestPlanRuns?.some(r => !r.isRerun);
+    return filter === FILTER_KEYS.AUTOMATED ? anyRerun : anyManual;
   };
 
   const filterOptions = useMemo(() => {
@@ -132,10 +133,12 @@ const TestQueue = () => {
       testPlan.testPlanVersions.forEach(testPlanVersion => {
         testPlanVersion.testPlanReports.forEach(testPlanReport => {
           allCount++;
-          if (shouldShowReport(testPlanReport, FILTER_KEYS.MANUAL)) {
+          if (reportHasRunsMatchingFilter(testPlanReport, FILTER_KEYS.MANUAL)) {
             manualCount++;
           }
-          if (shouldShowReport(testPlanReport, FILTER_KEYS.AUTOMATED)) {
+          if (
+            reportHasRunsMatchingFilter(testPlanReport, FILTER_KEYS.AUTOMATED)
+          ) {
             automatedCount++;
           }
         });
@@ -159,7 +162,8 @@ const TestQueue = () => {
         const filteredVersions = testPlan.testPlanVersions
           .map(testPlanVersion => {
             const filteredReports = testPlanVersion.testPlanReports.filter(
-              testPlanReport => shouldShowReport(testPlanReport, activeFilter)
+              testPlanReport =>
+                reportHasRunsMatchingFilter(testPlanReport, activeFilter)
             );
 
             return {

--- a/client/components/TestQueueRunCompletionStatus/index.js
+++ b/client/components/TestQueueRunCompletionStatus/index.js
@@ -53,7 +53,7 @@ const TestQueueRunCompletionStatus = ({
     );
 
   const getNumCompletedOutputs = result => {
-    const isRerun = !!testPlanReport.isRerun;
+    const isRerun = !!testPlanRun.isRerun;
     return result.scenarioResults.reduce((acc, scenario) => {
       return (
         acc +

--- a/client/components/common/fragments/TestPlanRun.js
+++ b/client/components/common/fragments/TestPlanRun.js
@@ -5,6 +5,7 @@ const TEST_PLAN_RUN_FIELDS = gql`
     __typename
     id
     initiatedByAutomation
+    isRerun
     tester {
       id
       username

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1019,6 +1019,10 @@ const graphqlSchema = gql`
     """
     initiatedByAutomation: Boolean!
     """
+    Whether this run was explicitly started by the rerun UI
+    """
+    isRerun: Boolean!
+    """
     The CollectionJob related to this testPlanRun
     """
     collectionJob: CollectionJob
@@ -1772,6 +1776,7 @@ const graphqlSchema = gql`
       The CollectionJob to schedule.
       """
       testPlanReportId: ID!
+      isRerun: Boolean
     ): CollectionJob!
     """
     Update a CollectionJob

--- a/server/migrations/20250930120000-add-isrerun-to-testplanrun.js
+++ b/server/migrations/20250930120000-add-isrerun-to-testplanrun.js
@@ -11,6 +11,20 @@ module.exports = {
         defaultValue: false
       });
     }
+
+    // Backfill: mark runs as rerun if any scenarioResult has a non-null match.type
+    await queryInterface.sequelize.query(
+      `
+        UPDATE "TestPlanRun" tpr
+        SET "isRerun" = TRUE
+        WHERE EXISTS (
+          SELECT 1
+          FROM jsonb_array_elements(COALESCE(tpr."testResults", '[]'::jsonb)) AS tr
+          CROSS JOIN jsonb_array_elements(COALESCE(tr->'scenarioResults', '[]'::jsonb)) AS sr
+          WHERE (sr->'match'->>'type') IS NOT NULL AND (sr->'match'->>'type') <> ''
+        );
+      `
+    );
   },
 
   async down(queryInterface) {

--- a/server/migrations/20250930120000-add-isrerun-to-testplanrun.js
+++ b/server/migrations/20250930120000-add-isrerun-to-testplanrun.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('TestPlanRun');
+    if (!table.isRerun) {
+      await queryInterface.addColumn('TestPlanRun', 'isRerun', {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: false
+      });
+    }
+  },
+
+  async down(queryInterface) {
+    try {
+      await queryInterface.removeColumn('TestPlanRun', 'isRerun');
+    } catch (e) {
+      console.error(e);
+    }
+  }
+};

--- a/server/models/TestPlanRun.js
+++ b/server/models/TestPlanRun.js
@@ -22,6 +22,11 @@ module.exports = function (sequelize, DataTypes) {
         type: DataTypes.BOOLEAN,
         allowNull: true,
         defaultValue: false
+      },
+      isRerun: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: false
       }
     },
     {

--- a/server/models/services/CollectionJobService.js
+++ b/server/models/services/CollectionJobService.js
@@ -204,11 +204,13 @@ const collectionJobTestStatusAssociation =
  * @param {number} options.values.testerUserId - ID of the Tester to which the CollectionJob should be assigned
  * @param {object} options.values.testPlanReportId - ID of the TestPlan with which the CollectionJob should be associated
  * @param {object} [options.values.testPlanRun] - TestPlan with wich the CollectionJob should be associated (if not provided, a new TestPlan will be created)
+ * @param {boolean} [options.values.isRerun] - Whether the associated TestPlanRun is a rerun
  * @param {string[]} options.collectionJobAttributes - CollectionJob attributes to be returned in the result
  * @param {string[]} options.collectionJobTestStatusAttributes - CollectionJobTestStatus attributes to be returned in the result
  * @param {string[]} options.testPlanReportAttributes - TestPlanReport attributes to be returned in the result
+ * @param {string[]} options.testPlanRunAttributes - TestPlanRun attributes to be returned in the result
  * @param {string[]} options.testPlanVersionAttributes - TestPlanVersion attributes to be returned in the result
- * @param {string[]} options.testPlanAttributes - TestPlanVersion attributes to be returned in the result
+ * @param {string[]} options.testPlanAttributes - TestPlan attributes to be returned in the result
  * @param {string[]} options.atAttributes - AT attributes to be returned in the result
  * @param {string[]} options.browserAttributes - Browser attributes to be returned in the result
  * @param {string[]} options.userAttributes - User attributes to be returned in the result
@@ -220,7 +222,8 @@ const createCollectionJob = async ({
     status = COLLECTION_JOB_STATUS.QUEUED,
     testerUserId,
     testPlanRun,
-    testPlanReportId
+    testPlanReportId,
+    isRerun = false
   },
   collectionJobAttributes = COLLECTION_JOB_ATTRIBUTES,
   collectionJobTestStatusAttributes = COLLECTION_JOB_TEST_STATUS_ATTRIBUTES,
@@ -238,7 +241,8 @@ const createCollectionJob = async ({
       values: {
         testerUserId,
         testPlanReportId: testPlanReportId,
-        isAutomated: true
+        isAutomated: true,
+        isRerun
       },
       transaction
     });
@@ -291,6 +295,7 @@ const createCollectionJob = async ({
  * @param {string[]} options.collectionJobAttributes - CollectionJob attributes to be returned in the result
  * @param {string[]} options.collectionJobTestStatusAttributes - CollectionJobTestStatus attributes to be returned in the result
  * @param {string[]} options.testPlanReportAttributes - TestPlanReport attributes to be returned in the result
+ * @param {string[]} options.testPlanRunAttributes - TestPlanRun attributes to be returned in the result
  * @param {string[]} options.testPlanVersionAttributes - TestPlanVersion attributes to be returned in the result
  * @param {string[]} options.testPlanAttributes - TestPlanVersion attributes to be returned in the result
  * @param {string[]} options.atAttributes - AT attributes to be returned in the result
@@ -434,6 +439,7 @@ const triggerWorkflow = async (job, testIds, atVersion, { transaction }) => {
  * @param {string[]} options.collectionJobAttributes  - CollectionJob attributes to be returned in the result
  * @param {string[]} options.collectionJobTestStatusAttributes  - CollectionJobTestStatus attributes to be returned in the result
  * @param {string[]} options.testPlanReportAttributes - TestPlanReport attributes to be returned in the result
+ * @param {string[]} options.testPlanRunAttributes - TestPlanRun attributes to be returned in the result
  * @param {string[]} options.testPlanVersionAttributes - TestPlanVersion attributes to be returned in the result
  * @param {string[]} options.testPlanAttributes - TestPlanVersion attributes to be returned in the result
  * @param {string[]} options.atAttributes - AT attributes to be returned in the result
@@ -536,12 +542,13 @@ const retryCanceledCollections = async ({ collectionJob }, { transaction }) => {
  * @param {string} input.testPlanReportId id of test plan report to use for scheduling
  * @param {Array<string>} [input.testIds] optional: ids of tests to run
  * @param {object} [input.atVersion] optional: AT version to use for the job
+ * @param {boolean} [input.isRerun] optional: mark associated TestPlanRun as rerun
  * @param {object} options
  * @param {*} options.transaction - Sequelize transaction
  * @returns {Promise<*>}
  */
 const scheduleCollectionJob = async (
-  { testPlanReportId, testIds = null, atVersion },
+  { testPlanReportId, testIds = null, atVersion, isRerun = false },
   { transaction }
 ) => {
   const context = getGraphQLContext({ req: { transaction } });
@@ -600,7 +607,8 @@ const scheduleCollectionJob = async (
     values: {
       status: COLLECTION_JOB_STATUS.QUEUED,
       testerUserId,
-      testPlanReportId
+      testPlanReportId,
+      isRerun
     },
     transaction
   });
@@ -808,7 +816,7 @@ const createCollectionJobsFromPreviousAtVersion = async ({
           if (!atVersion) return;
 
           const job = await scheduleCollectionJob(
-            { testPlanReportId: newReport.id, atVersion },
+            { testPlanReportId: newReport.id, atVersion, isRerun: true },
             { transaction }
           );
 

--- a/server/models/services/TestPlanRunService.js
+++ b/server/models/services/TestPlanRunService.js
@@ -233,7 +233,8 @@ const createTestPlanRun = async ({
     testerUserId,
     testPlanReportId,
     testResults = [],
-    isAutomated = false
+    isAutomated = false,
+    isRerun = false
   },
   testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
   nestedTestPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
@@ -270,7 +271,8 @@ const createTestPlanRun = async ({
       testerUserId,
       testPlanReportId,
       testResults,
-      initiatedByAutomation: isAutomated
+      initiatedByAutomation: isAutomated,
+      isRerun
     },
     transaction
   });
@@ -313,7 +315,7 @@ const createTestPlanRun = async ({
  */
 const updateTestPlanRunById = async ({
   id,
-  values: { testerUserId, testResults, isPrimary },
+  values: { testerUserId, testResults, isPrimary, isRerun },
   testPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
   nestedTestPlanRunAttributes = TEST_PLAN_RUN_ATTRIBUTES,
   testPlanReportAttributes = TEST_PLAN_REPORT_ATTRIBUTES,
@@ -326,7 +328,7 @@ const updateTestPlanRunById = async ({
 }) => {
   await ModelService.update(TestPlanRun, {
     where: { id },
-    values: { testResults, testerUserId, isPrimary },
+    values: { testResults, testerUserId, isPrimary, isRerun },
     transaction
   });
   return ModelService.getById(TestPlanRun, {

--- a/server/resolvers/TestPlanReport/isRerunResolver.js
+++ b/server/resolvers/TestPlanReport/isRerunResolver.js
@@ -7,41 +7,22 @@ const isRerunResolver = async (
   args, // eslint-disable-line no-unused-vars
   context // eslint-disable-line no-unused-vars
 ) => {
-  // Simple per-request memoization
-  if (context) {
-    if (!context._isRerunCache) context._isRerunCache = new Map();
-    const cached = context._isRerunCache.get(testPlanReport.id);
-    if (typeof cached === 'boolean') return cached;
-  }
-  const hasMatchInRuns = report =>
+  const hasRerunInRuns = report =>
     Array.isArray(report.testPlanRuns) &&
-    report.testPlanRuns.some(
-      run =>
-        Array.isArray(run.testResults) &&
-        run.testResults.some(
-          tr =>
-            Array.isArray(tr.scenarioResults) &&
-            tr.scenarioResults.some(sr => sr?.match && sr.match?.type)
-        )
-    );
+    report.testPlanRuns.some(run => !!run.isRerun);
 
-  // If testPlanRuns with nested results were already populated, use them
-  if (hasMatchInRuns(testPlanReport)) {
-    if (context && context._isRerunCache)
-      context._isRerunCache.set(testPlanReport.id, true);
+  // If testPlanRuns were already populated with runs, use them
+  if (hasRerunInRuns(testPlanReport)) {
     return true;
   }
 
-  // Otherwise, load with nested results to check for matches
+  // Otherwise, load report with nested runs to check for isRerun
   const { transaction } = context || {};
   const loaded = await getTestPlanReportById({
     id: testPlanReport.id,
     transaction
   });
-  const result = hasMatchInRuns(loaded);
-  if (context && context._isRerunCache)
-    context._isRerunCache.set(testPlanReport.id, result);
-  return result;
+  return hasRerunInRuns(loaded);
 };
 
 module.exports = isRerunResolver;

--- a/server/resolvers/scheduleCollectionJobResolver.js
+++ b/server/resolvers/scheduleCollectionJobResolver.js
@@ -5,7 +5,7 @@ const {
 
 const scheduleCollectionJobResolver = async (
   _,
-  { testPlanReportId },
+  { testPlanReportId, isRerun = false },
   context
 ) => {
   const { user, transaction } = context;
@@ -16,7 +16,7 @@ const scheduleCollectionJobResolver = async (
     throw new AuthenticationError();
   }
 
-  return scheduleCollectionJob({ testPlanReportId }, { transaction });
+  return scheduleCollectionJob({ testPlanReportId, isRerun }, { transaction });
 };
 
 module.exports = scheduleCollectionJobResolver;


### PR DESCRIPTION
Previous behavior derived the `isRerun` state for a report by determining if the conditions of a "rerun" were met (ie a finalized historical report exists for the same at + browser + test plan combo using a previous version of the at). 

This PR changes that behavior so that `isRerun` is a designation reserved for runs starting through the report rerun UI. 

Notes:
- Reports that have rerun reports and manual reports will appear in both tabs with all runs underneath. This is because a column under a test plan disclosure on the test queue represents a report in its entirety. Dividing these reports by run risks conveying incomplete information about the report in contexts where report-level actions can occur.