### PR TITLE
fix: Restore phase update to `RECOMMENDED` and restore negative side effects expected mutations

### DIFF
--- a/server/migrations/20251118203125-fix-failed-to-untestable.js
+++ b/server/migrations/20251118203125-fix-failed-to-untestable.js
@@ -7,7 +7,9 @@ const { dumpTable } = require('./utils');
 module.exports = {
   async up(queryInterface) {
     // From production_dump_20251118.sql, found these to be the faulty reports which prevented progression to RECOMMENDED
-    const testPlanReportIdsWithNonMatchingFailures = [419, 472, 475, 516, 433];
+    const testPlanReportIdsWithNonMatchingFailures = [
+      419, 472, 475, 516, 433, 432
+    ];
 
     const transaction = await queryInterface.sequelize.transaction();
 
@@ -68,7 +70,7 @@ module.exports = {
             return;
           }
 
-          // Nw update all TestPlanRuns to set untestable: true
+          // Now update all TestPlanRuns to set untestable: true
           // for scenarios that are untestable in any run
           const updatedRunIds = [];
 

--- a/server/migrations/20251118203125-fix-failed-to-untestable.js
+++ b/server/migrations/20251118203125-fix-failed-to-untestable.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const recalculateMetrics = require('./utils/recalculateMetrics');
+const { dumpTable } = require('./utils');
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // From production_dump_20251118.sql, found these to be the faulty reports which prevented progression to RECOMMENDED
+    const testPlanReportIdsWithNonMatchingFailures = [419, 472, 475, 516, 433];
+
+    const transaction = await queryInterface.sequelize.transaction();
+
+    // Process each TestPlanReport in parallel
+    try {
+      await Promise.all(
+        testPlanReportIdsWithNonMatchingFailures.map(async testPlanReportId => {
+          const testPlanRuns = await queryInterface.sequelize.query(
+            `SELECT id, "testResults" FROM "TestPlanRun" WHERE "testPlanReportId" = :testPlanReportId`,
+            {
+              type: queryInterface.sequelize.QueryTypes.SELECT,
+              replacements: { testPlanReportId },
+              transaction
+            }
+          );
+
+          if (testPlanRuns.length === 0) {
+            // eslint-disable-next-line
+            console.info(
+              `No TestPlanRuns found for TestPlanReport ${testPlanReportId}`
+            );
+            return;
+          }
+
+          // Build a set of (testId, scenarioId) pairs that have untestable: true
+          // across all TestPlanRuns for this report
+          const untestableScenarios = new Set();
+
+          // Collect all scenarios with untestable: true
+          for (const run of testPlanRuns) {
+            const testResults = Array.isArray(run.testResults)
+              ? run.testResults
+              : [];
+
+            for (const testResult of testResults) {
+              const scenarioResults = Array.isArray(testResult.scenarioResults)
+                ? testResult.scenarioResults
+                : [];
+
+              for (const scenarioResult of scenarioResults) {
+                if (
+                  scenarioResult.untestable === true &&
+                  testResult.testId &&
+                  scenarioResult.scenarioId
+                ) {
+                  const key = `${testResult.testId}:${scenarioResult.scenarioId}`;
+                  untestableScenarios.add(key);
+                }
+              }
+            }
+          }
+
+          if (untestableScenarios.size === 0) {
+            // eslint-disable-next-line
+            console.info(
+              `No untestable scenarios found for TestPlanReport ${testPlanReportId}`
+            );
+            return;
+          }
+
+          // Nw update all TestPlanRuns to set untestable: true
+          // for scenarios that are untestable in any run
+          const updatedRunIds = [];
+
+          for (const run of testPlanRuns) {
+            const testResults = Array.isArray(run.testResults)
+              ? run.testResults
+              : [];
+
+            let hasChanges = false;
+            const updatedTestResults = testResults.map(testResult => {
+              const scenarioResults = Array.isArray(testResult.scenarioResults)
+                ? testResult.scenarioResults
+                : [];
+
+              const updatedScenarioResults = scenarioResults.map(
+                scenarioResult => {
+                  if (testResult.testId && scenarioResult.scenarioId) {
+                    const key = `${testResult.testId}:${scenarioResult.scenarioId}`;
+                    if (
+                      untestableScenarios.has(key) &&
+                      scenarioResult.untestable !== true
+                    ) {
+                      hasChanges = true;
+                      return {
+                        ...scenarioResult,
+                        untestable: true
+                      };
+                    }
+                  }
+                  return scenarioResult;
+                }
+              );
+
+              return {
+                ...testResult,
+                scenarioResults: updatedScenarioResults
+              };
+            });
+
+            if (hasChanges) {
+              await queryInterface.sequelize.query(
+                `UPDATE "TestPlanRun" SET "testResults" = :testResults WHERE id = :runId`,
+                {
+                  replacements: {
+                    testResults: JSON.stringify(updatedTestResults),
+                    runId: run.id
+                  },
+                  transaction
+                }
+              );
+              updatedRunIds.push(run.id);
+
+              // eslint-disable-next-line
+              console.info(
+                `Updated TestPlanRun ${run.id} for TestPlanReport ${testPlanReportId}`
+              );
+            }
+          }
+
+          if (updatedRunIds.length > 0) {
+            // eslint-disable-next-line
+            console.info(
+              `TestPlanReport ${testPlanReportId}: Updated ${
+                updatedRunIds.length
+              } TestPlanRun(s): ${updatedRunIds.join(', ')}`
+            );
+          }
+        })
+      );
+
+      await dumpTable('TestPlanRun');
+      await recalculateMetrics(queryInterface, transaction);
+
+      await transaction.commit();
+    } catch (err) {
+      await transaction.rollback();
+      throw err;
+    }
+  },
+
+  async down() {
+    // This migration cannot be safely reversed as we don't know
+    // which scenarios originally had untestable: null vs false
+    // Use the dumped TestPlanRun table
+  }
+};

--- a/server/resolvers/TestPlanReport/conflictsResolver.js
+++ b/server/resolvers/TestPlanReport/conflictsResolver.js
@@ -85,7 +85,8 @@ const conflictsResolver = async (testPlanReport, _, context) => {
 
         // Ignore negativeSideEffect details text during comparison of conflicts
         picked.negativeSideEffects = picked.negativeSideEffects.map(
-          negativeSideEffect => omit(negativeSideEffect, ['details'])
+          negativeSideEffect =>
+            omit(negativeSideEffect, ['details', 'encodedId', 'atBugs'])
         );
 
         return picked;

--- a/server/resolvers/TestResultOperations/saveTestResultCommon.js
+++ b/server/resolvers/TestResultOperations/saveTestResultCommon.js
@@ -17,12 +17,14 @@ const {
 const { updatePercentComplete } = require('../../util/updatePercentComplete');
 const {
   bulkCreateNegativeSideEffects,
-  getNegativeSideEffectsByTestPlanRunId
+  getNegativeSideEffectsByTestPlanRunId,
+  updateNegativeSideEffectById,
+  deleteNegativeSideEffectById
 } = require('../../models/services/NegativeSideEffectService');
 
 /**
- * Persists negative side effects to DB, avoiding duplicates.
- * Creates unique IDs (testResultId+scenarioResultId+negativeSideEffectId), filters existing, bulk creates.
+ * Persists negative side effects to DB, syncing with test result data.
+ * Creates unique IDs (testResultId+scenarioResultId+negativeSideEffectId), updates existing records, creates new ones, and deletes removed ones.
  * Non-critical operation - errors logged but not thrown.
  *
  * @param {Object} options
@@ -43,15 +45,21 @@ const createNegativeSideEffectsForTestResult = async ({
         transaction
       });
 
-    // Create a set of existing negative side effect IDs for efficient lookup
-    const existingIds = new Set(
-      existingNegativeSideEffects.map(
-        nse =>
-          `${nse.testResultId}_${nse.scenarioResultId}_${nse.negativeSideEffectId}`
-      )
+    // Filter existing negative side effects to only those for this test result
+    const existingForTestResult = existingNegativeSideEffects.filter(
+      nse => nse.testResultId === testResult.id
     );
 
+    // Create a map of existing negative side effects by unique ID for efficient lookup
+    const existingMap = new Map();
+    existingForTestResult.forEach(nse => {
+      const uniqueId = `${nse.testResultId}_${nse.scenarioResultId}_${nse.negativeSideEffectId}`;
+      existingMap.set(uniqueId, nse);
+    });
+
     const negativeSideEffectsData = [];
+    const updatePromises = [];
+    const newUniqueIds = new Set();
 
     // Process each scenario result
     if (
@@ -65,9 +73,35 @@ const createNegativeSideEffectsForTestResult = async ({
         ) {
           for (const negativeSideEffect of scenarioResult.negativeSideEffects) {
             const uniqueId = `${testResult.id}_${scenarioResult.id}_${negativeSideEffect.id}`;
+            newUniqueIds.add(uniqueId);
+            const existing = existingMap.get(uniqueId);
 
-            // Only create if it doesn't already exist
-            if (!existingIds.has(uniqueId)) {
+            if (existing) {
+              // Update existing record if values have changed
+              const updateValues = {
+                impact: negativeSideEffect.impact || 'MODERATE',
+                details: negativeSideEffect.details || null,
+                highlightRequired:
+                  negativeSideEffect.highlightRequired || false,
+                updatedAt: new Date()
+              };
+
+              // Only update if values have actually changed
+              if (
+                existing.impact !== updateValues.impact ||
+                existing.details !== updateValues.details ||
+                existing.highlightRequired !== updateValues.highlightRequired
+              ) {
+                updatePromises.push(
+                  updateNegativeSideEffectById({
+                    id: existing.id,
+                    values: updateValues,
+                    transaction
+                  })
+                );
+              }
+            } else {
+              // Create new record
               negativeSideEffectsData.push({
                 testPlanRunId,
                 testResultId: testResult.id,
@@ -84,6 +118,38 @@ const createNegativeSideEffectsForTestResult = async ({
             }
           }
         }
+      }
+    }
+
+    // Delete any existing negative side effects that are no longer in the test result
+    const deletePromises = [];
+    for (const existing of existingForTestResult) {
+      const uniqueId = `${existing.testResultId}_${existing.scenarioResultId}_${existing.negativeSideEffectId}`;
+      if (!newUniqueIds.has(uniqueId)) {
+        deletePromises.push(
+          deleteNegativeSideEffectById({
+            id: existing.id,
+            transaction
+          })
+        );
+      }
+    }
+
+    // Delete removed negative side effects
+    if (deletePromises.length > 0) {
+      try {
+        await Promise.all(deletePromises);
+      } catch (error) {
+        console.error('Error deleting negative side effects:', error);
+      }
+    }
+
+    // Update existing records in parallel
+    if (updatePromises.length > 0) {
+      try {
+        await Promise.all(updatePromises);
+      } catch (error) {
+        console.error('Error updating negative side effects:', error);
       }
     }
 


### PR DESCRIPTION
Address #1652 

This PR addresses 2 notable issues which affected older submitted reports but were part of advanced test plan versions:
1. Assertions marked as 'untestable' weren't in sync with another tester's run that marked it as 'failed'. This wasn't a problem before but now that conflicts consider these cases of untestable vs failed since #1599, it has to
2. Now that `AtBugs` and `encodedId` exists on a negative side effect since #1577, those also have to be explicitly ignored or even when the negative side effect matches, it shows up as a conflict

Apart from those, found that a created negative side effect could not be removed or updated for a Test Run page.

For reviewers:
To confirm the changes of the migration, locally I removed the `markedFinalAt` attribute for those TestPlanReport rows so I could easily view them in the Test Queue