### PR TITLE
fix: remove alert role from key metrics banner

### DIFF
--- a/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
+++ b/client/components/KeyMetricsBanner/KeyMetricsBanner.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Alert } from 'react-bootstrap';
 import { KEY_METRICS_QUERY } from './queries';
 import { useQuery } from '@apollo/client';
 import styles from './KeyMetricsBanner.module.css';
@@ -15,10 +14,10 @@ const KeyMetricsBanner = () => {
     testsCount
   } = keyMetricsQuery?.keyMetrics ?? {};
   return (
-    <Alert
-      className={styles.keyMetrics}
-      variant="primary"
-      show={Boolean(keyMetricsQuery)}
+    <div
+      className={`${styles.keyMetrics} alert alert-primary fade ${
+        keyMetricsQuery ? 'show' : ''
+      }`}
     >
       {keyMetricsQuery && (
         <>
@@ -35,7 +34,7 @@ const KeyMetricsBanner = () => {
           </p>
         </>
       )}
-    </Alert>
+    </div>
   );
 };
 

--- a/client/tests/e2e/snapshots/saved/_.html
+++ b/client/tests/e2e/snapshots/saved/_.html
@@ -84,7 +84,7 @@
       </div>
       <div class="container-fluid">
         <main id="main" tabindex="-1" class="home-page container container">
-          <div role="alert" class="fade keyMetrics alert alert-primary show">
+          <div class="keyMetrics alert alert-primary fade show">
             <h2>Today's Testing Snapshot:</h2>
             <p data-test-id="keyMetrics">
               As of <strong>Sep 25 2025</strong>,

--- a/client/tests/e2e/snapshots/saved/_reports.html
+++ b/client/tests/e2e/snapshots/saved/_reports.html
@@ -87,7 +87,7 @@
           id="main"
           tabindex="-1"
           class="fh-container reportsContainer container">
-          <div role="alert" class="fade keyMetrics alert alert-primary show">
+          <div class="keyMetrics alert alert-primary fade show">
             <h2>Today's Testing Snapshot:</h2>
             <p data-test-id="keyMetrics">
               As of <strong>Sep 25 2025</strong>,


### PR DESCRIPTION
As reqested in https://github.com/w3c/aria-at-app/issues/1525#issuecomment-3439155435 - removes the `role="alert"` from this element to make it not an aria-live region