### PR TITLE
fix: allow add test plans disclosure to add test plan versions without initial reports

### DIFF
--- a/client/components/ManageTestQueue/useAddTestPlansData.js
+++ b/client/components/ManageTestQueue/useAddTestPlansData.js
@@ -56,24 +56,20 @@ export const useAddTestPlansData = isOpen => {
 
     if (mainQueryData.testPlanVersions) {
       mainQueryData.testPlanVersions.forEach(version => {
-        if (version.testPlanReports && version.testPlanReports.length > 0) {
-          const testPlanDirectory = version.testPlan?.directory;
-          if (testPlanDirectory) {
-            allTestPlanVersions.push(
-              normalizeVersion(version, testPlanDirectory)
-            );
-          }
+        const testPlanDirectory = version.testPlan?.directory;
+        if (testPlanDirectory) {
+          allTestPlanVersions.push(
+            normalizeVersion(version, testPlanDirectory)
+          );
         }
       });
     } else if (mainQueryData.testPlans) {
       mainQueryData.testPlans.forEach(testPlan => {
         const versions = testPlan.testPlanVersions || [];
         versions.forEach(version => {
-          if (version.testPlanReports && version.testPlanReports.length > 0) {
-            allTestPlanVersions.push(
-              normalizeVersion(version, testPlan.directory)
-            );
-          }
+          allTestPlanVersions.push(
+            normalizeVersion(version, testPlan.directory)
+          );
         });
       });
     }

--- a/client/tests/e2e/snapshots/saved/_account_settings.html
+++ b/client/tests/e2e/snapshots/saved/_account_settings.html
@@ -258,7 +258,7 @@
             <button type="button" class="btn btn-primary">
               Import Latest Test Plan Versions
             </button>
-            <p>Date of latest test plan version: November 10, 2025 06:01 UTC</p>
+            <p>Date of latest test plan version: November 13, 2025 23:25 UTC</p>
           </section>
         </main>
       </div>

--- a/client/tests/e2e/snapshots/saved/_data-management.html
+++ b/client/tests/e2e/snapshots/saved/_data-management.html
@@ -1590,7 +1590,7 @@
                   <td>
                     <div class="status-cell">
                       <span class="pill full-width rd">R&amp;D</span>
-                      <p class="review-text">Complete <b>Nov 6, 2025</b></p>
+                      <p class="review-text">Complete <b>Nov 13, 2025</b></p>
                     </div>
                   </td>
                   <td>
@@ -1611,7 +1611,7 @@
                               <path
                                 fill="currentColor"
                                 d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg
-                            ><b>V25.11.06</b></span
+                            ><b>V25.11.13</b></span
                           ></a
                         ></span
                       ><button


### PR DESCRIPTION
This issue was discovered by @ChrisC while manual testing. The dropdown in `AddTestPlans` is populated with test plans that have at least one version in `DRAFT`, `CANDIDATE`, or `RECOMMENDED`. It also filters for test plans that have a version in one of those phases with an existing report. This secondary filter is incorrect.

This issue is quite old but likely wasn't discovered until now due to another method for adding initial reports being used.