### PR TITLE
fix: Missing Suspense wrapper when navigating to ARIA/HTML Feature page

### DIFF
--- a/client/routes/index.js
+++ b/client/routes/index.js
@@ -174,7 +174,11 @@ export default () => (
     <Route
       exact
       path="/aria-html-feature/:atId/:browserId/:refId/:refType"
-      element={<AriaHtmlFeatureDetailReport />}
+      element={
+        <Suspense fallback={<PageLoader />}>
+          <AriaHtmlFeatureDetailReport />
+        </Suspense>
+      }
     />
     <Route
       exact


### PR DESCRIPTION
Adds expected `<Suspense>` for additional instance of call to `<AriaHtmlFeatureDetailReport>` since it is being lazy-loaded.

The pattern for `/aria-html-feature/:atId/:browserId/:refId` was handled but not `/aria-html-feature/:atId/:browserId/:refId/:refType`