### PR TITLE
fix: Invalid `querySelector` call when deleting Test Queue reports

### DIFF
--- a/client/components/TestQueue/Actions.jsx
+++ b/client/components/TestQueue/Actions.jsx
@@ -203,7 +203,7 @@ const Actions = ({
 
       setTimeout(() => {
         const focusTarget =
-          document.querySelector(`h2#${testPlan.directory}`) ??
+          document.querySelector(`h2#${CSS.escape(testPlan.directory)}`) ??
           document.querySelector('#main');
 
         focusTarget.focus();


### PR DESCRIPTION
Since directory names now include a `/`. eg. 'alert' -> 'apg/alert' and those directory names have gotten directly used in this selector. The `/` isn't valid for `document.querySelector()`. This ensures it is properly escaped.

This issue can be reproduced when deleting a report on the Test Queue.