### PR TITLE
fix: browser correction for edge support on automation

### DIFF
--- a/server/models/services/BrowserService.js
+++ b/server/models/services/BrowserService.js
@@ -92,7 +92,11 @@ const getBrowsers = async ({
 }) => {
   // search and filtering options
   const searchQuery = search ? `%${search}%` : '';
-  if (searchQuery) where = { ...where, name: { [Op.iLike]: searchQuery } };
+  if (searchQuery)
+    where = {
+      ...where,
+      [Op.or]: [{ key: search }, { name: { [Op.iLike]: searchQuery } }]
+    };
 
   return ModelService.get(Browser, {
     where,

--- a/server/tests/models/services/BrowserService.test.js
+++ b/server/tests/models/services/BrowserService.test.js
@@ -228,6 +228,60 @@ describe('BrowserModel Data Checks', () => {
     });
   });
 
+  it('should return correct browser for chrome', async () => {
+    await dbCleaner(async () => {
+      // A1
+      const search = 'chrome';
+
+      // A2
+      const result = await BrowserService.getBrowsers({
+        search,
+        transaction: false
+      });
+
+      // A3
+      expect(result).toBeInstanceOf(Array);
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            name: 'Chrome',
+            browserVersions: expect.any(Array),
+            ats: expect.any(Array)
+          })
+        ])
+      );
+    });
+  });
+
+  it('should return correct browser for MicrosoftEdge', async () => {
+    await dbCleaner(async () => {
+      // A1
+      const search = 'MicrosoftEdge';
+
+      // A2
+      const result = await BrowserService.getBrowsers({
+        search,
+        transaction: false
+      });
+
+      // A3
+      expect(result).toBeInstanceOf(Array);
+      expect(result.length).toEqual(1);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: expect.any(Number),
+            name: 'Microsoft Edge',
+            browserVersions: expect.any(Array),
+            ats: expect.any(Array)
+          })
+        ])
+      );
+    });
+  });
+
   it('should return collection of browsers with paginated structure', async () => {
     // A1
     const result = await BrowserService.getBrowsers({


### PR DESCRIPTION
It wasn't finding `MicrosoftEdge` browser with the old query.

This resulted in "empty" result values in the report.

This fixes the problem on my local:
<img width="662" height="204" alt="image" src="https://github.com/user-attachments/assets/5cbeb752-5558-46cc-bca9-1bcb5d742445" />
