### PR TITLE
fix: Support older imported TestPlanVersions in automation

### DIFF
--- a/client/tests/e2e/snapshots/saved/_account_settings.html
+++ b/client/tests/e2e/snapshots/saved/_account_settings.html
@@ -102,7 +102,7 @@
             <button type="button" class="btn btn-primary">
               Import Latest Test Plan Versions
             </button>
-            <p>Date of latest test plan version: November 6, 2025 21:57 UTC</p>
+            <p>Date of latest test plan version: November 10, 2025 06:01 UTC</p>
           </section>
         </main>
       </div>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -280,7 +280,7 @@
                       </option>
                       <option value="97">Rating Radio Group</option>
                       <option value="59">Rating Slider</option>
-                      <option value="7">Select Only Combobox Example</option>
+                      <option value="39">Select Only Combobox Example</option>
                       <option value="99">Switch Example</option>
                       <option value="100">
                         Switch Example Using HTML Button

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -280,7 +280,7 @@
                       </option>
                       <option value="97">Rating Radio Group</option>
                       <option value="59">Rating Slider</option>
-                      <option value="39">Select Only Combobox Example</option>
+                      <option value="7">Select Only Combobox Example</option>
                       <option value="99">Switch Example</option>
                       <option value="100">
                         Switch Example Using HTML Button
@@ -294,6 +294,7 @@
                       <option value="103">Tabs with Manual Activation</option>
                       <option value="104">Toggle Button</option>
                       <option value="105">Vertical Temperature Slider</option>
+                      <option value="106">aria-required on a Text Input</option>
                     </select>
                   </div>
                   <div class="form-group">
@@ -393,7 +394,7 @@
                 data-testid="filter-all"
                 aria-pressed="true"
                 class="filter-button btn active btn-secondary">
-                All Plans (40)
+                All Plans (41)
               </button>
             </li>
             <li>
@@ -402,7 +403,7 @@
                 data-testid="filter-rd"
                 aria-pressed="false"
                 class="filter-button btn btn-secondary">
-                R&amp;D Complete (36)
+                R&amp;D Complete (37)
               </button>
             </li>
             <li>
@@ -436,7 +437,7 @@
           <div class="table-responsive">
             <table
               aria-label="Test Plans Status Summary Table"
-              aria-rowcount="40"
+              aria-rowcount="41"
               class="data-management table table-bordered table-hover">
               <thead>
                 <tr>
@@ -2992,6 +2993,60 @@
                                 fill="currentColor"
                                 d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
                             ><b>V25.11.06</b></span
+                          ></a
+                        ></span
+                      ><button
+                        type="button"
+                        class="advance-button btn btn-secondary">
+                        Advance to Draft
+                      </button>
+                    </div>
+                  </td>
+                  <td>
+                    <span class="none centered absolute">Not Started</span>
+                  </td>
+                  <td>
+                    <span class="none centered absolute">Not Started</span>
+                  </td>
+                  <td><span class="none centered absolute">None Yet</span></td>
+                </tr>
+                <tr aria-rowindex="40">
+                  <th>
+                    <a href="/data-management/aria/aria-required-text-input"
+                      ><b>aria-required on a Text Input</b></a
+                    >
+                  </th>
+                  <td>
+                    <div>
+                      <b>JAWS</b><span>, </span><b>NVDA</b><span> and </span
+                      ><b>VoiceOver for macOS</b>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="status-cell">
+                      <span class="pill full-width rd">R&amp;D</span>
+                      <p class="review-text">Complete <b>Nov 10, 2025</b></p>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="phase-cell" role="list" aria-setsize="2">
+                      <span class="styled-pill full-width auto-width"
+                        ><a href="/test-review/106"
+                          ><span
+                            ><svg
+                              aria-hidden="true"
+                              focusable="false"
+                              data-prefix="fas"
+                              data-icon="circle-check"
+                              class="svg-inline--fa fa-circle-check check"
+                              role="img"
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 512 512"
+                              color="var(--positive-green)">
+                              <path
+                                fill="currentColor"
+                                d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
+                            ><b>V25.11.10</b></span
                           ></a
                         ></span
                       ><button

--- a/server/models/services/CollectionJobService.js
+++ b/server/models/services/CollectionJobService.js
@@ -405,7 +405,14 @@ const getCollectionJobs = async ({
  */
 const triggerWorkflow = async (job, testIds, atVersion, { transaction }) => {
   const { testPlanVersion } = job.testPlanRun.testPlanReport;
-  const { gitSha, directory } = testPlanVersion;
+  let { gitSha, directory, updatedAt } = testPlanVersion;
+
+  const testPlanVersionCommitDate = new Date(updatedAt);
+  const preApgTestsDate = new Date('2025-11-06 11:57:41.000000 +00:00');
+  if (testPlanVersionCommitDate < preApgTestsDate) {
+    directory = directory.replace('apg/', '');
+  }
+
   try {
     if (isGithubWorkflowEnabled()) {
       // TODO: pass the reduced list of testIds along / deal with them somehow


### PR DESCRIPTION
This PR adds a check to remove 'apg/' from TestPlanVersion.directory when running automation for TestPlanVersions imported before the subfolder change in https://github.com/w3c/aria-at/commit/01923da5f533dda74c9f33a68ee20e112069c6de