### PR TITLE
fix: Display alert on duplicate report when adding to the Test Queue

### DIFF
--- a/client/components/AddTestToQueueWithConfirmation/queries.js
+++ b/client/components/AddTestToQueueWithConfirmation/queries.js
@@ -71,17 +71,20 @@ export const ADD_TEST_QUEUE_MUTATION = gql`
         copyResultsFromTestPlanVersionId: $copyResultsFromTestPlanVersionId
       }
     ) {
-      testPlanReport {
-        id
-        at {
+      alreadyExisted
+      populatedData {
+        testPlanReport {
+          id
+          at {
+            id
+          }
+          browser {
+            id
+          }
+        }
+        testPlanVersion {
           id
         }
-        browser {
-          id
-        }
-      }
-      testPlanVersion {
-        id
       }
     }
   }

--- a/server/graphql-schema.js
+++ b/server/graphql-schema.js
@@ -1971,7 +1971,7 @@ const graphqlSchema = gql`
       The TestPlanReport to create.
       """
       input: TestPlanReportInput!
-    ): PopulatedData!
+    ): CreateTestPlanReportResponse!
     """
     Get the available mutations for the given TestPlanReport.
     """
@@ -2093,6 +2093,20 @@ const graphqlSchema = gql`
   type CreateCollectionJobsFromPreviousVersionResponse {
     collectionJobs: [CollectionJob!]!
     message: String!
+  }
+
+  """
+  Response type for createTestPlanReport mutation.
+  """
+  type CreateTestPlanReportResponse {
+    """
+    The populated data containing the test plan report and related entities.
+    """
+    populatedData: PopulatedData!
+    """
+    Whether the test plan report already existed before this mutation was called.
+    """
+    alreadyExisted: Boolean!
   }
 
   type KeyMetrics {

--- a/server/tests/integration/graphql.test.js
+++ b/server/tests/integration/graphql.test.js
@@ -1002,6 +1002,10 @@ describe('graphql', () => {
               }
             ) {
               __typename
+              populatedData {
+                __typename
+              }
+              alreadyExisted
             }
             testPlanReport(id: 1) {
               __typename


### PR DESCRIPTION
When a duplicate report combination (Test Plan Version + AT Version + Browser Version) is added to the Test Queue, the creation is quietly ignored since it already exists.

However if the admin user is on a separate tab when the creation was done and it exists in the other, there is confusion on where the report is. eg. the duplicate is on the automated updates tab but the user is currently viewing the manual test runs tab.

This PR aims to address that UX concern by displaying a message when a duplicate creation attempt has happened.

_Note: marked as draft to explore a more robust approach_