### PR TITLE
chore(migrations): avoid using `vendors.txt` to dictate Vendor id in seeder

### DIFF
--- a/server/seeders/20240903165406-add-vendors.js
+++ b/server/seeders/20240903165406-add-vendors.js
@@ -7,43 +7,65 @@ module.exports = {
   async up(queryInterface, Sequelize) {
     const vendorLines = await getUsersFromFile('vendors.txt');
 
+    const vendorToUsers = new Map();
     for (const line of vendorLines) {
       const [username, companyName] = line.split('|');
       if (username && companyName) {
-        // Create vendor if it doesn't exist
-        const [vendor] = await queryInterface.sequelize.query(
-          `INSERT INTO "Vendor" (name, "createdAt", "updatedAt") 
-           VALUES (:name, NOW(), NOW()) 
-           ON CONFLICT (name) DO UPDATE SET name = :name 
-           RETURNING id`,
-          {
-            replacements: { name: companyName },
-            type: Sequelize.QueryTypes.INSERT
-          }
-        );
+        if (!vendorToUsers.has(companyName)) {
+          vendorToUsers.set(companyName, []);
+        }
+        vendorToUsers.get(companyName).push(username);
+      }
+    }
 
-        // Associate user with vendor if user exists
-        await queryInterface.sequelize.query(
-          `UPDATE "User" SET "vendorId" = :vendorId 
+    // Create vendor if it doesn't exist
+    for (const [companyName, companyInfo] of Object.entries(
+      VENDOR_NAME_TO_AT_MAPPING
+    )) {
+      const [vendor] = await queryInterface.sequelize.query(
+        `INSERT INTO "Vendor" (id, name, "createdAt", "updatedAt")
+         VALUES (:id, :name, NOW(), NOW())
+         ON CONFLICT (name) DO UPDATE SET name = :name
+         RETURNING id`,
+        {
+          replacements: { id: companyInfo.id, name: companyName },
+          type: Sequelize.QueryTypes.INSERT
+        }
+      );
+
+      // Update sequence to ensure nextval is curr + 1
+      await queryInterface.sequelize.query(
+        `SELECT setval(pg_get_serial_sequence('"Vendor"', 'id'), :id, false)`,
+        {
+          replacements: { id: vendor[0].id },
+          type: Sequelize.QueryTypes.SELECT
+        }
+      );
+
+      // Associate user with vendor if user exists
+      const usernames = vendorToUsers.get(companyName);
+      if (usernames) {
+        for (const username of usernames) {
+          await queryInterface.sequelize.query(
+            `UPDATE "User" SET "vendorId" = :vendorId
            WHERE username = :username`,
+            {
+              replacements: { vendorId: vendor[0].id, username },
+              type: Sequelize.QueryTypes.UPDATE
+            }
+          );
+        }
+      }
+
+      for (const atName of companyInfo.ats) {
+        await queryInterface.sequelize.query(
+          `UPDATE "At" SET "vendorId" = :vendorId
+           WHERE name = :atName`,
           {
-            replacements: { vendorId: vendor[0].id, username },
+            replacements: { vendorId: vendor[0].id, atName },
             type: Sequelize.QueryTypes.UPDATE
           }
         );
-
-        if (VENDOR_NAME_TO_AT_MAPPING[companyName]) {
-          for (const atName of VENDOR_NAME_TO_AT_MAPPING[companyName]) {
-            await queryInterface.sequelize.query(
-              `UPDATE "At" SET "vendorId" = :vendorId 
-               WHERE name = :atName`,
-              {
-                replacements: { vendorId: vendor[0].id, atName },
-                type: Sequelize.QueryTypes.UPDATE
-              }
-            );
-          }
-        }
       }
     }
   },

--- a/server/seeders/20241030144705-addNvAccessVendor.js
+++ b/server/seeders/20241030144705-addNvAccessVendor.js
@@ -4,10 +4,11 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
     return queryInterface.sequelize.transaction(async transaction => {
-      // Create NVDA vendor and retrieve id to use with 'At' table
+      // Insert vendor if it doesn't exist, or get existing id
       const [vendor] = await queryInterface.sequelize.query(
         `insert into "Vendor" (name, "createdAt", "updatedAt")
          values ('nvAccess', now(), now())
+         on conflict (name) do update set name = excluded.name
          returning id`,
         {
           type: Sequelize.QueryTypes.INSERT,

--- a/server/util/constants.js
+++ b/server/util/constants.js
@@ -15,9 +15,18 @@ const AT_VERSIONS_SUPPORTED_BY_COLLECTION_JOBS = {
 };
 
 const VENDOR_NAME_TO_AT_MAPPING = {
-  vispero: ['JAWS'],
-  nvAccess: ['NVDA'],
-  apple: ['VoiceOver for macOS']
+  vispero: {
+    id: 1,
+    ats: ['JAWS']
+  },
+  apple: {
+    id: 4,
+    ats: ['VoiceOver for macOS']
+  },
+  nvAccess: {
+    id: 6,
+    ats: ['NVDA']
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
Previously, the amount of lines in the vendors.txt in combination with postgres' `ON CONFLICT` was unintentionally bumping the `nextval` of new Vendor table entries.

This PR instead uses VENDOR_NAME_TO_AT_MAPPING to dictate currently known vendor information and better support for future entries.

This issue appears to only affect local development environments and shouldn't have any notable impact on deployed environments