### PR TITLE
fix: escape directory selector on report delete

### DIFF
--- a/client/components/TestQueue/Actions.jsx
+++ b/client/components/TestQueue/Actions.jsx
@@ -202,8 +202,9 @@ const Actions = ({
       hideConfirmationModal();
 
       setTimeout(() => {
+        const escapedDirectory = testPlan.directory.replace(/\//g, '\\/');
         const focusTarget =
-          document.querySelector(`h2#${testPlan.directory}`) ??
+          document.querySelector(`h2#${escapedDirectory}`) ??
           document.querySelector('#main');
 
         focusTarget.focus();

--- a/client/tests/e2e/snapshots/saved/_account_settings.html
+++ b/client/tests/e2e/snapshots/saved/_account_settings.html
@@ -258,7 +258,7 @@
             <button type="button" class="btn btn-primary">
               Import Latest Test Plan Versions
             </button>
-            <p>Date of latest test plan version: November 10, 2025 06:01 UTC</p>
+            <p>Date of latest test plan version: November 13, 2025 23:25 UTC</p>
           </section>
         </main>
       </div>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -1590,7 +1590,7 @@
                   <td>
                     <div class="status-cell">
                       <span class="pill full-width rd">R&amp;D</span>
-                      <p class="review-text">Complete <b>Nov 6, 2025</b></p>
+                      <p class="review-text">Complete <b>Nov 13, 2025</b></p>
                     </div>
                   </td>
                   <td>
@@ -1611,7 +1611,7 @@
                               <path
                                 fill="currentColor"
                                 d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                            ><b>V25.11.06</b></span
+                            ><b>V25.11.13</b></span
                           ></a
                         ></span
                       ><button


### PR DESCRIPTION
Prior to this PR, deleting a report would throw

```
ERROR
Document.querySelector: 'h2#apg/checkbox' is not a valid selector
./components/TestQueue/Actions.jsx/Actions/deleteReport/_callee4/_callee4$/<@http://localhost:3000/components_TestQueue_index_jsx.bundle.js:2106:69
```

This is due to the directory having a forward slash that needs to be escaped after the nested directory migration