### PR TITLE
fix: Display additional information for reports

### DIFF
--- a/client/components/Reports/SummarizeTestPlanVersion.jsx
+++ b/client/components/Reports/SummarizeTestPlanVersion.jsx
@@ -103,14 +103,22 @@ const SummarizeTestPlanVersion = ({ testPlanVersion, testPlanReports }) => {
         if (testPlanReport.status === 'DRAFT') return null;
         const overallMetrics = getMetrics({ testPlanReport });
 
-        const { at, browser, recommendedAtVersion } = testPlanReport;
+        const {
+          at,
+          browser,
+          recommendedAtVersion,
+          exactAtVersion,
+          minimumAtVersion
+        } = testPlanReport;
 
         // Construct testPlanTarget
         const testPlanTarget = {
           id: `${at.id}${browser.id}`,
           at,
           browser,
-          atVersion: recommendedAtVersion
+          atVersion: recommendedAtVersion || exactAtVersion || minimumAtVersion,
+          isMinimumAtVersion:
+            !recommendedAtVersion && !exactAtVersion && !!minimumAtVersion
         };
 
         return (

--- a/client/components/Reports/getTitles.js
+++ b/client/components/Reports/getTitles.js
@@ -8,9 +8,16 @@ const getTestPlanVersionTitle = (
   return title;
 };
 
-const getTestPlanTargetTitle = ({ at, browser, atVersion }) => {
+const getTestPlanTargetTitle = ({
+  at,
+  browser,
+  atVersion,
+  isMinimumAtVersion
+}) => {
   if (!atVersion) return `${at.name} and ${browser.name}`;
-  return `${at.name} ${atVersion.name} and ${browser.name}`;
+  return `${at.name} ${atVersion.name}${
+    isMinimumAtVersion ? ' or later' : ''
+  } and ${browser.name}`;
 };
 
 export { getTestPlanTargetTitle, getTestPlanVersionTitle };

--- a/client/components/Reports/queries.js
+++ b/client/components/Reports/queries.js
@@ -145,6 +145,12 @@ export const REPORT_PAGE_QUERY = gql`
         recommendedAtVersion {
           ...AtVersionFields
         }
+        exactAtVersion {
+          ...AtVersionFields
+        }
+        minimumAtVersion {
+          ...AtVersionFields
+        }
         runnableTests {
           ...TestFieldsSimple
         }

--- a/client/tests/e2e/Reports.e2e.test.js
+++ b/client/tests/e2e/Reports.e2e.test.js
@@ -213,17 +213,17 @@ describe('Report page for candidate report', () => {
       const validJawsHeadingMatchFound = await checkForHeading(
         page,
         'h2 ::-p-text(JAWS)',
-        'JAWS and Chrome'
+        'JAWS 2021.2111.13 or later and Chrome'
       );
       const validNvdaHeadingMatchFound = await checkForHeading(
         page,
         'h2 ::-p-text(NVDA)',
-        'NVDA and Chrome'
+        'NVDA 2020.4 or later and Chrome'
       );
       const validVoiceoverHeadingMatchFound = await checkForHeading(
         page,
         'h2 ::-p-text(VoiceOver for macOS)',
-        'VoiceOver for macOS and Safari'
+        'VoiceOver for macOS 11.6 (20G165) or later and Safari'
       );
 
       expect(validReportCompletedOnDate).toBe(true);
@@ -242,20 +242,13 @@ describe('Report page for candidate report', () => {
       await page.click(viewResultsButton);
 
       await page.waitForSelector('h1 ::-p-text(Modal Dialog Example)');
-
-      const isVersionsSummaryFound = await page.evaluate(() => {
-        const elementsWithText = Array.from(
-          document.querySelectorAll('h2')
-        ).filter(element => element.textContent.includes('Versions Summary'));
-        return elementsWithText.length > 0;
-      });
+      await page.waitForSelector('h2 ::-p-text(Versions Summary)');
       await page.waitForSelector('h2 ::-p-text(Results for)');
       await page.waitForSelector(
         'details summary ::-p-text(Unapproved Report)'
       );
       const currentUrl = await page.url();
 
-      expect(isVersionsSummaryFound).toBe(false);
       expect(currentUrl).toMatch(/^.*\/report\/\d+\/targets\/\d+/);
     });
   });


### PR DESCRIPTION
Address https://github.com/w3c/aria-at-app/issues/1083#issuecomment-3383473134

This PR does the following on report pages:
* Expands trends table to be displayed for Candidate reports
* Shows exact and minimum AT version information where previously missing