### PR TITLE
fix: populate test plan versions and filter on first disclosure open

### DIFF
--- a/client/components/ManageTestQueue/AddTestPlans.jsx
+++ b/client/components/ManageTestQueue/AddTestPlans.jsx
@@ -88,7 +88,6 @@ const AddTestPlans = ({
         const matchingVersions = allTestPlanVersions
           .filter(
             version =>
-              version.title === selectedPlan.title &&
               version.testPlan.directory === selectedPlan.directory &&
               version.phase !== 'DEPRECATED' &&
               version.phase !== 'RD'

--- a/client/components/ManageTestQueue/index.jsx
+++ b/client/components/ManageTestQueue/index.jsx
@@ -6,11 +6,7 @@ import ManageAtVersions from '@components/ManageTestQueue/ManageAtVersions';
 import AddTestPlans from '@components/ManageTestQueue/AddTestPlans';
 import { AtPropType, TestPlanVersionPropType } from '../common/proptypes';
 
-const ManageTestQueue = ({
-  ats = [],
-  testPlanVersions = [],
-  triggerUpdate = () => {}
-}) => {
+const ManageTestQueue = ({ ats = [], triggerUpdate = () => {} }) => {
   const { loadingMessage } = useTriggerLoad();
 
   const [showManageATs, setShowManageATs] = useState(false);

--- a/client/components/ManageTestQueue/index.jsx
+++ b/client/components/ManageTestQueue/index.jsx
@@ -4,7 +4,7 @@ import { LoadingStatus, useTriggerLoad } from '../common/LoadingStatus';
 import DisclosureComponent from '../common/DisclosureComponent';
 import ManageAtVersions from '@components/ManageTestQueue/ManageAtVersions';
 import AddTestPlans from '@components/ManageTestQueue/AddTestPlans';
-import { AtPropType, TestPlanVersionPropType } from '../common/proptypes';
+import { AtPropType } from '../common/proptypes';
 
 const ManageTestQueue = ({ ats = [], triggerUpdate = () => {} }) => {
   const { loadingMessage } = useTriggerLoad();
@@ -45,7 +45,6 @@ const ManageTestQueue = ({ ats = [], triggerUpdate = () => {} }) => {
 
 ManageTestQueue.propTypes = {
   ats: PropTypes.arrayOf(AtPropType).isRequired,
-  testPlanVersions: PropTypes.arrayOf(TestPlanVersionPropType),
   triggerUpdate: PropTypes.func
 };
 

--- a/client/components/ManageTestQueue/useAddTestPlansData.js
+++ b/client/components/ManageTestQueue/useAddTestPlansData.js
@@ -86,12 +86,21 @@ export const useAddTestPlansFormState = allTestPlanVersions => {
     useState('');
 
   useMemo(() => {
-    if (
-      allTestPlanVersions.length &&
-      !selectedTestPlanVersionId &&
-      allTestPlanVersions[0]
-    ) {
-      setSelectedTestPlanVersionId(allTestPlanVersions[0].id);
+    if (allTestPlanVersions.length && !selectedTestPlanVersionId) {
+      const sortedVersions = [...allTestPlanVersions].sort((a, b) => {
+        if (a.title !== b.title) {
+          return a.title < b.title ? -1 : 1;
+        }
+        return new Date(b.updatedAt) - new Date(a.updatedAt);
+      });
+
+      const firstValidVersion = sortedVersions.find(
+        version => version.phase !== 'DEPRECATED' && version.phase !== 'RD'
+      );
+
+      if (firstValidVersion) {
+        setSelectedTestPlanVersionId(firstValidVersion.id);
+      }
     }
   }, [allTestPlanVersions]);
 


### PR DESCRIPTION
see title

fixes issue where when the "Add Test Plans" disclosure was first opened, the test plan version selected wasn't correctly updated to be filtered by the selected test plan.